### PR TITLE
CNF-13981: set reachabilityTotalTimeoutSeconds=1

### DIFF
--- a/telco-core/configuration/reference-crs-kube-compare/required/networking/Network.yaml
+++ b/telco-core/configuration/reference-crs-kube-compare/required/networking/Network.yaml
@@ -7,6 +7,8 @@ spec:
     ovnKubernetesConfig:
       gatewayConfig:
         routingViaHost: true
+      egressIPConfig:
+        reachabilityTotalTimeoutSeconds: 1
   {{ if hasKey .spec "useMultiNetworkPolicy" }}
   useMultiNetworkPolicy: {{ .spec.useMultiNetworkPolicy }}
   {{ end }}

--- a/telco-core/configuration/reference-crs/required/networking/Network.yaml
+++ b/telco-core/configuration/reference-crs/required/networking/Network.yaml
@@ -10,6 +10,8 @@ spec:
     ovnKubernetesConfig:
       gatewayConfig:
         routingViaHost: true
+      egressIPConfig:
+        reachabilityTotalTimeoutSeconds: 1
   # additional networks are optional and may alternatively be specified using NetworkAttachmentDefinition CRs
   additionalNetworks: [ $additionalNetworks ]
   # eg


### PR DESCRIPTION
The `reachabilityTotalTimeoutSeconds` parameter in the `Network` CR configures the EgressIP node reachability check total timeout in seconds. The recommended value is `1` second.