### PR TITLE
Update the MCP reference to fix paths

### DIFF
--- a/telco-core/configuration/core-finish.yaml
+++ b/telco-core/configuration/core-finish.yaml
@@ -19,10 +19,11 @@ policies:
     manifests:
       # The MCPs should be added as extra manifests at installation time. Their
       # inclusion here will reset the pause to false, allowing the MCPs to update
-      - path: ../install/custom-manifests/mcp-worker-1.yaml
+      - path: reference-crs/custom-manifests/mcp-worker-1.yaml
         patches:
         - spec:
             paused: false
+            maxUnavailable: 100%
           status:
             conditions:
             - type: Updated
@@ -30,10 +31,11 @@ policies:
             - type: Updating
               status: "False"
 
-      - path: ../install/custom-manifests/mcp-worker-2.yaml
+      - path: reference-crs/custom-manifests/mcp-worker-2.yaml
         patches:
         - spec:
             paused: false
+            maxUnavailable: 100%
           status:
             conditions:
             - type: Updated
@@ -41,10 +43,11 @@ policies:
             - type: Updating
               status: "False"
 
-      - path: ../install/custom-manifests/mcp-worker-3.yaml
+      - path: reference-crs/custom-manifests/mcp-worker-3.yaml
         patches:
         - spec:
             paused: false
+            maxUnavailable: 100%
           status:
             conditions:
             - type: Updated
@@ -57,15 +60,15 @@ policies:
       ran.openshift.io/ztp-deploy-wave: "201"
     manifests:
       # This sets the desired maxUnavailable on the customMCPs
-      - path: ../install/custom-manifests/mcp-worker-1.yaml
+      - path: reference-crs/custom-manifests/mcp-worker-1.yaml
         patches:
         - spec:
             maxUnavailable: 1
-      - path: ../install/custom-manifests/mcp-worker-2.yaml
+      - path: reference-crs/custom-manifests/mcp-worker-2.yaml
         patches:
         - spec:
             maxUnavailable: 1
-      - path: ../install/custom-manifests/mcp-worker-3.yaml
+      - path: reference-crs/custom-manifests/mcp-worker-3.yaml
         patches:
         - spec:
             maxUnavailable: 1

--- a/telco-core/configuration/core-upgrade.yaml
+++ b/telco-core/configuration/core-upgrade.yaml
@@ -34,18 +34,18 @@ policies:
         - spec:
             channel: stable-4.18
             installPlanApproval: Manual
-      # - path: customer/mcp-worker-1.yaml
-      #   patches:
-      #   - spec:
-      #       paused: true
-      # - path: customer/mcp-worker-2.yaml
-      #   patches:
-      #   - spec:
-      #       paused: true
-      # - path: customer/mcp-worker-3.yaml
-      #   patches:
-      #   - spec:
-      #       paused: true
+      - path: reference-crs/custom-manifests/mcp-worker-1.yaml
+        patches:
+        - spec:
+            paused: true
+      - path: reference-crs/custom-manifests/mcp-worker-2.yaml
+        patches:
+        - spec:
+            paused: true
+      - path: reference-crs/custom-manifests/mcp-worker-3.yaml
+        patches:
+        - spec:
+            paused: true
   - name: core-upgrade-ocp-18
     manifests:
       - path: reference-crs/optional/other/ClusterVersion.yaml

--- a/telco-core/configuration/reference-crs-kube-compare/compare_ignore
+++ b/telco-core/configuration/reference-crs-kube-compare/compare_ignore
@@ -16,3 +16,9 @@ upgrade-ack.yaml
 # Deprecated CRs, no longer in the reference-crs examples:
 optional/networking/sriov/SriovNetworkPoolConfig.yaml
 required/networking/metallb/service.yaml
+
+# These are examples only. Customer will provide their own 
+# based on cluster topology and desired MCP partitioning.
+custom-manifests/mcp-worker-1.yaml
+custom-manifests/mcp-worker-2.yaml
+custom-manifests/mcp-worker-3.yaml

--- a/telco-core/configuration/reference-crs/custom-manifests/README.md
+++ b/telco-core/configuration/reference-crs/custom-manifests/README.md
@@ -1,0 +1,10 @@
+# Custom CRs
+This directory is a placeholder for additional custom CRs which are
+outside the scope of the reference CRs.
+
+## Reference MCPs
+The MCP CRs contained here are examples for a multi-mcp cluster and
+are used to build policies which accelerate initial rollout of
+configuration by increasing maxUnavailable and manipulating the MCP
+pause. The MCPs should be created during initial cluster installation
+in a paused state with maxUnavailable of 100%.

--- a/telco-core/configuration/reference-crs/custom-manifests/mcp-worker-1.yaml
+++ b/telco-core/configuration/reference-crs/custom-manifests/mcp-worker-1.yaml
@@ -1,0 +1,18 @@
+---
+apiVersion: machineconfiguration.openshift.io/v1
+kind: MachineConfigPool
+metadata:
+  name: worker-1
+  labels:
+    machineconfiguration.openshift.io/role: worker-1
+spec:
+  machineConfigSelector:
+    matchExpressions:
+    - key: machineconfiguration.openshift.io/role
+      operator: In
+      values: [ worker, worker-1 ]
+  paused: false
+  maxUnavailable: 1
+  nodeSelector:
+    matchLabels:
+      node-role.kubernetes.io/worker-1: ""

--- a/telco-core/configuration/reference-crs/custom-manifests/mcp-worker-2.yaml
+++ b/telco-core/configuration/reference-crs/custom-manifests/mcp-worker-2.yaml
@@ -1,0 +1,18 @@
+---
+apiVersion: machineconfiguration.openshift.io/v1
+kind: MachineConfigPool
+metadata:
+  name: worker-2
+  labels:
+    machineconfiguration.openshift.io/role: worker-2
+spec:
+  machineConfigSelector:
+    matchExpressions:
+      - key: machineconfiguration.openshift.io/role
+        operator: In
+        values: [ worker, worker-2 ]
+  paused: false
+  maxUnavailable: 1
+  nodeSelector:
+    matchLabels:
+      node-role.kubernetes.io/worker-2: ""

--- a/telco-core/configuration/reference-crs/custom-manifests/mcp-worker-3.yaml
+++ b/telco-core/configuration/reference-crs/custom-manifests/mcp-worker-3.yaml
@@ -1,0 +1,18 @@
+---
+apiVersion: machineconfiguration.openshift.io/v1
+kind: MachineConfigPool
+metadata:
+  name: worker-3
+  labels:
+    machineconfiguration.openshift.io/role: worker-3
+spec:
+  machineConfigSelector:
+    matchExpressions:
+      - key: machineconfiguration.openshift.io/role
+        operator: In
+        values: [ worker, worker-3 ]
+  paused: false
+  maxUnavailable: 1
+  nodeSelector:
+    matchLabels:
+      node-role.kubernetes.io/worker-3: ""


### PR DESCRIPTION
For generation of policies all path references must exist under the top level kustomize directory (configuration in this case). Update the paths and make "local" copies of MCP CRs. Add a README to explain the content and use of MCP.