### PR TITLE
[draft] Add GitOps ZTP infrastructure CRs

### DIFF
--- a/telco-hub/configuration/reference-crs/required/gitops_ztp/app-project.yaml
+++ b/telco-hub/configuration/reference-crs/required/gitops_ztp/app-project.yaml
@@ -1,0 +1,45 @@
+apiVersion: argoproj.io/v1alpha1
+kind: AppProject
+metadata:
+  name: ztp-app-project
+  namespace: openshift-gitops
+spec:
+  clusterResourceWhitelist:
+  - group: 'hive.openshift.io'
+    kind: ClusterImageSet
+  - group: 'cluster.open-cluster-management.io'
+    kind: ManagedCluster
+  - group: ''
+    kind: Namespace
+  destinations:
+  - namespace: '*'
+    server: '*'
+  namespaceResourceWhitelist:
+  - group: ''
+    kind: ConfigMap
+  - group: ''
+    kind: Namespace
+  - group: ''
+    kind: Secret
+  - group: 'agent-install.openshift.io'
+    kind: InfraEnv
+  - group: 'agent-install.openshift.io'
+    kind: NMStateConfig
+  - group: 'extensions.hive.openshift.io'
+    kind: AgentClusterInstall
+  - group: 'hive.openshift.io'
+    kind: ClusterDeployment
+  - group: 'metal3.io'
+    kind: BareMetalHost
+  - group: 'metal3.io'
+    kind: HostFirmwareSettings
+  - group: 'agent.open-cluster-management.io'
+    kind: KlusterletAddonConfig
+  - group: 'cluster.open-cluster-management.io'
+    kind: ManagedCluster
+  - group: 'ran.openshift.io'
+    kind: SiteConfig
+  - group: 'siteconfig.open-cluster-management.io'
+    kind: ClusterInstance
+  sourceRepos:
+  - '*'

--- a/telco-hub/configuration/reference-crs/required/gitops_ztp/clusters-app.yaml
+++ b/telco-hub/configuration/reference-crs/required/gitops_ztp/clusters-app.yaml
@@ -1,0 +1,40 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: clusters-sub
+---
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: clusters
+  namespace: openshift-gitops
+spec:
+  destination:
+    server: https://kubernetes.default.svc
+    namespace: clusters-sub
+  project: ztp-app-project
+  source:
+    path: ztp/gitops-subscriptions/argocd/example/siteconfig
+    repoURL: https://github.com/openshift-kni/cnf-features-deploy
+    targetRevision: master
+    # uncomment the below plugin if you will be adding the plugin binaries in the same repo->dir where
+    # the sitconfig.yaml exist AND use the ../../hack/patch-argocd-dev.sh script to re-patch the deployment-repo-server
+#    plugin:
+#      name: kustomize-with-local-plugins
+  ignoreDifferences: # recommended way to allow ACM controller to manage its fields. alternative approach documented below (1)
+    - group: cluster.open-cluster-management.io
+      kind: ManagedCluster
+      managedFieldsManagers:
+        - controller
+# (1) alternatively you can choose to ignore a specific path like so (replace managedFieldsManagers with jsonPointers)
+#      jsonPointers:
+#        - /metadata/labels/cloud
+#        - /metadata/labels/vendor
+  syncPolicy:
+    automated:
+      prune: true
+      selfHeal: true
+    syncOptions:
+      - CreateNamespace=true
+      - PrunePropagationPolicy=background
+      - RespectIgnoreDifferences=true

--- a/telco-hub/configuration/reference-crs/required/gitops_ztp/gitops-cluster-rolebinding.yaml
+++ b/telco-hub/configuration/reference-crs/required/gitops_ztp/gitops-cluster-rolebinding.yaml
@@ -1,0 +1,12 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: gitops-cluster
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: cluster-admin
+subjects:
+- kind: ServiceAccount
+  name: openshift-gitops-argocd-application-controller
+  namespace: openshift-gitops

