### PR TITLE
OCPBUGS-54718: set CLO subscription channel to 6.2

### DIFF
--- a/telco-ran/configuration/argocd/example/acmpgfrompgt/hub-side-templating/source-crs/ClusterLogSubscription.yaml
+++ b/telco-ran/configuration/argocd/example/acmpgfrompgt/hub-side-templating/source-crs/ClusterLogSubscription.yaml
@@ -6,7 +6,7 @@ metadata:
   annotations:
     ran.openshift.io/ztp-deploy-wave: "2"
 spec:
-  channel: "stable-6.1"
+  channel: "stable-6.2"
   name: cluster-logging
   source: redhat-operators-disconnected
   sourceNamespace: openshift-marketplace

--- a/telco-ran/configuration/argocd/example/acmpgfrompgt/out/ztp-common_policy.open-cluster-management.io_v1_policy_common-latest-subscriptions-policy.yaml
+++ b/telco-ran/configuration/argocd/example/acmpgfrompgt/out/ztp-common_policy.open-cluster-management.io_v1_policy_common-latest-subscriptions-policy.yaml
@@ -192,7 +192,7 @@ spec:
               name: cluster-logging
               namespace: openshift-logging
             spec:
-              channel: stable-6.1
+              channel: stable-6.2
               installPlanApproval: Manual
               name: cluster-logging
               source: redhat-operators-disconnected

--- a/telco-ran/configuration/argocd/example/acmpgfrompgt/source-crs/ClusterLogSubscription.yaml
+++ b/telco-ran/configuration/argocd/example/acmpgfrompgt/source-crs/ClusterLogSubscription.yaml
@@ -6,7 +6,7 @@ metadata:
   annotations:
     ran.openshift.io/ztp-deploy-wave: "2"
 spec:
-  channel: "stable-6.1"
+  channel: "stable-6.2"
   name: cluster-logging
   source: redhat-operators-disconnected
   sourceNamespace: openshift-marketplace

--- a/telco-ran/configuration/kube-compare-reference/required/cluster-logging/ClusterLogSubscription.yaml
+++ b/telco-ran/configuration/kube-compare-reference/required/cluster-logging/ClusterLogSubscription.yaml
@@ -6,7 +6,7 @@ metadata:
   annotations:
     ran.openshift.io/ztp-deploy-wave: "2"
 spec:
-  channel: "stable-6.1"
+  channel: "stable-6.2"
   name: cluster-logging
   source: {{ .spec.source }}
   sourceNamespace: openshift-marketplace

--- a/telco-ran/configuration/source-crs/ClusterLogSubscription.yaml
+++ b/telco-ran/configuration/source-crs/ClusterLogSubscription.yaml
@@ -6,7 +6,7 @@ metadata:
   annotations:
     ran.openshift.io/ztp-deploy-wave: "2"
 spec:
-  channel: "stable-6.1"
+  channel: "stable-6.2"
   name: cluster-logging
   source: redhat-operators-disconnected
   sourceNamespace: openshift-marketplace


### PR DESCRIPTION
Changed and updated the subscription CR and references for ClusterLoggingOperator operator to use stable-6.2 channel instead of stable-6.1. The reason being, stable-6.1 is removed from 4.19 catalog.