### PR TITLE
SR-IOV: add disableDrain and logLevel parameters to SriovOperatorConfig

### DIFF
--- a/telco-core/configuration/reference-crs/required/networking/sriov/SriovOperatorConfig.yaml
+++ b/telco-core/configuration/reference-crs/required/networking/sriov/SriovOperatorConfig.yaml
@@ -12,3 +12,4 @@ spec:
   enableInjector: true
   enableOperatorWebhook: true
   disableDrain: false
+  logLevel: 2

--- a/telco-core/configuration/reference-crs/required/networking/sriov/SriovOperatorConfig.yaml
+++ b/telco-core/configuration/reference-crs/required/networking/sriov/SriovOperatorConfig.yaml
@@ -11,3 +11,4 @@ spec:
     node-role.kubernetes.io/worker: ""
   enableInjector: true
   enableOperatorWebhook: true
+  disableDrain: false


### PR DESCRIPTION
- Add logLevel to SriovOperatorConfig

Starting from OCP 4.16 GA, the SriovOperatorConfig is no longer automatically created by the Operator upon install. Instead it must be created by cluster administrators.
    
Option logLevel should be added to SriovOperatorConfig.yaml since it is the default value but more importantly because it is documented as an option users should set when creating the SriovOperatorConfig CR.

- Ensure node draining is on

The option to drain nodes in parallel enables faster rollouts of SR-IOV network configurations. This option is on by default in the code and is explicitly called out in the OpenShift documentation.

https://issues.redhat.com/browse/CNF-7347
https://docs.openshift.com/container-platform/4.16/networking/hardware_networks/configuring-sriov-operator.html