### PR TITLE
Adds image-based cluster installation CRDs to be managed by Argo ZTP app

### DIFF
--- a/telco-hub/configuration/reference-crs/required/gitops/ztp-installation/app-project.yaml
+++ b/telco-hub/configuration/reference-crs/required/gitops/ztp-installation/app-project.yaml
@@ -29,12 +29,16 @@ spec:
     kind: NMStateConfig
   - group: 'extensions.hive.openshift.io'
     kind: AgentClusterInstall
+  - group: 'extensions.hive.openshift.io'
+    kind: ImageClusterInstall
   - group: 'hive.openshift.io'
     kind: ClusterDeployment
   - group: 'metal3.io'
     kind: BareMetalHost
   - group: 'metal3.io'
     kind: HostFirmwareSettings
+  - group: 'metal3.io'
+    kind: DataImage
   - group: 'agent.open-cluster-management.io'
     kind: KlusterletAddonConfig
   - group: 'cluster.open-cluster-management.io'


### PR DESCRIPTION
The provisioning ZTP Argo App is missing the following **image-based** resources to be managed: `ImageClusterInstall` and `DataImage`

cc/  @imiller0 