### PR TITLE
Set all approvals to Automatic for Hub operators

### DIFF
--- a/telco-hub/configuration/reference-crs/required/acm/acmMCH.yaml
+++ b/telco-hub/configuration/reference-crs/required/acm/acmMCH.yaml
@@ -3,7 +3,7 @@ apiVersion: operator.open-cluster-management.io/v1
 kind: MultiClusterHub
 metadata:
   annotations:
-    installer.open-cluster-management.io/mce-subscription-spec: '{"installPlanApproval": "Manual"}'
+    installer.open-cluster-management.io/mce-subscription-spec: '{"installPlanApproval": "Automatic"}'
   name: multiclusterhub
   namespace: open-cluster-management
 spec:

--- a/telco-hub/configuration/reference-crs/required/acm/acmSubscription.yaml
+++ b/telco-hub/configuration/reference-crs/required/acm/acmSubscription.yaml
@@ -6,7 +6,7 @@ metadata:
   namespace: open-cluster-management
 spec:
   channel: release-2.12
-  installPlanApproval: Manual
+  installPlanApproval: Automatic
   name: advanced-cluster-management
   source: redhat-operators-disconnected
   sourceNamespace: openshift-marketplace

--- a/telco-hub/configuration/reference-crs/required/acm/readme.md
+++ b/telco-hub/configuration/reference-crs/required/acm/readme.md
@@ -1,9 +1,9 @@
 # Installation instructions
 
   1 - Create the `acmNS.yaml` `acmOperGroup.yaml` `acmSubscription.yaml`
-  2 - Approve the created InstallPlan on `open-cluster-management`
+  2 - If Subscription was set to Manual installPlanApproval, approve the created InstallPlan on `open-cluster-management`
   3 - Create the `acmMCH.yaml`
-  4 - Approve the created InstallPlan on `multicluster-engine`
+  4 - If Subscription was set to Manual installPlanApproval, approve the created InstallPlan on `multicluster-engine`
   5 - Apply the `acmProvisioning.yaml` ?
   6 - Create the  `acmAgentServiceConfig.yaml`
   7 - The `multicluster-engine` enables the `cluster-proxy-addon` feature by default. Apply the following patch to disable it: `oc patch multiclusterengines.multicluster.openshift.io multiclusterengine --type=merge --patch-file ./disable-cluster-proxy-addon.json`

--- a/telco-hub/configuration/reference-crs/required/gitops/gitopsSubscription.yaml
+++ b/telco-hub/configuration/reference-crs/required/gitops/gitopsSubscription.yaml
@@ -5,7 +5,7 @@ metadata:
   namespace: openshift-gitops-operator
 spec:
   channel: gitops-1.13
-  installPlanApproval: Manual
+  installPlanApproval: Automatic
   name: openshift-gitops-operator
   source: redhat-operators-disconnected
   sourceNamespace: openshift-marketplace

--- a/telco-hub/configuration/reference-crs/required/talm/talmSubscription.yaml
+++ b/telco-hub/configuration/reference-crs/required/talm/talmSubscription.yaml
@@ -6,7 +6,7 @@ metadata:
   namespace: openshift-operators
 spec:
   channel: stable
-  installPlanApproval: Manual
+  installPlanApproval: Automatic
   name: topology-aware-lifecycle-manager
   source: redhat-operators-disconnected
   sourceNamespace: openshift-marketplace


### PR DESCRIPTION
The Hub cluster will not be managed with TALM. Set all operators to Automatic installPlanApproval by default. Customers can control timing of updates by using separate catalogs for new hub cluster versions.