### PR TITLE
Delete annotations for workload partitioning

### DIFF
--- a/telco-core/configuration/reference-crs-kube-compare/optional/logging/ClusterLogNS.yaml
+++ b/telco-core/configuration/reference-crs-kube-compare/optional/logging/ClusterLogNS.yaml
@@ -2,5 +2,3 @@ apiVersion: v1
 kind: Namespace
 metadata:
   name: openshift-logging
-  annotations:
-    workload.openshift.io/allowed: management

--- a/telco-core/configuration/reference-crs-kube-compare/required/networking/NMStateNS.yaml
+++ b/telco-core/configuration/reference-crs-kube-compare/required/networking/NMStateNS.yaml
@@ -2,5 +2,3 @@ apiVersion: v1
 kind: Namespace
 metadata:
   name: openshift-nmstate
-  annotations:
-    workload.openshift.io/allowed: management

--- a/telco-core/configuration/reference-crs-kube-compare/required/networking/metallb/metallbNS.yaml
+++ b/telco-core/configuration/reference-crs-kube-compare/required/networking/metallb/metallbNS.yaml
@@ -3,7 +3,5 @@ apiVersion: v1
 kind: Namespace
 metadata:
   name: metallb-system
-  annotations:
-    workload.openshift.io/allowed: management
   labels:
     openshift.io/cluster-monitoring: "true"

--- a/telco-core/configuration/reference-crs-kube-compare/required/networking/sriov/SriovSubscriptionNS.yaml
+++ b/telco-core/configuration/reference-crs-kube-compare/required/networking/sriov/SriovSubscriptionNS.yaml
@@ -4,5 +4,3 @@ apiVersion: v1
 kind: Namespace
 metadata:
   name: openshift-sriov-network-operator
-  annotations:
-    workload.openshift.io/allowed: management

--- a/telco-core/configuration/reference-crs-kube-compare/required/scheduling/NROPSubscriptionNS.yaml
+++ b/telco-core/configuration/reference-crs-kube-compare/required/scheduling/NROPSubscriptionNS.yaml
@@ -4,5 +4,3 @@ apiVersion: v1
 kind: Namespace
 metadata:
   name: openshift-numaresources
-  annotations:
-    workload.openshift.io/allowed: management

--- a/telco-core/configuration/reference-crs-kube-compare/required/storage/odf-external/odfNS.yaml
+++ b/telco-core/configuration/reference-crs-kube-compare/required/storage/odf-external/odfNS.yaml
@@ -5,7 +5,5 @@ apiVersion: v1
 kind: Namespace
 metadata:
   name: openshift-storage
-  annotations:
-    workload.openshift.io/allowed: management
   labels:
     openshift.io/cluster-monitoring: "true"

--- a/telco-core/configuration/reference-crs/optional/logging/ClusterLogNS.yaml
+++ b/telco-core/configuration/reference-crs/optional/logging/ClusterLogNS.yaml
@@ -3,5 +3,3 @@ apiVersion: v1
 kind: Namespace
 metadata:
   name: openshift-logging
-  annotations:
-    workload.openshift.io/allowed: management

--- a/telco-core/configuration/reference-crs/required/networking/NMStateNS.yaml
+++ b/telco-core/configuration/reference-crs/required/networking/NMStateNS.yaml
@@ -2,5 +2,3 @@ apiVersion: v1
 kind: Namespace
 metadata:
   name: openshift-nmstate
-  annotations:
-    workload.openshift.io/allowed: management

--- a/telco-core/configuration/reference-crs/required/networking/metallb/metallbNS.yaml
+++ b/telco-core/configuration/reference-crs/required/networking/metallb/metallbNS.yaml
@@ -5,7 +5,5 @@ apiVersion: v1
 kind: Namespace
 metadata:
   name: metallb-system
-  annotations:
-    workload.openshift.io/allowed: management
   labels:
     openshift.io/cluster-monitoring: "true"

--- a/telco-core/configuration/reference-crs/required/networking/sriov/SriovSubscriptionNS.yaml
+++ b/telco-core/configuration/reference-crs/required/networking/sriov/SriovSubscriptionNS.yaml
@@ -4,5 +4,3 @@ apiVersion: v1
 kind: Namespace
 metadata:
   name: openshift-sriov-network-operator
-  annotations:
-    workload.openshift.io/allowed: management

--- a/telco-core/configuration/reference-crs/required/scheduling/NROPSubscriptionNS.yaml
+++ b/telco-core/configuration/reference-crs/required/scheduling/NROPSubscriptionNS.yaml
@@ -4,5 +4,3 @@ apiVersion: v1
 kind: Namespace
 metadata:
   name: openshift-numaresources
-  annotations:
-    workload.openshift.io/allowed: management

--- a/telco-core/configuration/reference-crs/required/storage/odf-external/odfNS.yaml
+++ b/telco-core/configuration/reference-crs/required/storage/odf-external/odfNS.yaml
@@ -5,7 +5,5 @@ apiVersion: v1
 kind: Namespace
 metadata:
   name: openshift-storage
-  annotations:
-    workload.openshift.io/allowed: management
   labels:
     openshift.io/cluster-monitoring: "true"


### PR DESCRIPTION
Workload partitioning can be enabled on multinode cluster but it has not been tested jointly with the annotations. Testing workload partitioning feature with the annotations would be required for that.