### PR TITLE
telco-hub: update operator channels and resources to 4.17

### DIFF
--- a/telco-hub/configuration/reference-crs/optional/odf-internal/odfSubscription.yaml
+++ b/telco-hub/configuration/reference-crs/optional/odf-internal/odfSubscription.yaml
@@ -5,7 +5,7 @@ metadata:
   name: odf-operator
   namespace: openshift-storage
 spec:
-  channel: "stable-4.16"
+  channel: "stable-4.17"
   name: odf-operator
   source: redhat-operators-disconnected
   sourceNamespace: openshift-marketplace

--- a/telco-hub/configuration/reference-crs/required/acm/acmAgentServiceConfig.yaml
+++ b/telco-hub/configuration/reference-crs/required/acm/acmAgentServiceConfig.yaml
@@ -38,3 +38,8 @@ spec:
     rootFSUrl: https://mirror.openshift.com/pub/openshift-v4/x86_64/dependencies/rhcos/4.16/latest/rhcos-live-rootfs.x86_64.img
     url: https://mirror.openshift.com/pub/openshift-v4/x86_64/dependencies/rhcos/4.16/latest/rhcos-live.x86_64.iso
     version: 4.16-latest
+  - cpuArchitecture: x86_64
+    openshiftVersion: "4.17"
+    rootFSUrl: https://mirror.openshift.com/pub/openshift-v4/x86_64/dependencies/rhcos/4.17/latest/rhcos-live-rootfs.x86_64.img
+    url: https://mirror.openshift.com/pub/openshift-v4/x86_64/dependencies/rhcos/4.17/latest/rhcos-live.x86_64.iso
+    version: 4.17-latest

--- a/telco-hub/configuration/reference-crs/required/acm/acmSubscription.yaml
+++ b/telco-hub/configuration/reference-crs/required/acm/acmSubscription.yaml
@@ -5,7 +5,7 @@ metadata:
   name: open-cluster-management-subscription
   namespace: open-cluster-management
 spec:
-  channel: release-2.11
+  channel: release-2.12
   installPlanApproval: Manual
   name: advanced-cluster-management
   source: redhat-operators-disconnected


### PR DESCRIPTION
* ACM version upgraded to 2.12 (including the new SiteConfig operator).
* ODF version upgraded to 4.17.
* Add RHCOS 4.17 OS image to the AgentServiceConfig CR.