### PR TITLE
CNF-13731: Add cert-manager-operator and corresponding resources

### DIFF
--- a/telco-hub/configuration/reference-crs/optional/cert-manager/certManagerClusterIssuer.yaml
+++ b/telco-hub/configuration/reference-crs/optional/cert-manager/certManagerClusterIssuer.yaml
@@ -1,0 +1,7 @@
+---
+apiVersion: cert-manager.io/v1
+kind: ClusterIssuer
+metadata:
+  name: selfsigned-issuer
+spec:
+  selfSigned: {}

--- a/telco-hub/configuration/reference-crs/optional/cert-manager/certManagerClusterIssuer.yaml
+++ b/telco-hub/configuration/reference-crs/optional/cert-manager/certManagerClusterIssuer.yaml
@@ -2,6 +2,15 @@
 apiVersion: cert-manager.io/v1
 kind: ClusterIssuer
 metadata:
-  name: selfsigned-issuer
+  name: acme-issuer
 spec:
-  selfSigned: {}
+  # Example based on: https://cert-manager.io/docs/configuration/acme/#creating-a-basic-acme-issuer
+  acme:
+    server: https://acme-v02.api.letsencrypt.org/directory
+    email: your-email@example.com
+    privateKeySecretRef:
+      name: acme-account-key
+    solvers:
+    - http01:
+        ingress:
+          class: nginx

--- a/telco-hub/configuration/reference-crs/optional/cert-manager/certManagerClusterIssuer.yaml
+++ b/telco-hub/configuration/reference-crs/optional/cert-manager/certManagerClusterIssuer.yaml
@@ -13,4 +13,4 @@ spec:
     solvers:
     - http01:
         ingress:
-          class: nginx
+          class: openshift-default

--- a/telco-hub/configuration/reference-crs/optional/cert-manager/certManagerNS.yaml
+++ b/telco-hub/configuration/reference-crs/optional/cert-manager/certManagerNS.yaml
@@ -1,0 +1,5 @@
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: cert-manager-operator

--- a/telco-hub/configuration/reference-crs/optional/cert-manager/certManagerOperatorgroup.yaml
+++ b/telco-hub/configuration/reference-crs/optional/cert-manager/certManagerOperatorgroup.yaml
@@ -1,0 +1,7 @@
+apiVersion: operators.coreos.com/v1
+kind: OperatorGroup
+metadata:
+  name: cert-manager-operator
+  namespace: cert-manager-operator
+spec:
+  upgradeStrategy: Default

--- a/telco-hub/configuration/reference-crs/optional/cert-manager/certManagerOperatorgroup.yaml
+++ b/telco-hub/configuration/reference-crs/optional/cert-manager/certManagerOperatorgroup.yaml
@@ -2,6 +2,6 @@ apiVersion: operators.coreos.com/v1
 kind: OperatorGroup
 metadata:
   name: cert-manager-operator
-  namespace: cert-manager-operator
+  namespace: openshift-console
 spec:
   upgradeStrategy: Default

--- a/telco-hub/configuration/reference-crs/optional/cert-manager/certManagerSubscription.yaml
+++ b/telco-hub/configuration/reference-crs/optional/cert-manager/certManagerSubscription.yaml
@@ -3,7 +3,7 @@ apiVersion: operators.coreos.com/v1alpha1
 kind: Subscription
 metadata:
   name: openshift-cert-manager-operator
-  namespace: cert-manager-operator
+  namespace: openshift-console
 spec:
   channel: stable-v1
   name: openshift-cert-manager-operator

--- a/telco-hub/configuration/reference-crs/optional/cert-manager/certManagerSubscription.yaml
+++ b/telco-hub/configuration/reference-crs/optional/cert-manager/certManagerSubscription.yaml
@@ -1,0 +1,14 @@
+---
+apiVersion: operators.coreos.com/v1alpha1
+kind: Subscription
+metadata:
+  name: openshift-cert-manager-operator
+  namespace: cert-manager-operator
+  labels:
+    operators.coreos.com/openshift-cert-manager-operator.cert-manager-operator: ''
+spec:
+  channel: stable-v1
+  name: openshift-cert-manager-operator
+  source: redhat-operators
+  sourceNamespace: openshift-marketplace
+  installPlanApproval: Automatic

