### PR TITLE
add examples of usage with multiple mcps

### DIFF
--- a/telco-core/configuration/core-finish.yaml
+++ b/telco-core/configuration/core-finish.yaml
@@ -1,0 +1,71 @@
+---
+apiVersion: policy.open-cluster-management.io/v1
+kind: PolicyGenerator
+metadata:
+  name: core-customer-policies
+policyDefaults:
+  namespace: ztp-core-policies
+  policySets: []
+  placement:
+    clusterSelectors:
+      common: "core"
+      version: "4.18"
+  remediationAction: "inform"
+policies:
+  # unpause baseline configuration
+  - name: custom-mcp-unpause
+    policyAnnotations:
+      ran.openshift.io/ztp-deploy-wave: "200"
+    manifests:
+      # The MCPs should be added as extra manifests at installation time. Their
+      # inclusion here will reset the pause to false, allowing the MCPs to update
+      - path: ../install/custom-manifests/mcp-worker-1.yaml
+        patches:
+        - spec:
+            paused: false
+          status:
+            conditions:
+            - type: Updated
+              status: "True"
+            - type: Updating
+              status: "False"
+
+      - path: ../install/custom-manifests/mcp-worker-2.yaml
+        patches:
+        - spec:
+            paused: false
+          status:
+            conditions:
+            - type: Updated
+              status: "True"
+            - type: Updating
+              status: "False"
+
+      - path: ../install/custom-manifests/mcp-worker-3.yaml
+        patches:
+        - spec:
+            paused: false
+          status:
+            conditions:
+            - type: Updated
+              status: "True"
+            - type: Updating
+              status: "False"
+
+  - name: core-custom-mcp-set-maxavailable
+    policyAnnotations:
+      ran.openshift.io/ztp-deploy-wave: "201"
+    manifests:
+      # This sets the desired maxUnavailable on the customMCPs
+      - path: ../install/custom-manifests/mcp-worker-1.yaml
+        patches:
+        - spec:
+            maxUnavailable: 1
+      - path: ../install/custom-manifests/mcp-worker-2.yaml
+        patches:
+        - spec:
+            maxUnavailable: 1
+      - path: ../install/custom-manifests/mcp-worker-3.yaml
+        patches:
+        - spec:
+            maxUnavailable: 1

--- a/telco-core/configuration/kustomization.yaml
+++ b/telco-core/configuration/kustomization.yaml
@@ -9,3 +9,4 @@ generators:
   - core-baseline.yaml
   - core-overlay.yaml
   - core-upgrade.yaml
+  - core-finish.yaml

--- a/telco-core/install/custom-manifests/mcp-worker-3.yaml
+++ b/telco-core/install/custom-manifests/mcp-worker-3.yaml
@@ -1,0 +1,18 @@
+---
+apiVersion: machineconfiguration.openshift.io/v1
+kind: MachineConfigPool
+metadata:
+  name: worker-3
+  labels:
+    machineconfiguration.openshift.io/role: worker-3
+spec:
+  machineConfigSelector:
+    matchExpressions:
+      - key: machineconfiguration.openshift.io/role
+        operator: In
+        values: [ worker, worker-3 ]
+  paused: true
+  maxUnavailable: 100%
+  nodeSelector:
+    matchLabels:
+      node-role.kubernetes.io/worker-3: ""


### PR DESCRIPTION
Adding PolicyGen with unpause and setting maxUnavailable in a unique harmonized example.
Created new MCP worker-3. Update kustomize. 