### PR TITLE
OCPBUGS-54973: core cluster-compare: default empty struct values

### DIFF
--- a/telco-core/configuration/reference-crs-kube-compare/required/networking/sriov/sriovNetworkNodePolicy.yaml
+++ b/telco-core/configuration/reference-crs-kube-compare/required/networking/sriov/sriovNetworkNodePolicy.yaml
@@ -6,7 +6,7 @@ metadata:
   name: {{ .metadata.name  }}
   namespace: openshift-sriov-network-operator
 spec: # $spec
-{{ .spec | toYaml | indent 2 }}
+{{ .spec | default dict | toYaml | indent 2 }}
   # eg
   #deviceType: netdevice
   #nicSelector:


### PR DESCRIPTION
Without proper defaults, running "make check" will fail in upcoming
cluster-compare releases.

Signed-off-by: Jim Ramsay <jramsay@redhat.com>
