### PR TITLE
Drop address-pool from IPAddressPool

### DIFF
--- a/telco-core/configuration/reference-crs/required/networking/metallb/addr-pool.yaml
+++ b/telco-core/configuration/reference-crs/required/networking/metallb/addr-pool.yaml
@@ -5,8 +5,6 @@ kind: IPAddressPool
 metadata:
   name: $name # eg addresspool3
   namespace: metallb-system
-  annotations:
-    metallb.universe.tf/address-pool: $name # eg addresspool3
 spec:
   ##############
   # Expected variation in this configuration


### PR DESCRIPTION
`metallb.universe.tf/address-pool` annotation is used to request an IP address from the specified address pool when configuring `Service` CR.