### PR TITLE
telco-hub: add first set of reference templates for the cluster-compare tool

### DIFF
--- a/.yamllint.yaml
+++ b/.yamllint.yaml
@@ -24,3 +24,9 @@ rules:
   # which are quite long.
   line-length:
     max: 2000
+
+# Skip the yamls augmented with golang templating as they are not
+# expected to be legal yaml.
+ignore:
+  - telco-core/configuration/reference-crs-kube-compare/
+  - telco-hub/configuration/reference-crs-kube-compare/

--- a/Makefile
+++ b/Makefile
@@ -5,14 +5,7 @@ CONTAINER_TOOL ?= podman
 
 # Basic lint checking
 lintCheck:
-	# The configuration is done piece-wise in order to skip the
-	# kube-compare reference tree. Those yamls are augmented with
-	# golang templating and are not expected to be legal yaml.
-	yamllint -c .yamllint.yaml telco-core/configuration/*yaml
-	yamllint -c .yamllint.yaml telco-core/configuration/reference-crs
-	yamllint -c .yamllint.yaml telco-core/configuration/template-values
-	yamllint -c .yamllint.yaml telco-core/install/
-	yamllint -c .yamllint.yaml telco-hub/
+	yamllint .
 
 # markdownlint rules, following: https://github.com/openshift/enhancements/blob/master/Makefile
 .PHONY: markdownlint-image

--- a/telco-hub/configuration/reference-crs-kube-compare/ReferenceVersionCheck.yaml
+++ b/telco-hub/configuration/reference-crs-kube-compare/ReferenceVersionCheck.yaml
@@ -1,0 +1,7 @@
+apiVersion: config.openshift.io/v1
+kind: ClusterVersion
+metadata:
+  name: version
+status:
+  desired:
+    version: {{ template "versionMatch" (list .status.desired.version "4.17") }}

--- a/telco-hub/configuration/reference-crs-kube-compare/ReferenceVersionCheck.yaml
+++ b/telco-hub/configuration/reference-crs-kube-compare/ReferenceVersionCheck.yaml
@@ -1,3 +1,4 @@
+---
 apiVersion: config.openshift.io/v1
 kind: ClusterVersion
 metadata:

--- a/telco-hub/configuration/reference-crs-kube-compare/compare_ignore
+++ b/telco-hub/configuration/reference-crs-kube-compare/compare_ignore
@@ -1,0 +1,5 @@
+# Internal files for cluster-compare, not real CRs
+metadata.yaml
+
+# Used in the reference only for version compliance checks
+ReferenceVersionCheck.yaml

--- a/telco-hub/configuration/reference-crs-kube-compare/metadata.yaml
+++ b/telco-hub/configuration/reference-crs-kube-compare/metadata.yaml
@@ -1,0 +1,111 @@
+apiVersion: v2
+parts:
+  - name: version-check
+    description: |-
+      A mismatch here means you may be using the wrong reference.
+      This reference was designed for OpenShift 4.17.
+    components:
+      - name: version-check
+        allOf:
+          - path: ReferenceVersionCheck.yaml
+            config:
+              ignore-unspecified-fields: true
+              fieldsToOmitRefs:
+                - allowStatusCheck
+  - name: required-storage
+    description: |-
+      TODO: Link to Hub RDS storage section when published
+    components:
+      - name: local-storage-operator
+        allOf:
+          - path: required/lso/lsoNS.yaml
+          - path: required/lso/lsoOperatorGroup.yaml
+          - path: required/lso/lsoSubscription.yaml
+          - path: required/lso/lsoLocalVolume.yaml
+      - name: odf-internal-operator
+        allOf:
+          - path: required/odf-internal/odfNS.yaml
+          - path: required/odf-internal/odfOperatorGroup.yaml
+          - path: required/odf-internal/odfSubscription.yaml
+          - path: required/odf-internal/storageCluster.yaml
+            config:
+              ignore-unspecified-fields: true
+  - name: required-talm
+    description: |-
+      TODO: Link to Hub RDS TALM section when published
+    components:
+      - name: talm-operator
+        allOf:
+          - path: required/talm/talmSubscription.yaml
+  - name: required-acm
+    description: |-
+      TODO: Link to Hub RDS ACM section when published
+    components:
+      - name: acm-operator
+        allOf:
+          - path: required/acm/acmNS.yaml
+          - path: required/acm/acmOperGroup.yaml
+          - path: required/acm/acmSubscription.yaml
+          - path: required/acm/acmMCH.yaml
+            config:
+              ignore-unspecified-fields: true
+          - path: required/acm/acmProvisioning.yaml
+            config:
+              ignore-unspecified-fields: true
+          - path: required/acm/acmMirrorRegistryCM.yaml
+          - path: required/acm/acmAgentServiceConfig.yaml
+  - name: optional-logging
+    description: |-
+      TODO: Link to Hub RDS logging section when published
+    components:
+      - name: cluster-logging-operator
+        allOf:
+          - path: optional/logging/clusterLogNS.yaml
+          - path: optional/logging/clusterLogOperGroup.yaml
+          - path: optional/logging/clusterLogSubscription.yaml
+  - name: optional-quay
+    description: |-
+      TODO: Link to Hub RDS Quay section when published
+    components:
+      - name: quay-operator
+        allOf:
+          - path: optional/quay/quayNS.yaml
+          - path: optional/quay/quayOperatorGroup.yaml
+          - path: optional/quay/quaySubscription.yaml
+
+templateFunctionFiles:
+  - version_match.tmpl
+
+fieldsToOmit:
+  defaultOmitRef: all
+  items:
+    defaults:
+      - pathToKey: metadata.annotations."kubectl.kubernetes.io/last-applied-configuration"
+      - pathToKey: metadata.annotations."openshift.io/sa.scc.uid-range"
+      - pathToKey: metadata.annotations."openshift.io/sa.scc.mcs"
+      - pathToKey: metadata.annotations."openshift.io/sa.scc.supplemental-groups"
+      - pathToKey: metadata.annotations."olm.providedAPIs"
+      - pathToKey: metadata.labels."kubernetes.io/metadata.name"
+      - pathToKey: metadata.labels."security.openshift.io/scc.podSecurityLabelSync"
+      - pathToKey: metadata.labels."operators.coreos.com/local-storage-operator.openshift-local-storage"
+      - pathToKey: metadata.labels."operators.coreos.com/odf-operator.openshift-storage"
+      - pathToKey: metadata.labels."operators.coreos.com/topology-aware-lifecycle-manager.openshift-operators"
+      - pathToKey: metadata.labels."operators.coreos.com/advanced-cluster-management.open-cluster-management"
+      - pathToKey: metadata.labels."agent-install.openshift.io/watch"
+      - pathToKey: metadata.labels."cluster.open-cluster-management.io/backup"
+      - pathToKey: metadata.labels."pod-security.kubernetes.io"
+        isPrefix: true
+      - pathToKey: metadata.labels."olm.operatorgroup.uid"
+        isPrefix: true
+      - pathToKey: metadata.creationTimestamp
+      - pathToKey: metadata.finalizers
+      - pathToKey: metadata.generation
+      - pathToKey: metadata.resourceVersion
+      - pathToKey: metadata.uid
+      - pathToKey: metadata.ownerReferences
+      - pathToKey: spec.finalizers
+    allowStatusCheck:
+      - include: defatuls
+    all:
+      - include: defaults
+      - pathToKey: status

--- a/telco-hub/configuration/reference-crs-kube-compare/metadata.yaml
+++ b/telco-hub/configuration/reference-crs-kube-compare/metadata.yaml
@@ -1,3 +1,4 @@
+---
 apiVersion: v2
 parts:
   - name: version-check

--- a/telco-hub/configuration/reference-crs-kube-compare/optional/logging/clusterLogNS.yaml
+++ b/telco-hub/configuration/reference-crs-kube-compare/optional/logging/clusterLogNS.yaml
@@ -1,0 +1,7 @@
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: openshift-logging
+  annotations:
+    workload.openshift.io/allowed: management

--- a/telco-hub/configuration/reference-crs-kube-compare/optional/logging/clusterLogOperGroup.yaml
+++ b/telco-hub/configuration/reference-crs-kube-compare/optional/logging/clusterLogOperGroup.yaml
@@ -1,0 +1,12 @@
+---
+apiVersion: operators.coreos.com/v1
+kind: OperatorGroup
+metadata:
+  name: cluster-logging
+  namespace: openshift-logging
+spec:
+  targetNamespaces:
+  - openshift-logging
+  {{- if .spec.upgradeStrategy }}
+  upgradeStrategy: Default
+  {{- end }}

--- a/telco-hub/configuration/reference-crs-kube-compare/optional/logging/clusterLogSubscription.yaml
+++ b/telco-hub/configuration/reference-crs-kube-compare/optional/logging/clusterLogSubscription.yaml
@@ -1,0 +1,12 @@
+---
+apiVersion: operators.coreos.com/v1alpha1
+kind: Subscription
+metadata:
+  name: cluster-logging
+  namespace: openshift-logging
+spec:
+  channel: "stable"
+  name: cluster-logging
+  source: {{ .spec.source }}
+  sourceNamespace: openshift-marketplace
+  installPlanApproval: Automatic

--- a/telco-hub/configuration/reference-crs-kube-compare/optional/quay/quayNS.yaml
+++ b/telco-hub/configuration/reference-crs-kube-compare/optional/quay/quayNS.yaml
@@ -1,0 +1,7 @@
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+  labels:
+    openshift.io/cluster-monitoring: "true"
+  name: quay-enterprise

--- a/telco-hub/configuration/reference-crs-kube-compare/optional/quay/quayOperatorGroup.yaml
+++ b/telco-hub/configuration/reference-crs-kube-compare/optional/quay/quayOperatorGroup.yaml
@@ -1,0 +1,12 @@
+---
+apiVersion: operators.coreos.com/v1
+kind: OperatorGroup
+metadata:
+  name: quay-operator
+  namespace: quay-enterprise
+spec:
+  targetNamespaces:
+  - quay-enterprise
+  {{- if .spec.upgradeStrategy }}
+  upgradeStrategy: Default
+  {{- end }}

--- a/telco-hub/configuration/reference-crs-kube-compare/optional/quay/quaySubscription.yaml
+++ b/telco-hub/configuration/reference-crs-kube-compare/optional/quay/quaySubscription.yaml
@@ -1,0 +1,12 @@
+---
+apiVersion: operators.coreos.com/v1alpha1
+kind: Subscription
+metadata:
+  name: quay-operator
+  namespace: quay-enterprise
+spec:
+  sourceNamespace: openshift-marketplace
+  source: {{ .spec.source }}
+  channel: stable-3.12  # should match latest version
+  installPlanApproval: Automatic
+  name: quay-operator

--- a/telco-hub/configuration/reference-crs-kube-compare/required/acm/acmAgentServiceConfig.yaml
+++ b/telco-hub/configuration/reference-crs-kube-compare/required/acm/acmAgentServiceConfig.yaml
@@ -1,0 +1,36 @@
+---
+apiVersion: agent-install.openshift.io/v1beta1
+kind: AgentServiceConfig
+metadata:
+  name: agent
+spec:
+  databaseStorage:
+    accessModes:
+      - ReadWriteOnce
+    resources:
+      requests:
+        storage: 20Gi
+  filesystemStorage:
+    accessModes:
+      - ReadWriteOnce
+    resources:
+      requests:
+        storage: 20Gi
+  imageStorage:
+    accessModes:
+      - ReadWriteOnce
+    resources:
+      requests:
+        storage: 100Gi
+  mirrorRegistryRef:
+    name: mirror-registry-config
+  {{- if .spec.osImages }}
+  osImages:
+  # Replace <http-server-address:port> with the address of the local web server that stores the RHCOS images.
+  # The images can be downloaded from "https://mirror.openshift.com/pub/openshift-v4/x86_64/dependencies/rhcos/".
+  - cpuArchitecture: "x86_64"
+    openshiftVersion: "4.17"
+    rootFSUrl: {{ (index .spec.osImages 0).rootFSUrl }}
+    url: {{ (index .spec.osImages 0).url }}
+    version: "417.94.202409121747-0"
+  {{- end }}

--- a/telco-hub/configuration/reference-crs-kube-compare/required/acm/acmMCH.yaml
+++ b/telco-hub/configuration/reference-crs-kube-compare/required/acm/acmMCH.yaml
@@ -3,8 +3,6 @@ apiVersion: operator.open-cluster-management.io/v1
 kind: MultiClusterHub
 metadata:
   annotations:
-    argocd.argoproj.io/sync-wave: "4"
-    argocd.argoproj.io/sync-options: SkipDryRunOnMissingResource=true
     installer.open-cluster-management.io/mce-subscription-spec: '{"installPlanApproval": "Automatic"}'
   name: multiclusterhub
   namespace: open-cluster-management

--- a/telco-hub/configuration/reference-crs-kube-compare/required/acm/acmMirrorRegistryCM.yaml
+++ b/telco-hub/configuration/reference-crs-kube-compare/required/acm/acmMirrorRegistryCM.yaml
@@ -1,0 +1,10 @@
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: mirror-registry-config
+  namespace: multicluster-engine
+  labels:
+    app: assisted-service
+data:
+    {{- .data | toYaml | nindent 2 }}

--- a/telco-hub/configuration/reference-crs-kube-compare/required/acm/acmNS.yaml
+++ b/telco-hub/configuration/reference-crs-kube-compare/required/acm/acmNS.yaml
@@ -1,0 +1,7 @@
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+  labels:
+    openshift.io/cluster-monitoring: "true"
+  name: open-cluster-management

--- a/telco-hub/configuration/reference-crs-kube-compare/required/acm/acmOperGroup.yaml
+++ b/telco-hub/configuration/reference-crs-kube-compare/required/acm/acmOperGroup.yaml
@@ -1,0 +1,12 @@
+---
+apiVersion: operators.coreos.com/v1
+kind: OperatorGroup
+metadata:
+  name: open-cluster-management-group
+  namespace: open-cluster-management
+spec:
+  targetNamespaces:
+  - open-cluster-management
+  {{- if .spec.upgradeStrategy }}
+  upgradeStrategy: Default
+  {{- end }}

--- a/telco-hub/configuration/reference-crs-kube-compare/required/acm/acmProvisioning.yaml
+++ b/telco-hub/configuration/reference-crs-kube-compare/required/acm/acmProvisioning.yaml
@@ -1,0 +1,10 @@
+---
+apiVersion: metal3.io/v1alpha1
+kind: Provisioning
+metadata:
+  name: provisioning-configuration
+spec:
+  watchAllNamespaces: true
+  # some servers do not support virtual media installations
+  # when the image is served using the https protocol
+  # disableVirtualMediaTLS: true

--- a/telco-hub/configuration/reference-crs-kube-compare/required/acm/acmSubscription.yaml
+++ b/telco-hub/configuration/reference-crs-kube-compare/required/acm/acmSubscription.yaml
@@ -1,0 +1,12 @@
+---
+apiVersion: operators.coreos.com/v1alpha1
+kind: Subscription
+metadata:
+  name: open-cluster-management-subscription
+  namespace: open-cluster-management
+spec:
+  channel: release-2.12
+  installPlanApproval: Automatic
+  name: advanced-cluster-management
+  source: {{ .spec.source }}
+  sourceNamespace: openshift-marketplace

--- a/telco-hub/configuration/reference-crs-kube-compare/required/lso/lsoLocalVolume.yaml
+++ b/telco-hub/configuration/reference-crs-kube-compare/required/lso/lsoLocalVolume.yaml
@@ -1,0 +1,21 @@
+---
+apiVersion: "local.storage.openshift.io/v1"
+kind: "LocalVolume"
+metadata:
+  name: {{ .metadata.name }}
+  namespace: "openshift-local-storage"
+spec:
+  logLevel: Normal
+  managementState: Managed
+  {{- if .spec.nodeSelector }}
+  nodeSelector:
+    {{- .spec.nodeSelector | toYaml | nindent 4 }}
+  {{- end }}
+  storageClassDevices:
+    {{- range .spec.storageClassDevices }}
+    - storageClassName: {{ .storageClassName }}
+      forceWipeDevicesAndDestroyAllData: true
+      volumeMode: Block
+      devicePaths:
+        {{- .devicePaths | toYaml | nindent 8 }}
+    {{- end}}

--- a/telco-hub/configuration/reference-crs-kube-compare/required/lso/lsoNS.yaml
+++ b/telco-hub/configuration/reference-crs-kube-compare/required/lso/lsoNS.yaml
@@ -1,0 +1,7 @@
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: openshift-local-storage
+  labels:
+    openshift.io/cluster-monitoring: "true"

--- a/telco-hub/configuration/reference-crs-kube-compare/required/lso/lsoOperatorGroup.yaml
+++ b/telco-hub/configuration/reference-crs-kube-compare/required/lso/lsoOperatorGroup.yaml
@@ -1,0 +1,12 @@
+---
+apiVersion: operators.coreos.com/v1
+kind: OperatorGroup
+metadata:
+  name: local-operator-group
+  namespace: openshift-local-storage
+spec:
+  targetNamespaces:
+  - openshift-local-storage
+  {{- if .spec.upgradeStrategy }}
+  upgradeStrategy: Default
+  {{- end }}

--- a/telco-hub/configuration/reference-crs-kube-compare/required/lso/lsoSubscription.yaml
+++ b/telco-hub/configuration/reference-crs-kube-compare/required/lso/lsoSubscription.yaml
@@ -1,0 +1,12 @@
+---
+apiVersion: operators.coreos.com/v1alpha1
+kind: Subscription
+metadata:
+  name: local-storage-operator
+  namespace: openshift-local-storage
+spec:
+  channel: stable
+  installPlanApproval: Automatic
+  name: local-storage-operator
+  source: {{ .spec.source }}
+  sourceNamespace: openshift-marketplace

--- a/telco-hub/configuration/reference-crs-kube-compare/required/odf-internal/odfNS.yaml
+++ b/telco-hub/configuration/reference-crs-kube-compare/required/odf-internal/odfNS.yaml
@@ -1,0 +1,9 @@
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: openshift-storage
+  annotations:
+    workload.openshift.io/allowed: management
+  labels:
+    openshift.io/cluster-monitoring: "true"

--- a/telco-hub/configuration/reference-crs-kube-compare/required/odf-internal/odfOperatorGroup.yaml
+++ b/telco-hub/configuration/reference-crs-kube-compare/required/odf-internal/odfOperatorGroup.yaml
@@ -1,0 +1,12 @@
+---
+apiVersion: operators.coreos.com/v1
+kind: OperatorGroup
+metadata:
+  name: openshift-storage-operatorgroup
+  namespace: openshift-storage
+spec:
+  targetNamespaces:
+    - openshift-storage
+  {{- if .spec.upgradeStrategy }}
+  upgradeStrategy: Default
+  {{- end }}

--- a/telco-hub/configuration/reference-crs-kube-compare/required/odf-internal/odfSubscription.yaml
+++ b/telco-hub/configuration/reference-crs-kube-compare/required/odf-internal/odfSubscription.yaml
@@ -1,0 +1,12 @@
+---
+apiVersion: operators.coreos.com/v1alpha1
+kind: Subscription
+metadata:
+  name: odf-operator
+  namespace: openshift-storage
+spec:
+  channel: "stable-4.17"
+  name: odf-operator
+  source: {{ .spec.source }}
+  sourceNamespace: openshift-marketplace
+  installPlanApproval: Automatic

--- a/telco-hub/configuration/reference-crs-kube-compare/required/odf-internal/storageCluster.yaml
+++ b/telco-hub/configuration/reference-crs-kube-compare/required/odf-internal/storageCluster.yaml
@@ -1,0 +1,32 @@
+---
+apiVersion: ocs.openshift.io/v1
+kind: StorageCluster
+metadata:
+  name: ocs-storagecluster
+  namespace: openshift-storage
+spec:
+  manageNodes: false
+  {{- if .spec.resources }}
+  resources:
+    {{- .spec.resources | toYaml | nindent 4 }}
+  {{- end }}
+  monDataDirHostPath: /var/lib/rook
+  storageDeviceSets:
+  {{- range .spec.storageDeviceSets }}
+  - count: {{ .count }}  # <-- Modify count to desired value. For each set of 3 disks increment the count by 1.
+    dataPVCTemplate:
+      spec:
+        accessModes:
+        - ReadWriteOnce
+        resources:
+          requests:
+            storage: {{ .dataPVCTemplate.spec.resources.requests.storage }}  # <-- This should be changed as per storage size. Minimum 100 GiB and Maximum 4 TiB
+        storageClassName: {{ .dataPVCTemplate.spec.storageClassName }}  # match this with the storage block created at the LSO step
+        volumeMode: Block
+    name: ocs-deviceset
+    placement: {}
+    portable: false
+    replica: 3
+    resources:
+      {{- .resources | toYaml | nindent 6 }}
+  {{- end }}

--- a/telco-hub/configuration/reference-crs-kube-compare/required/talm/talmSubscription.yaml
+++ b/telco-hub/configuration/reference-crs-kube-compare/required/talm/talmSubscription.yaml
@@ -1,0 +1,12 @@
+---
+apiVersion: operators.coreos.com/v1alpha1
+kind: Subscription
+metadata:
+  name: openshift-topology-aware-lifecycle-manager-subscription
+  namespace: openshift-operators
+spec:
+  channel: stable
+  installPlanApproval: Automatic
+  name: topology-aware-lifecycle-manager
+  source: {{ .spec.source }}
+  sourceNamespace: openshift-marketplace

--- a/telco-hub/configuration/reference-crs-kube-compare/version_match.tmpl
+++ b/telco-hub/configuration/reference-crs-kube-compare/version_match.tmpl
@@ -1,0 +1,9 @@
+{{- define "versionMatch" }}
+  {{- $version := semver (index . 0 | default "0.0.0") }}
+  {{- $target := semver (index . 1) }}
+  {{- $result := print ($target.Original) ".*" }}
+  {{- if and (eq $version.Major $target.Major) (eq $version.Minor $target.Minor) }}
+    {{- $result = $version.Original }}
+  {{- end }}
+  {{- $result }}
+{{- end }}

--- a/telco-hub/configuration/reference-crs/required/acm/readme.md
+++ b/telco-hub/configuration/reference-crs/required/acm/readme.md
@@ -5,15 +5,16 @@
 3. Create the `acmMCH.yaml`.
 4. If Subscription was set to Manual installPlanApproval, approve the created InstallPlan on `multicluster-engine`
 5. Apply the `acmProvisioning.yaml`.
-6. Create the `acmAgentServiceConfig.yaml` (Two PVs are required, so ODF must be configured prior to this step).
-7. The `multicluster-engine` enables the `cluster-proxy-addon` feature by default. Apply the following patch to disable it: `oc patch multiclusterengines.multicluster.openshift.io multiclusterengine --type=merge --patch-file ./disable-cluster-proxy-addon.json`.
-8. Create the `observabilityNS.yaml`.
-9. Generate the pull-secret `observabilitySecret.yaml`. The value for the `.dockerconfigjson` field can be found as follows:
+6. Create the `acmMirrorRegistryCM.yaml`.
+7. Create the `acmAgentServiceConfig.yaml` (Two PVs are required, so ODF must be configured prior to this step).
+8. The `multicluster-engine` enables the `cluster-proxy-addon` feature by default. Apply the following patch to disable it: `oc patch multiclusterengines.multicluster.openshift.io multiclusterengine --type=merge --patch-file ./disable-cluster-proxy-addon.json`.
+9. Create the `observabilityNS.yaml`.
+10. Generate the pull-secret `observabilitySecret.yaml`. The value for the `.dockerconfigjson` field can be found as follows:
     - Try `oc extract secret/multiclusterhub-operator-pull-secret -n open-cluster-management --to=-`.
     - If the previous command returns an empty value use: `oc extract secret/pull-secret -n openshift-config --to=-`.
-10. Create the `observabilityOBC.yaml`.
-11. Create the Thanos secret `thanosSecret.yaml`.
+11. Create the `observabilityOBC.yaml`.
+12. Create the Thanos secret `thanosSecret.yaml`.
     - The `bucket` and the `endpoint` can be obtained from the ConfigMap that the OBC automatically creates in its namespace. Use the fields `BUCKET_NAME` (without any protocol or port specification) and `BUCKET_HOST` respectively.
     - The `access_key` and the `secret_key` can be obtained from the Secret that the OBC creates automatically in its namespace. Use the fields `AWS_ACCESS_KEY_ID` and `AWS_SECRET_ACCESS_KEY` respectively. This two fields are encoded in base64 in the OBC Secret but must be decoded in the Thanos Secret (use `echo -n "<string>" | base64 -d` to decode it).
-12. Create the `observabilityMCO.yaml`.
-13. When all the installation is done. Apply the `acmPerfSearch.yaml` .This will configure Search CR called `search-v2-operator` considering different performance and scale optimizations.
+13. Create the `observabilityMCO.yaml`.
+14. When all the installation is done. Apply the `acmPerfSearch.yaml` .This will configure Search CR called `search-v2-operator` considering different performance and scale optimizations.

--- a/telco-hub/configuration/reference-crs/required/lso/lsoLocalVolume.yaml
+++ b/telco-hub/configuration/reference-crs/required/lso/lsoLocalVolume.yaml
@@ -8,6 +8,8 @@ metadata:
     argocd.argoproj.io/sync-wave: "2"
     argocd.argoproj.io/sync-options: SkipDryRunOnMissingResource=true
 spec:
+  logLevel: Normal
+  managementState: Managed
   nodeSelector:
     nodeSelectorTerms:
     - matchExpressions:


### PR DESCRIPTION
The templates cover the reference CRs for:
    * LSO
    * ODF
    * TALM
    * ACM (without the observability configuration)
    * Cluster logging
    * Quay
    
    The ACM MultiClusterHub is also updated to include the SiteConfig
    Operator.