### PR TITLE
Removed dedicatedServiceMonitors from kube-compare cr

### DIFF
--- a/telco-core/configuration/reference-crs-kube-compare/optional/other/monitoring-config-cm.yaml
+++ b/telco-core/configuration/reference-crs-kube-compare/optional/other/monitoring-config-cm.yaml
@@ -8,9 +8,6 @@ metadata:
   namespace: openshift-monitoring
 data:
   config.yaml: |
-    k8sPrometheusAdapter:
-      dedicatedServiceMonitors:
-        enabled: true
     prometheusK8s:
       retention: 15d
       volumeClaimTemplate:


### PR DESCRIPTION
_dedicatedServiceMonitors_ part was removed some time ago in b67c2cf5abd9a0a7c17cea982b93ba9e312a1b1e but respective kube-compare CR was missed. Adjusting now.