### PR TITLE
CNF-13731: Add policy for copying certs to openshift-config namespace

### DIFF
--- a/telco-core/configuration/reference-crs-kube-compare/compare_ignore
+++ b/telco-core/configuration/reference-crs-kube-compare/compare_ignore
@@ -22,3 +22,6 @@ required/networking/metallb/service.yaml
 custom-manifests/mcp-worker-1.yaml
 custom-manifests/mcp-worker-2.yaml
 custom-manifests/mcp-worker-3.yaml
+
+# Certificate Copying CRs
+optional/other/server-cert-openshift-config-copy.yaml

--- a/telco-core/configuration/reference-crs/optional/other/server-cert-openshift-config-copy.yaml
+++ b/telco-core/configuration/reference-crs/optional/other/server-cert-openshift-config-copy.yaml
@@ -9,7 +9,7 @@ spec:
 apiVersion: policy.open-cluster-management.io/v1
 kind: Policy
 metadata:
-  name: copy-config-secrets
+  name: copy-platform-route-managed-secrets
   namespace: openshift-config
 spec:
   disabled: false
@@ -18,7 +18,7 @@ spec:
         apiVersion: policy.open-cluster-management.io/v1
         kind: ConfigurationPolicy
         metadata:
-          name: copy-config-secrets
+          name: copy-platform-route-managed-secrets
         spec:
           # The object templates are copying the following secrets from their respective namespaces to 'openshift-config':
           # - openshift-oauth-apiserver/serving-cert --> oauth-apiserver-serving-cert
@@ -75,7 +75,7 @@ spec:
 apiVersion: cluster.open-cluster-management.io/v1beta1
 kind: Placement
 metadata:
-  name: copy-config-secrets-placement
+  name: copy-platform-route-managed-secrets-placement
   namespace: openshift-config
 spec:
   clusterSets:
@@ -89,13 +89,13 @@ spec:
 apiVersion: policy.open-cluster-management.io/v1
 kind: PlacementBinding
 metadata:
-  name: copy-config-secrets-placement
+  name: copy-platform-route-managed-secrets-placement
   namespace: openshift-config
 placementRef:
-  name: copy-config-secrets-placement
+  name: copy-platform-route-managed-secrets-placement
   apiGroup: cluster.open-cluster-management.io
   kind: Placement
 subjects:
-  - name: copy-config-secrets
+  - name: copy-platform-route-managed-secrets
     apiGroup: policy.open-cluster-management.io
     kind: Policy

--- a/telco-core/configuration/reference-crs/optional/other/server-cert-openshift-config-copy.yaml
+++ b/telco-core/configuration/reference-crs/optional/other/server-cert-openshift-config-copy.yaml
@@ -1,0 +1,101 @@
+apiVersion: cluster.open-cluster-management.io/v1beta2
+kind: ManagedClusterSetBinding
+metadata:
+  name: global
+  namespace: openshift-config
+spec:
+  clusterSet: global
+---
+apiVersion: policy.open-cluster-management.io/v1
+kind: Policy
+metadata:
+  name: copy-config-secrets
+  namespace: openshift-config
+spec:
+  disabled: false
+  policy-templates:
+    - objectDefinition:
+        apiVersion: policy.open-cluster-management.io/v1
+        kind: ConfigurationPolicy
+        metadata:
+          name: copy-config-secrets
+        spec:
+          # The object templates are copying the following secrets from their respective namespaces to 'openshift-config':
+          # - openshift-oauth-apiserver/serving-cert --> oauth-apiserver-serving-cert
+          # - openshift-apiserver/serving-cert --> apiserver-serving-cert
+          # - openshift-console/console-serving-cert --> console-serving-cert
+          object-templates:
+            - complianceType: musthave
+              objectDefinition:
+                apiVersion: v1
+                data:
+                  tls.crt: '{{ fromSecret "openshift-oauth-apiserver" "serving-cert" "tls.crt" }}'
+                  tls.key: '{{ fromSecret "openshift-oauth-apiserver" "serving-cert" "tls.key" }}'
+                kind: Secret
+                metadata:
+                  name: oauth-apiserver-serving-cert
+                  namespace: openshift-config
+                type: kubernetes.io/tls
+              pruneObjectBehavior: DeleteIfCreated
+              remediationAction: enforce
+              severity: low
+            - complianceType: musthave
+              objectDefinition:
+                apiVersion: v1
+                data:
+                  tls.crt: '{{ fromSecret "openshift-apiserver" "serving-cert" "tls.crt" }}'
+                  tls.key: '{{ fromSecret "openshift-apiserver" "serving-cert" "tls.key" }}'
+                kind: Secret
+                metadata:
+                  name: apiserver-serving-cert
+                  namespace: openshift-config
+                type: kubernetes.io/tls
+              pruneObjectBehavior: DeleteIfCreated
+              remediationAction: enforce
+              severity: low
+            - complianceType: musthave
+              objectDefinition:
+                apiVersion: v1
+                data:
+                  tls.crt: '{{ fromSecret "openshift-console" "console-serving-cert" "tls.crt" }}'
+                  tls.key: '{{ fromSecret "openshift-console" "console-serving-cert" "tls.key" }}'
+                kind: Secret
+                metadata:
+                  name: console-serving-cert
+                  namespace: openshift-config
+                type: kubernetes.io/tls
+              pruneObjectBehavior: DeleteIfCreated
+              remediationAction: enforce
+              severity: low
+          pruneObjectBehavior: None
+          remediationAction: enforce
+          severity: low
+  remediationAction: enforce
+---
+apiVersion: cluster.open-cluster-management.io/v1beta1
+kind: Placement
+metadata:
+  name: copy-config-secrets-placement
+  namespace: openshift-config
+spec:
+  clusterSets:
+    - global
+  tolerations:
+    - key: cluster.open-cluster-management.io/unreachable
+      operator: Exists
+    - key: cluster.open-cluster-management.io/unavailable
+      operator: Exists
+---
+apiVersion: policy.open-cluster-management.io/v1
+kind: PlacementBinding
+metadata:
+  name: copy-config-secrets-placement
+  namespace: openshift-config
+placementRef:
+  name: copy-config-secrets-placement
+  apiGroup: cluster.open-cluster-management.io
+  kind: Placement
+subjects:
+  - name: copy-config-secrets
+    apiGroup: policy.open-cluster-management.io
+    kind: Policy


### PR DESCRIPTION
Potential WIP.  I know there are additional certificates that might need to be added to this YAML which might be able to be added in other PRs if needed.

The object templates are copying the following secrets from their respective namespaces to 'openshift-config':
  - openshift-oauth-apiserver/serving-cert --> oauth-apiserver-serving-cert
  - openshift-apiserver/serving-cert --> apiserver-serving-cert
  - openshift-console/console-serving-cert --> console-serving-cert