### PR TITLE
OCPBUGS-42371: Update core reference to ignore automatically-added operator labels

### DIFF
--- a/telco-core/configuration/reference-crs-kube-compare/metadata.yaml
+++ b/telco-core/configuration/reference-crs-kube-compare/metadata.yaml
@@ -145,12 +145,13 @@ fieldsToOmit:
       - pathToKey: metadata.labels."kubernetes.io/metadata.name"
       - pathToKey: metadata.labels."pod-security.kubernetes.io"
         isPrefix: true
+      - pathToKey: metadata.labels."operators.coreos.com/"
+        isPrefix: true
       - pathToKey: metadata.labels."security.openshift.io/scc.podSecurityLabelSync"
       - pathToKey: metadata.resourceVersion
       - pathToKey: metadata.uid
       - pathToKey: spec.finalizers
       - pathToKey: metadata.creationTimestamp
-      - pathToKey: metadata."pod-security.kubernetes.io"
       - pathToKey: metadata.generation
       - pathToKey: status # TODO:  We need to check status in Subscription and CatalogSource. CNF-13521
       - pathToKey: metadata.finalizers

--- a/telco-core/configuration/reference-crs-kube-compare/required/networking/NMStateNS.yaml
+++ b/telco-core/configuration/reference-crs-kube-compare/required/networking/NMStateNS.yaml
@@ -2,3 +2,5 @@ apiVersion: v1
 kind: Namespace
 metadata:
   name: openshift-nmstate
+  labels:
+    openshift.io/cluster-monitoring: "true"

--- a/telco-core/configuration/reference-crs/required/networking/NMStateNS.yaml
+++ b/telco-core/configuration/reference-crs/required/networking/NMStateNS.yaml
@@ -3,3 +3,5 @@ apiVersion: v1
 kind: Namespace
 metadata:
   name: openshift-nmstate
+  labels:
+    openshift.io/cluster-monitoring: "true"


### PR DESCRIPTION
Signed-off-by: Jim Ramsay <jramsay@redhat.com>
