### PR TITLE
Drop address-pool from IPAddressPool from reference-crs-kube-compare template

### DIFF
--- a/telco-core/configuration/reference-crs-kube-compare/required/networking/metallb/addr-pool.yaml
+++ b/telco-core/configuration/reference-crs-kube-compare/required/networking/metallb/addr-pool.yaml
@@ -3,8 +3,6 @@ kind: IPAddressPool
 metadata:
   name: {{ .metadata.name }} # eg addresspool3
   namespace: metallb-system
-  annotations:
-    metallb.universe.tf/address-pool: {{ .metadata.name }} # eg addresspool3
 spec:
   ##############
   # Expected variation in this configuration


### PR DESCRIPTION
`metallb.universe.tf/address-pool` annotation is used to request an IP address from the specified address pool when configuring Service CR.

This was already removed from CR in https://github.com/openshift-kni/telco-reference/pull/19