### PR TITLE
Storage needs based on capacity planning tool

### DIFF
--- a/telco-hub/configuration/reference-crs/required/acm/observabilityMCO.yaml
+++ b/telco-hub/configuration/reference-crs/required/acm/observabilityMCO.yaml
@@ -10,19 +10,20 @@ metadata:
     # https://issues.redhat.com/browse/CNF-13398
     mco-disable-alerting: "true"
 spec:
-    # based on the data provided by acm-capacity tool
-    # https://github.com/stolostron/capacity-planning/blob/main/calculation/ObsSizingTemplate-Rev1.ipynb
-    # for an scenario with:
-    # 3500SNOs, 125 pods and 5 Namespaces (apart from Openshift NS)
-    # storage retention 365 days
-    # downsampling disabled
-    # default MCO Addon configuration samples_per_hour, pv_retention_hrs.
+  # based on the data provided by acm-capacity tool
+  # https://github.com/stolostron/capacity-planning/blob/main/calculation/ObsSizingTemplate-Rev1.ipynb
+  # for an scenario with:
+  # 3500SNOs, 125 pods and 4 Namespaces (apart from Openshift NS)
+  # storage retention 15 days
+  # downsampling disabled
+  # default MCO Addon configuration samples_per_hour, pv_retention_hrs.
+  # More on how to stimate: https://access.redhat.com/articles/7103886
   advanced:
     retentionConfig:
       blockDuration: 2h
       deleteDelay: 48h
       retentionInLocal: 24h
-      retentionResolutionRaw: 3d
+      retentionResolutionRaw: 15d
   enableDownsampling: false
   observabilityAddonSpec:
     enableMetrics: true
@@ -31,10 +32,11 @@ spec:
     alertmanagerStorageSize: 10Gi
     compactStorageSize: 100Gi
     metricObjectStorage:
-    # buckets storage should provide a capacity
-    # of at least 2.5TB
       key: thanos.yaml
       name: thanos-object-storage
     receiveStorageSize: 10Gi
     ruleStorageSize: 30Gi
     storeStorageSize: 100Gi
+    # A part from this storage settings, the `metricObjectStorage`
+    # points to an Objet Storage. Here it cannot be configured its
+    # capacity. Consider an extra reservation of about 101Gi

--- a/telco-hub/configuration/reference-crs/required/acm/observabilityMCO.yaml
+++ b/telco-hub/configuration/reference-crs/required/acm/observabilityMCO.yaml
@@ -37,6 +37,6 @@ spec:
     receiveStorageSize: 10Gi
     ruleStorageSize: 30Gi
     storeStorageSize: 100Gi
-    # A part from this storage settings, the `metricObjectStorage`
-    # points to an Objet Storage. Here it cannot be configured its
-    # capacity. Consider an extra reservation of about 101Gi
+    # In addition to these storage settings, the `metricObjectStorage`
+    # points to an Object Storage. Under the reference configuration, 
+    # scale and retention the estimated object storage is about 101Gi

--- a/telco-hub/configuration/reference-crs/required/acm/observabilityMCO.yaml
+++ b/telco-hub/configuration/reference-crs/required/acm/observabilityMCO.yaml
@@ -38,5 +38,5 @@ spec:
     ruleStorageSize: 30Gi
     storeStorageSize: 100Gi
     # In addition to these storage settings, the `metricObjectStorage`
-    # points to an Object Storage. Under the reference configuration, 
+    # points to an Object Storage. Under the reference configuration,
     # scale and retention the estimated object storage is about 101Gi


### PR DESCRIPTION
Updated storage needs using the capacity planning tool:
https://github.com/stolostron/capacity-planning/blob/main/calculation/ObsSizingTemplate-Rev1.ipynb 
and the requirements for a Telco Hub managing Telco RAN managed clusters.