### PR TITLE
Remove unavailable modules

### DIFF
--- a/telco-core/configuration/reference-crs/optional/other/control-plane-load-kernel-modules.yaml
+++ b/telco-core/configuration/reference-crs/optional/other/control-plane-load-kernel-modules.yaml
@@ -19,7 +19,7 @@ spec:
         overwrite: true
         path: /etc/modprobe.d/kernel-blacklist.conf
       - contents:
-          source: data:text/plain;charset=utf-8;base64,aXBfZ3JlCmlwNl90YWJsZXMKaXA2dF9SRUpFQ1QKaXA2dGFibGVfZmlsdGVyCmlwNnRhYmxlX21hbmdsZQppcHRhYmxlX2ZpbHRlcgppcHRhYmxlX21hbmdsZQppcHRhYmxlX25hdAp4dF9tdWx0aXBvcnQKeHRfb3duZXIKeHRfUkVESVJFQ1QKeHRfc3RhdGlzdGljCnh0X1RDUE1TUwp4dF91MzI=
+          source: data:text/plain;charset=utf-8;base64,aXBfZ3JlCmlwNl90YWJsZXMKaXA2dF9SRUpFQ1QKaXA2dGFibGVfZmlsdGVyCmlwNnRhYmxlX21hbmdsZQppcHRhYmxlX2ZpbHRlcgppcHRhYmxlX21hbmdsZQppcHRhYmxlX25hdAp4dF9tdWx0aXBvcnQKeHRfb3duZXIKeHRfUkVESVJFQ1QKeHRfc3RhdGlzdGljCnh0X1RDUE1TUwo=
         mode: 420
         overwrite: true
         path: /etc/modules-load.d/kernel-load.conf

--- a/telco-core/configuration/reference-crs/optional/other/worker-load-kernel-modules.yaml
+++ b/telco-core/configuration/reference-crs/optional/other/worker-load-kernel-modules.yaml
@@ -19,7 +19,7 @@ spec:
         overwrite: true
         path: /etc/modprobe.d/kernel-blacklist.conf
       - contents:
-          source: data:text/plain;charset=utf-8;base64,aXBfZ3JlCmlwNl90YWJsZXMKaXA2dF9SRUpFQ1QKaXA2dGFibGVfZmlsdGVyCmlwNnRhYmxlX21hbmdsZQppcHRhYmxlX2ZpbHRlcgppcHRhYmxlX21hbmdsZQppcHRhYmxlX25hdAp4dF9tdWx0aXBvcnQKeHRfb3duZXIKeHRfUkVESVJFQ1QKeHRfc3RhdGlzdGljCnh0X1RDUE1TUwp4dF91MzI=
+          source: data:text/plain;charset=utf-8;base64,aXBfZ3JlCmlwNl90YWJsZXMKaXA2dF9SRUpFQ1QKaXA2dGFibGVfZmlsdGVyCmlwNnRhYmxlX21hbmdsZQppcHRhYmxlX2ZpbHRlcgppcHRhYmxlX21hbmdsZQppcHRhYmxlX25hdAp4dF9tdWx0aXBvcnQKeHRfb3duZXIKeHRfUkVESVJFQ1QKeHRfc3RhdGlzdGljCnh0X1RDUE1TUwo=
         mode: 420
         overwrite: true
         path: /etc/modules-load.d/kernel-load.conf


### PR DESCRIPTION
The xt_u32 kernel module is no longer available, removing from the list