### PR TITLE
update sctp mc

### DIFF
--- a/telco-core/configuration/reference-crs/optional/other/sctp_module_mc.yaml
+++ b/telco-core/configuration/reference-crs/optional/other/sctp_module_mc.yaml
@@ -4,23 +4,23 @@
 apiVersion: machineconfiguration.openshift.io/v1
 kind: MachineConfig
 metadata:
+  name: load-sctp-module
   labels:
     machineconfiguration.openshift.io/role: worker
-  name: load-sctp-module
 spec:
   config:
     ignition:
-      version: 2.2.0
+      version: 3.2.0
     storage:
       files:
-        - contents:
+        - path: /etc/modprobe.d/sctp-blacklist.conf
+          mode: 420
+          overwrite: true
+          contents:
             source: data:,
-            verification: {}
-          filesystem: root
+        - path: /etc/modules-load.d/sctp-load.conf
           mode: 420
-          path: /etc/modprobe.d/sctp-blacklist.conf
-        - contents:
-            source: data:text/plain;charset=utf-8;base64,c2N0cA==
-          filesystem: root
-          mode: 420
-          path: /etc/modules-load.d/sctp-load.conf
+          overwrite: true
+          contents:
+            source: data:,sctp
+

--- a/telco-core/configuration/reference-crs/optional/other/sctp_module_mc.yaml
+++ b/telco-core/configuration/reference-crs/optional/other/sctp_module_mc.yaml
@@ -23,4 +23,3 @@ spec:
           overwrite: true
           contents:
             source: data:,sctp
-


### PR DESCRIPTION
update sctp mc as discussed in previous PR
From prior PR comment:
> The current version of load-sctp-module machineConfig is using different value for ignition version and file permission comparing to Red Hat Official Documentation for Openshift 4.14.
> Updating load-sctp-module machineConfig to align with Red Hat Official Documentation for Openshift 4.14
> [Enabling SCTP on OCP 4.14](https://docs.openshift.com/container-platform/4.14/networking/using-sctp.html#nw-sctp-enabling_using-sctp)