### PR TITLE
Exclude SRIOV annotation from compare

### DIFF
--- a/telco-core/configuration/reference-crs-kube-compare/metadata.yaml
+++ b/telco-core/configuration/reference-crs-kube-compare/metadata.yaml
@@ -171,3 +171,4 @@ fieldsToOmit:
       - pathToKey: metadata.labels."olm.operatorgroup.uid"
         isPrefix: true
       - pathToKey: metadata.annotations."nmstate.io/webhook-mutating-timestamp"
+      - pathToKey: metadata.annotations."operator.sriovnetwork.openshift.io/last-network-namespace"


### PR DESCRIPTION
The
metadata.annotations."operator.sriovnetwork.openshift.io/last-network-namespace" annotation is automatically added and maintained by the SRIOV operator. It should not be included in the comparison.