### PR TITLE
Add mustonlyhave compliance type to the generated policy for sctp mc

### DIFF
--- a/telco-core/configuration/core-overlay.yaml
+++ b/telco-core/configuration/core-overlay.yaml
@@ -26,6 +26,7 @@ policies:
               - example.com/sample-path
               source: nomatch.io/sample-path
       - path: reference-crs/optional/other/sctp_module_mc.yaml
+        complianceType: mustonlyhave
       - path: reference-crs/optional/other/worker-load-kernel-modules.yaml
       - path: reference-crs/optional/other/control-plane-load-kernel-modules.yaml
       - path: reference-crs/optional/networking/multus/tap_cni/mc_rootless_pods_selinux.yaml


### PR DESCRIPTION
 without setting the policy compliance to "mustonlyhave" we will end up creating the machine config with 4 entries rather than the 2 desired ones when we upgrade from older versions of the reference with that MC in place.
 Added mustonlyhave compliance type to the generated policy for sctp mc.