### PR TITLE
Loosen requirement for  static assignment with IPAddressPool

### DIFF
--- a/telco-core/configuration/reference-crs-kube-compare/required/networking/metallb/addr-pool.yaml
+++ b/telco-core/configuration/reference-crs-kube-compare/required/networking/metallb/addr-pool.yaml
@@ -11,5 +11,7 @@ spec:
 {{ .spec.addresses | toYaml | indent 2}}
 {{ end }}
   #- 3.3.3.0/24
-  autoAssign: true
+{{ if .spec.autoAssign }}
+  autoAssign: {{ .spec.autoAssign }}
+{{ end }}
   ##############

--- a/telco-core/configuration/reference-crs/required/networking/metallb/addr-pool.yaml
+++ b/telco-core/configuration/reference-crs/required/networking/metallb/addr-pool.yaml
@@ -11,5 +11,4 @@ spec:
   # Expected variation in this configuration
   addresses: [ $pools ]
   # - 3.3.3.0/24
-  autoAssign: true
   ##############


### PR DESCRIPTION
Leave IP address assignment to the operators