### PR TITLE
Fix issue with kube-compare sriov operator template

### DIFF
--- a/telco-core/configuration/reference-crs-kube-compare/required/networking/sriov/SriovOperatorConfig.yaml
+++ b/telco-core/configuration/reference-crs-kube-compare/required/networking/sriov/SriovOperatorConfig.yaml
@@ -8,7 +8,7 @@ metadata:
   namespace: openshift-sriov-network-operator
 spec:
   configDaemonNodeSelector:
-    {{ range $key, $val := .spec.configDaemonNodeSelector -}}
+    {{ range $key, $val := .spec.configDaemonNodeSelector }}
     {{ $key }}: {{ quote $val}}
     {{- end }}
   enableInjector: true


### PR DESCRIPTION
Issue caused the manifest out put to be invalid if there was multiple selectors

/cc @jnunyez 