### PR TITLE
CNF-10595: add egressIP configuration

### DIFF
--- a/telco-core/configuration/reference-crs-kube-compare/required/networking/Network.yaml
+++ b/telco-core/configuration/reference-crs-kube-compare/required/networking/Network.yaml
@@ -7,6 +7,8 @@ spec:
     ovnKubernetesConfig:
       gatewayConfig:
         routingViaHost: true
+      egressIPConfig:
+        reachabilityTotalTimeoutSeconds: 1
   {{ if hasKey .spec "useMultiNetworkPolicy" }}
   useMultiNetworkPolicy: {{ .spec.useMultiNetworkPolicy }}
   {{ end }}

--- a/telco-core/configuration/reference-crs/required/networking/Network.yaml
+++ b/telco-core/configuration/reference-crs/required/networking/Network.yaml
@@ -10,6 +10,8 @@ spec:
     ovnKubernetesConfig:
       gatewayConfig:
         routingViaHost: true
+      egressIPConfig:
+        reachabilityTotalTimeoutSeconds: 1
   # additional networks are optional and may alternatively be specified using NetworkAttachmentDefinition CRs
   additionalNetworks: [ $additionalNetworks ]
   # eg


### PR DESCRIPTION
The `reachabilityTotalTimeoutSeconds` parameter configures the EgressIP node reachability check total timeout in seconds. The platform chooses a reasonable default value, which is subject to change over time and is set to 1 second by default.

For Telco, we recommend adding an explicit setting of 1 second to protect against future changes.