### PR TITLE
ztp: update disconnected-idms in acm examples

### DIFF
--- a/telco-ran/configuration/argocd/example/acmpolicygenerator/acm-common-ranGen.yaml
+++ b/telco-ran/configuration/argocd/example/acmpolicygenerator/acm-common-ranGen.yaml
@@ -38,10 +38,10 @@ policies:
         spec:
           displayName: disconnected-redhat-operators
           image: registry.example.com:5000/disconnected-redhat-operators/disconnected-redhat-operator-index:v4.9
-    - path: source-crs/DisconnectedICSP.yaml
+    - path: source-crs/DisconnectedIDMS.yaml
       patches:
       - spec:
-          repositoryDigestMirrors:
+          imageDigestMirrors:
           - mirrors:
             - registry.example.com:5000
             source: registry.redhat.io

--- a/telco-ran/configuration/argocd/example/policygentemplates/common-ranGen.yaml
+++ b/telco-ran/configuration/argocd/example/policygentemplates/common-ranGen.yaml
@@ -94,10 +94,10 @@ spec:
       spec:
         displayName: disconnected-redhat-operators
         image: registry.example.com:5000/disconnected-redhat-operators/disconnected-redhat-operator-index:v4.9
-    - fileName: DisconnectedICSP.yaml
+    - fileName: DisconnectedIDMS.yaml
       policyName: "config-policy"
       spec:
-        repositoryDigestMirrors:
+        imageDigestMirrors:
         - mirrors:
           - registry.example.com:5000
           source: registry.redhat.io


### PR DESCRIPTION
This MR replaces references to DisconnectedICSP with DisconnectedIDMS in argoCD examples.