### PR TITLE
Exclude the irdma kernel module

### DIFF
--- a/telco-core/configuration/reference-crs-kube-compare/metadata.yaml
+++ b/telco-core/configuration/reference-crs-kube-compare/metadata.yaml
@@ -163,6 +163,7 @@ parts:
 
 templateFunctionFiles:
   - version_match.tmpl
+  - unordered_list.tmpl
 
 fieldsToOmit:
   defaultOmitRef: all

--- a/telco-core/configuration/reference-crs-kube-compare/required/performance/PerformanceProfile.yaml
+++ b/telco-core/configuration/reference-crs-kube-compare/required/performance/PerformanceProfile.yaml
@@ -9,6 +9,11 @@ metadata:
     kubeletconfig.experimental: |
       {"allowedUnsafeSysctls":["net.ipv6.conf.all.accept_ra"]}
 spec:
+  additionalKernelArgs:
+    {{- template "unorderedList" (list .spec.additionalKernelArgs (list
+      "module_blacklist=irdma"
+      ) (list
+      ) ) }}
   cpu:
     # node0 CPUs: 0-17,36-53
     # node1 CPUs: 18-34,54-71

--- a/telco-core/configuration/reference-crs-kube-compare/unordered_list.tmpl
+++ b/telco-core/configuration/reference-crs-kube-compare/unordered_list.tmpl
@@ -1,0 +1,19 @@
+{{- define "unorderedList" }}
+{{/* compare two unordered lists: unorderedList <listToEval> <requiredValues> [optionalValues] */}}
+{{- $result := list }}
+{{- $optionalArgs := list }}
+{{- if gt (len .) 2 }}
+{{- $optionalArgs = concat $optionalArgs (index . 2) }}
+{{- end }}
+{{- $expectedArgs := index . 1 }}
+{{- range $value := (index . 0) }}
+  {{- if or (has $value $expectedArgs) (has $value $optionalArgs) }}
+    {{- $result = append $result $value }}
+    {{- $expectedArgs = without $expectedArgs $value }}
+  {{- end }}
+{{- end }}
+{{- range $value := $expectedArgs }}
+  {{- $result = append $result $value }}
+{{- end }}
+{{- $result | toYaml | nindent 4 }}
+{{- end }}

--- a/telco-core/configuration/reference-crs/required/performance/PerformanceProfile.yaml
+++ b/telco-core/configuration/reference-crs/required/performance/PerformanceProfile.yaml
@@ -10,6 +10,8 @@ metadata:
     kubeletconfig.experimental: |
       {"allowedUnsafeSysctls":["net.ipv6.conf.all.accept_ra"]}
 spec:
+  additionalKernelArgs:
+  - module_blacklist=irdma
   cpu:
     # node0 CPUs: 0-17,36-53
     # node1 CPUs: 18-34,54-71


### PR DESCRIPTION
The irdma kernel module can cause an excessive number of interrupts on CPUs with large numbers of cores. This removes the module. CNF-16652