### PR TITLE
dedicatedServiceMonitors param removed from monitoring-config-cm.yaml

### DIFF
--- a/telco-core/configuration/reference-crs/optional/other/monitoring-config-cm.yaml
+++ b/telco-core/configuration/reference-crs/optional/other/monitoring-config-cm.yaml
@@ -8,9 +8,6 @@ metadata:
   namespace: openshift-monitoring
 data:
   config.yaml: |
-    k8sPrometheusAdapter:
-      dedicatedServiceMonitors:
-        enabled: true
     prometheusK8s:
       retention: 15d
       volumeClaimTemplate:


### PR DESCRIPTION
Since OCP 4.15 setting `DedicatedServiceMonitors` has no effect - https://docs.openshift.com/container-platform/4.15/release_notes/ocp-4-15-release-notes.html#ocp-4-15-monitoring-improved-staleness-handling-for-the-kubelet-service-monitor