### PR TITLE
Update OWNERS to support RAN reference

### DIFF
--- a/OWNERS
+++ b/OWNERS
@@ -1,14 +1,17 @@
 approvers:
   - MarSik
   - imiller0
+  - irinamihai
+  - lack
 reviewers:
   - MarSik
   - yanirq
   - ffromani
   - imiller0
+  - irinamihai
   - lack
   - SchSeba
   - fedepaol
   - yuvalk
   - cgoncalves
-  
+  - sabbir-47


### PR DESCRIPTION
With the addition of the telco-ran reference we need reviewers/approvers for that use case included in the OWNERS file.