### PR TITLE
OCPBUGS-48672: core RDS: Allow 'avoidBuggyIps' in metallb IpAddressPools

### DIFF
--- a/telco-core/configuration/reference-crs-kube-compare/required/networking/metallb/addr-pool.yaml
+++ b/telco-core/configuration/reference-crs-kube-compare/required/networking/metallb/addr-pool.yaml
@@ -14,4 +14,7 @@ spec:
 {{ if .spec.autoAssign }}
   autoAssign: {{ .spec.autoAssign }}
 {{ end }}
+{{ if .spec.avoidBuggyIPs }}
+  avoidBuggyIps: {{ .spec.avoidBuggyIPs }}
+{{ end }}
   ##############


### PR DESCRIPTION
Signed-off-by: Jim Ramsay <jramsay@redhat.com>