--- a/telco-hub/configuration/reference-crs/optional/cert-manager/certManagerSubscription.yaml
+++ b/telco-hub/configuration/reference-crs/optional/cert-manager/certManagerSubscription.yaml
@@ -4,11 +4,9 @@ kind: Subscription
 metadata:
   name: openshift-cert-manager-operator
   namespace: cert-manager-operator
-  labels:
-    operators.coreos.com/openshift-cert-manager-operator.cert-manager-operator: ''
 spec:
   channel: stable-v1
   name: openshift-cert-manager-operator
-  source: redhat-operators
+  source: redhat-operators-disconnected
   sourceNamespace: openshift-marketplace
   installPlanApproval: Automatic

--- a/telco-hub/configuration/reference-crs/optional/cert-manager/consoleCertificate.yaml
+++ b/telco-hub/configuration/reference-crs/optional/cert-manager/consoleCertificate.yaml
@@ -1,0 +1,17 @@
+---
+apiVersion: cert-manager.io/v1
+kind: Certificate
+metadata:
+  name: console-certificate
+  namespace: cert-manager-operator
+spec:
+  commonName: selfsigned-ca.dns.name
+  isCA: true
+  issuerRef:
+    group: cert-manager.io
+    kind: ClusterIssuer
+    name: selfsigned-issuer
+  privateKey:
+    algorithm: ECDSA
+    size: 256
+  secretName: console-ca-root-secret

--- a/telco-hub/configuration/reference-crs/optional/cert-manager/consoleCertificate.yaml
+++ b/telco-hub/configuration/reference-crs/optional/cert-manager/consoleCertificate.yaml
@@ -3,7 +3,7 @@ apiVersion: cert-manager.io/v1
 kind: Certificate
 metadata:
   name: console-certificate
-  namespace: cert-manager-operator
+  namespace: openshift-console
 spec:
   commonName: selfsigned-ca.dns.name
   isCA: false

--- a/telco-hub/configuration/reference-crs/optional/cert-manager/consoleCertificate.yaml
+++ b/telco-hub/configuration/reference-crs/optional/cert-manager/consoleCertificate.yaml
@@ -6,11 +6,11 @@ metadata:
   namespace: cert-manager-operator
 spec:
   commonName: selfsigned-ca.dns.name
-  isCA: true
+  isCA: false
   issuerRef:
     group: cert-manager.io
     kind: ClusterIssuer
-    name: selfsigned-issuer
+    name: acme-issuer
   privateKey:
     algorithm: ECDSA
     size: 256

--- a/telco-hub/configuration/reference-crs/optional/cert-manager/downloadsCertificate.yaml
+++ b/telco-hub/configuration/reference-crs/optional/cert-manager/downloadsCertificate.yaml
@@ -3,7 +3,7 @@ apiVersion: cert-manager.io/v1
 kind: Certificate
 metadata:
   name: downloads-certificate
-  namespace: cert-manager-operator
+  namespace: openshift-console
 spec:
   commonName: selfsigned-ca.dns.name
   isCA: false

--- a/telco-hub/configuration/reference-crs/optional/cert-manager/downloadsCertificate.yaml
+++ b/telco-hub/configuration/reference-crs/optional/cert-manager/downloadsCertificate.yaml
@@ -1,0 +1,17 @@
+---
+apiVersion: cert-manager.io/v1
+kind: Certificate
+metadata:
+  name: downloads-certificate
+  namespace: cert-manager-operator
+spec:
+  commonName: selfsigned-ca.dns.name
+  isCA: true
+  issuerRef:
+    group: cert-manager.io
+    kind: ClusterIssuer
+    name: selfsigned-issuer
+  privateKey:
+    algorithm: ECDSA
+    size: 256
+  secretName: downloads-ca-root-secret

--- a/telco-hub/configuration/reference-crs/optional/cert-manager/downloadsCertificate.yaml
+++ b/telco-hub/configuration/reference-crs/optional/cert-manager/downloadsCertificate.yaml
@@ -6,11 +6,11 @@ metadata:
   namespace: cert-manager-operator
 spec:
   commonName: selfsigned-ca.dns.name
-  isCA: true
+  isCA: false
   issuerRef:
     group: cert-manager.io
     kind: ClusterIssuer
-    name: selfsigned-issuer
+    name: acme-issuer
   privateKey:
     algorithm: ECDSA
     size: 256

