### PR TITLE
OCPBUGS-48492: core RDS: Ignore k8s.v1.cni.cncf.io/resourceName annotation

### DIFF
--- a/telco-core/configuration/reference-crs-kube-compare/metadata.yaml
+++ b/telco-core/configuration/reference-crs-kube-compare/metadata.yaml
@@ -203,6 +203,7 @@ fieldsToOmit:
         isPrefix: true
       - pathToKey: metadata.annotations."nmstate.io/webhook-mutating-timestamp"
       - pathToKey: metadata.annotations."operator.sriovnetwork.openshift.io/last-network-namespace"
+      - pathToKey: metadata.annotations."k8s.v1.cni.cncf.io/resourceName"
     allowStatusCheck:
       - include: defaults
     all:


### PR DESCRIPTION
Signed-off-by: Jim Ramsay <jramsay@redhat.com>
