### PR TITLE
Loosen validation of echoMode option in BFDProfile

### DIFF
--- a/telco-core/configuration/reference-crs-kube-compare/required/networking/metallb/bfd-profile.yaml
+++ b/telco-core/configuration/reference-crs-kube-compare/required/networking/metallb/bfd-profile.yaml
@@ -12,7 +12,9 @@ spec:
   echoInterval: {{ if .spec.echoInterval }} {{ .spec.echoInterval }} {{ else }} "50ms" {{ end }} # default 50ms
   {{ end }}
   detectMultiplier: {{ if .spec.detectMultiplier }} {{ .spec.detectMultiplier }} {{ else }} "3" {{ end }} # default 3
-  echoMode: true
+  {{- if .spec.echoMode }}
+  echoMode: {{ .spec.echoMode }}
+  {{- end }}
   passiveMode: true
   minimumTtl: {{ if .spec.minimumTtl }} {{ .spec.minimumTtl }} {{ else }} "254" {{ end }} # default 254
   #

--- a/telco-core/configuration/reference-crs/required/networking/metallb/bfd-profile.yaml
+++ b/telco-core/configuration/reference-crs/required/networking/metallb/bfd-profile.yaml
@@ -13,7 +13,6 @@ spec:
   transmitInterval: 150  # default 300ms
   # echoInterval: 300  # default 50ms
   detectMultiplier: 10  # default 3
-  echoMode: true
   passiveMode: true
   minimumTtl: 5  # default 254
   #


### PR DESCRIPTION
Existing value (_true_) only works if the other side is _FRR_ and not BGP capable router therefore removing it from the reference- and compare- CRs.