### PR TITLE
OCPBUGS-42833: Policy support to upgrade logging 5.x to 6.0

### DIFF
--- a/telco-core/configuration/core-baseline.yaml
+++ b/telco-core/configuration/core-baseline.yaml
@@ -32,9 +32,20 @@ policies:
       - path: reference-crs/optional/logging/ClusterLogNS.yaml
       - path: reference-crs/optional/logging/ClusterLogOperGroup.yaml
       - path: reference-crs/optional/logging/ClusterLogSubscription.yaml
+      - path: reference-crs/optional/logging/ClusterLogOperatorStatus.yaml
         patches:
-        - spec:
-            installPlanApproval: Manual
+        - status:
+            components:
+              refs:
+              - kind: ClusterServiceVersion
+                namespace: openshift-logging
+                # Update with specific target version
+                name: cluster-logging.v6.0.0
+                conditions:
+                  - type: Succeeded
+                    status: "True"
+                    reason: InstallSucceeded
+
       - path: reference-crs/required/networking/sriov/SriovSubscriptionNS.yaml
       - path: reference-crs/required/networking/sriov/SriovSubscriptionOperGroup.yaml
       - path: reference-crs/required/networking/sriov/SriovSubscription.yaml

--- a/telco-core/configuration/core-overlay.yaml
+++ b/telco-core/configuration/core-overlay.yaml
@@ -258,3 +258,12 @@ policies:
                   apiVersion: "v1"
                   staticConfigs:
                   - "10.11.12.14:9999"
+
+  # When upgrading from Cluster Logging 5.x to 6.0 the old API CRs
+  # need to be removed AFTER the new logging is set up. This policy
+  # removes those CRs.
+  - name: core-overlay-cleanup-4.16
+    policyAnnotations:
+      ran.openshift.io/ztp-deploy-wave: "9"
+    manifests:
+      - path: "reference-crs/optional/logging/ClusterLogging5Cleanup.yaml"

--- a/telco-core/configuration/reference-crs-kube-compare/optional/logging/ClusterLogServiceAccount.yaml
+++ b/telco-core/configuration/reference-crs-kube-compare/optional/logging/ClusterLogServiceAccount.yaml
@@ -2,5 +2,5 @@
 apiVersion: v1
 kind: ServiceAccount
 metadata:
-  name: logcollector
+  name: collector
   namespace: openshift-logging

--- a/telco-core/configuration/reference-crs-kube-compare/optional/logging/ClusterLogServiceAccountAuditBinding.yaml
+++ b/telco-core/configuration/reference-crs-kube-compare/optional/logging/ClusterLogServiceAccountAuditBinding.yaml
@@ -9,5 +9,5 @@ roleRef:
   name: collect-audit-logs
 subjects:
 - kind: ServiceAccount
-  name: logcollector
+  name: collector
   namespace: openshift-logging

--- a/telco-core/configuration/reference-crs-kube-compare/optional/logging/ClusterLogServiceAccountInfrastructureBinding.yaml
+++ b/telco-core/configuration/reference-crs-kube-compare/optional/logging/ClusterLogServiceAccountInfrastructureBinding.yaml
@@ -9,5 +9,5 @@ roleRef:
   name: collect-infrastructure-logs
 subjects:
 - kind: ServiceAccount
-  name: logcollector
+  name: collector
   namespace: openshift-logging

--- a/telco-core/configuration/reference-crs/optional/logging/ClusterLogForwarder.yaml
+++ b/telco-core/configuration/reference-crs/optional/logging/ClusterLogForwarder.yaml
@@ -8,7 +8,12 @@ spec:
   # outputs: $outputs
   # pipelines: $pipelines
   serviceAccount:
-    name: logcollector
+    name: collector
+status:
+  # Verify that the configuration is correct
+  conditions:
+  - type: observability.openshift.io/Valid
+    status: "True"
 
 # apiVersion: "observability.openshift.io/v1"
 # kind: ClusterLogForwarder
@@ -40,4 +45,4 @@ spec:
 #      outputRefs:
 #      - kafka-open
 #    serviceAccount:
-#      name: logcollector
+#      name: collector

--- a/telco-core/configuration/reference-crs/optional/logging/ClusterLogForwarderDeleted.yaml
+++ b/telco-core/configuration/reference-crs/optional/logging/ClusterLogForwarderDeleted.yaml
@@ -1,7 +1,0 @@
-# This CR is no longer used in Cluster Logging 6.0. It remains in the reference to support removal via policy.
-apiVersion: logging.openshift.io/v1
-kind: ClusterLogForwarder
-metadata:
-  name: instance
-  namespace: openshift-logging
-spec: {}

