### PR TITLE
metallb: set bgpBackend to frr-k8s

### DIFF
--- a/telco-core/configuration/reference-crs/required/networking/metallb/metallb.yaml
+++ b/telco-core/configuration/reference-crs/required/networking/metallb/metallb.yaml
@@ -6,5 +6,6 @@ metadata:
   name: metallb
   namespace: metallb-system
 spec:
+  bgpBackend: frr-k8s
   nodeSelector:
     node-role.kubernetes.io/worker: ""


### PR DESCRIPTION
Starting from OCP 4.17 GA, frr-k8s is the default BGP backend and fully supported. The deprecated 'frr' BGP mode is still available. Upgrading clusters with 'bgpBackend' explicitely set are encouraged to migrate to frr-k8s.

https://issues.redhat.com/browse/CNF-11914
https://github.com/metallb/metallb-operator/pull/476

cc @fedepaol @oribon 