--- a/telco-hub/configuration/reference-crs/required/gitops_ztp/gitops-policy-rolebinding.yaml
+++ b/telco-hub/configuration/reference-crs/required/gitops_ztp/gitops-policy-rolebinding.yaml
@@ -1,0 +1,12 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: gitops-policy
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: open-cluster-management:cluster-manager-admin
+subjects:
+- kind: ServiceAccount
+  name: openshift-gitops-argocd-application-controller
+  namespace: openshift-gitops

--- a/telco-hub/configuration/reference-crs/required/gitops_ztp/openshift-gitops-operator.yaml
+++ b/telco-hub/configuration/reference-crs/required/gitops_ztp/openshift-gitops-operator.yaml
@@ -1,0 +1,16 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: openshift-gitops
+---
+apiVersion: operators.coreos.com/v1alpha1
+kind: Subscription
+metadata:
+  name: openshift-gitops-operator
+  namespace: openshift-operators
+spec:
+  channel: gitops-1.12
+  name: openshift-gitops-operator
+  source: redhat-operators
+  sourceNamespace: openshift-marketplace
+  installPlanApproval: Automatic

--- a/telco-hub/configuration/reference-crs/required/gitops_ztp/policies-app-project.yaml
+++ b/telco-hub/configuration/reference-crs/required/gitops_ztp/policies-app-project.yaml
@@ -1,0 +1,38 @@
+---
+apiVersion: argoproj.io/v1alpha1
+kind: AppProject
+metadata:
+  name: policy-app-project
+  namespace: openshift-gitops
+spec:
+  clusterResourceWhitelist:
+  - group: ''
+    kind: Namespace
+  destinations:
+  - namespace: 'ztp*'
+    server: '*'
+  - namespace: 'policies-sub'
+    server: '*'
+  namespaceResourceWhitelist:
+  - group: ''
+    kind: ConfigMap
+  - group: ''
+    kind: Namespace
+  - group: 'apps.open-cluster-management.io'
+    kind: PlacementRule
+  - group: 'policy.open-cluster-management.io'
+    kind: Policy
+  - group: 'policy.open-cluster-management.io'
+    kind: PlacementBinding
+  - group: 'ran.openshift.io'
+    kind: PolicyGenTemplate
+  - group: cluster.open-cluster-management.io
+    kind: Placement
+  - group: policy.open-cluster-management.io
+    kind: PolicyGenerator
+  - group: policy.open-cluster-management.io
+    kind: PolicySet
+  - group: cluster.open-cluster-management.io
+    kind: ManagedClusterSetBinding
+  sourceRepos:
+  - '*'

--- a/telco-hub/configuration/reference-crs/required/gitops_ztp/policies-app.yaml
+++ b/telco-hub/configuration/reference-crs/required/gitops_ztp/policies-app.yaml
@@ -1,0 +1,30 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+    name: policies-sub
+---
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: policies
+  namespace: openshift-gitops
+spec:
+  destination:
+    server: https://kubernetes.default.svc
+    namespace: policies-sub
+  project: policy-app-project
+  source:
+    path: ztp/gitops-subscriptions/argocd/example/policygentemplates
+    repoURL: https://github.com/openshift-kni/cnf-features-deploy
+    targetRevision: master
+    # uncomment the below plugin if you will be adding the plugin binaries in the same repo->dir where
+    # the policyGenTemplate.yaml exist AND use the ../../hack/patch-argocd-dev.sh script to re-patch the deployment-repo-server
+#    plugin:
+#      name: kustomize-with-local-plugins
+  syncPolicy:
+    automated:
+      prune: true
+      selfHeal: true
+    syncOptions:
+    - CreateNamespace=true
+


### PR DESCRIPTION
These are pulled directly from
https://github.com/openshift-kni/cnf-features-deploy/tree/master/ztp/gitops-subscriptions/argocd/deployment to create the baseline infrastructure for synchronizing deployment (SiteConfig or ClusterInstance) and policy (PolicyGenerator, PolicyGenTemplate) CRs to a hub cluster in support of managing a fleet of telco clusters.