--- a/telco-core/configuration/reference-crs/optional/logging/ClusterLogOperatorStatus.yaml
+++ b/telco-core/configuration/reference-crs/optional/logging/ClusterLogOperatorStatus.yaml
@@ -1,0 +1,29 @@
+# This CR can be used to verify the installation/upgrade of the
+# Cluster Logging Operator by including status fields as shown in
+# examples below
+---
+apiVersion: operators.coreos.com/v1
+kind: Operator
+metadata:
+  name: cluster-logging.openshift-logging
+  annotations:
+    ran.openshift.io/ztp-deploy-wave: "2"
+status:
+#  components:
+#    refs:
+#    - kind: Subscription
+#      namespace: openshift-logging
+#      conditions:
+#      - type: CatalogSourcesUnhealthy
+#        status: "False"
+#    - kind: InstallPlan
+#      namespace: openshift-logging
+#      conditions:
+#      - type: Installed
+#        status: "True"
+#    - kind: ClusterServiceVersion
+#      namespace: openshift-logging
+#      conditions:
+#      - type: Succeeded
+#        status: "True"
+#        reason: InstallSucceeded

--- a/telco-core/configuration/reference-crs/optional/logging/ClusterLogServiceAccount.yaml
+++ b/telco-core/configuration/reference-crs/optional/logging/ClusterLogServiceAccount.yaml
@@ -2,5 +2,5 @@
 apiVersion: v1
 kind: ServiceAccount
 metadata:
-  name: logcollector
+  name: collector
   namespace: openshift-logging

--- a/telco-core/configuration/reference-crs/optional/logging/ClusterLogServiceAccountAuditBinding.yaml
+++ b/telco-core/configuration/reference-crs/optional/logging/ClusterLogServiceAccountAuditBinding.yaml
@@ -9,5 +9,5 @@ roleRef:
   name: collect-audit-logs
 subjects:
 - kind: ServiceAccount
-  name: logcollector
+  name: collector
   namespace: openshift-logging

--- a/telco-core/configuration/reference-crs/optional/logging/ClusterLogServiceAccountInfrastructureBinding.yaml
+++ b/telco-core/configuration/reference-crs/optional/logging/ClusterLogServiceAccountInfrastructureBinding.yaml
@@ -9,5 +9,5 @@ roleRef:
   name: collect-infrastructure-logs
 subjects:
 - kind: ServiceAccount
-  name: logcollector
+  name: collector
   namespace: openshift-logging

--- a/telco-core/configuration/reference-crs/optional/logging/ClusterLogging.yaml
+++ b/telco-core/configuration/reference-crs/optional/logging/ClusterLogging.yaml
@@ -1,7 +1,0 @@
-# This CR is no longer used in Cluster Logging 6.0. It remains in the reference to support removal via policy.
-apiVersion: logging.openshift.io/v1
-kind: ClusterLogging
-metadata:
-  name: instance
-  namespace: openshift-logging
-spec: {}

--- a/telco-core/configuration/reference-crs/optional/logging/ClusterLogging5Cleanup.yaml
+++ b/telco-core/configuration/reference-crs/optional/logging/ClusterLogging5Cleanup.yaml
@@ -1,0 +1,37 @@
+# This content is only for use in creating a Policy which will remove
+# the Cluster Logging Operator 5.x ClusterLogForwarder and ClusterLogging
+# CRs from a cluster. The object-template-raw is used in order to handle
+# existing clusters where the CRD is defined as well as new clusters
+# where the CRD is not defined.
+---
+object-templates-raw: |
+  {{ if ne (default "" (lookup "apiextensions.k8s.io/v1" "CustomResourceDefinition" "" "clusterlogforwarders.logging.openshift.io").metadata.name) "" }}
+  - complianceType: mustnothave
+    objectDefinition:
+      apiVersion: logging.openshift.io/v1
+      kind: ClusterLogForwarder
+      metadata:
+        name: instance
+        namespace: openshift-logging
+  - complianceType: mustnothave
+    objectDefinition:
+      apiVersion: apiextensions.k8s.io/v1
+      kind: CustomResourceDefinition
+      metadata:
+        name: clusterlogforwarders.logging.openshift.io
+  {{ end }}
+  {{ if ne (default "" (lookup "apiextensions.k8s.io/v1" "CustomResourceDefinition" "" "clusterloggings.logging.openshift.io").metadata.name) "" }}
+  - complianceType: mustnothave
+    objectDefinition:
+      apiVersion: logging.openshift.io/v1
+      kind: ClusterLogging
+      metadata:
+        name: instance
+        namespace: openshift-logging
+  - complianceType: mustnothave
+    objectDefinition:
+      apiVersion: apiextensions.k8s.io/v1
+      kind: CustomResourceDefinition
+      metadata:
+        name: clusterloggings.logging.openshift.io
+  {{ end }}


### PR DESCRIPTION
The upgrade from Cluster Logging Operator 5.x to 6.0 requires a couple steps in the proper order to ensure upgrade without loss of logs. 

1. Set subscription channel to stable-6.0
2. Approve the install plan
3. Wait for the operator/operand to upgrade
4. Create the new API ClusterLogForwarder.observability CR
5. Wait for Valid status
6. Remove old API CRs ClusterLogForwarder.logging and ClusterLogging
This PR builds on #35 by adding support for step 6. Steps 1-5 are included in the previous PR.