### PR TITLE
Removing unnecessary lines into SriovOperatorConfigForSNO 

### DIFF
--- a/telco-ran/configuration/kube-compare-reference/default_value.yaml
+++ b/telco-ran/configuration/kube-compare-reference/default_value.yaml
@@ -372,9 +372,6 @@ required_sriov_operator_SriovOperatorConfigForSNO:
 - spec:
     configDaemonNodeSelector:
       "node-role.kubernetes.io/$mcp": ""
-    enableInjector: false
-    enableOperatorWebhook: false
-    logLevel: 0
 required_sriov_operator_SriovSubscription:
 - spec:
     source: redhat-operators-disconnected

--- a/telco-ran/configuration/source-crs/SriovOperatorConfigForSNO.yaml
+++ b/telco-ran/configuration/source-crs/SriovOperatorConfigForSNO.yaml
@@ -23,6 +23,3 @@ spec:
   #          openshift.io/<resource_name>:  "1"
   # Disable drain is needed for Single Node Openshift
   disableDrain: true
-  enableInjector: false
-  enableOperatorWebhook: false
-  logLevel: 0


### PR DESCRIPTION
Proposition to remove those lines in the SRIOV operator SNO config as it did create confusion, you can see the discussion here: https://issues.redhat.com/browse/OCPBUGS-53346
Those fields are already set to those values by default

I did change only SNO config but maybe it could be a good thing to have those removed for other configuration.