--- a/telco-hub/configuration/reference-crs/optional/cert-manager/oauthServiceCertificate.yaml
+++ b/telco-hub/configuration/reference-crs/optional/cert-manager/oauthServiceCertificate.yaml
@@ -3,7 +3,7 @@ apiVersion: cert-manager.io/v1
 kind: Certificate
 metadata:
   name: oauth-service-certificate
-  namespace: cert-manager-operator
+  namespace: openshift-authentication
 spec:
   commonName: selfsigned-ca.dns.name
   isCA: false

--- a/telco-hub/configuration/reference-crs/optional/cert-manager/oauthServiceCertificate.yaml
+++ b/telco-hub/configuration/reference-crs/optional/cert-manager/oauthServiceCertificate.yaml
@@ -1,0 +1,17 @@
+---
+apiVersion: cert-manager.io/v1
+kind: Certificate
+metadata:
+  name: oauth-service-certificate
+  namespace: cert-manager-operator
+spec:
+  commonName: selfsigned-ca.dns.name
+  isCA: true
+  issuerRef:
+    group: cert-manager.io
+    kind: ClusterIssuer
+    name: selfsigned-issuer
+  privateKey:
+    algorithm: ECDSA
+    size: 256
+  secretName: oauth-service-ca-root-secret

--- a/telco-hub/configuration/reference-crs/optional/cert-manager/oauthServiceCertificate.yaml
+++ b/telco-hub/configuration/reference-crs/optional/cert-manager/oauthServiceCertificate.yaml
@@ -6,11 +6,11 @@ metadata:
   namespace: cert-manager-operator
 spec:
   commonName: selfsigned-ca.dns.name
-  isCA: true
+  isCA: false
   issuerRef:
     group: cert-manager.io
     kind: ClusterIssuer
-    name: selfsigned-issuer
+    name: acme-issuer
   privateKey:
     algorithm: ECDSA
     size: 256


### PR DESCRIPTION
Related to: #114 

### Configuration Additions:

* [`telco-hub/configuration/reference-crs/optional/cert-manager/certManagerClusterIssuer.yaml`](diffhunk://#diff-cb58374a9c4e06f67cbb532ff20e01532dc461cb03ab185ba46828b50fe51133R1-R7): Added a new `ClusterIssuer` configuration for self-signed certificates.
* [`telco-hub/configuration/reference-crs/optional/cert-manager/certManagerNS.yaml`](diffhunk://#diff-edad66b31be2d6b1db536f91ad0c167bf55caa9b8cfc3cca0b17109b2ef70cfbR1-R5): Added a new `Namespace` configuration for the cert-manager operator.
* [`telco-hub/configuration/reference-crs/optional/cert-manager/certManagerOperatorgroup.yaml`](diffhunk://#diff-f6f274b48650029c958a24a3e12c50ed4a014bf3d2e0bdfe410a1c3782a42311R1-R7): Added a new `OperatorGroup` configuration for the cert-manager operator with a default upgrade strategy.
* [`telco-hub/configuration/reference-crs/optional/cert-manager/certManagerSubscription.yaml`](diffhunk://#diff-d9b85328045ad522f16b881e2590260769b56a8a946db45873d5a6e5fd7a4e3aR1-R14): Added a new `Subscription` configuration for the cert-manager operator, specifying the stable-v1 channel and automatic install plan approval.

### Certificate Configurations:

* [`telco-hub/configuration/reference-crs/optional/cert-manager/consoleCertificate.yaml`](diffhunk://#diff-8155dc6a83627d8d973b046e00d0cbe78e0c4631b201d3eb878b2dd90f7478f4R1-R17): Added a new `Certificate` configuration for the console, using the self-signed `ClusterIssuer`.
* [`telco-hub/configuration/reference-crs/optional/cert-manager/downloadsCertificate.yaml`](diffhunk://#diff-6c21f285509c350fc26215e1b7244a27fd9179a0b8513c4b2450cedcda12f38eR1-R17): Added a new `Certificate` configuration for downloads, using the self-signed `ClusterIssuer`.
* [`telco-hub/configuration/reference-crs/optional/cert-manager/oauthServiceCertificate.yaml`](diffhunk://#diff-b339cfc5f0175a9161b146667cde341dec7a0124b44491fa2d5154ce033a1eabR1-R17): Added a new `Certificate` configuration for the OAuth service, using the self-signed `ClusterIssuer`.