### PR TITLE
ztp: OCPBUGS-56072: update disk references in install examples

### DIFF
--- a/telco-ran/configuration/argocd/example/siteconfig/example-sno.yaml
+++ b/telco-ran/configuration/argocd/example/siteconfig/example-sno.yaml
@@ -76,7 +76,7 @@ spec:
         bootMode: "UEFISecureBoot"
         rootDeviceHints:
           deviceName: "/dev/disk/by-path/pci-0000:01:00.0-scsi-0:2:0:0"
-        # disk partition at `/var/lib/containers` with ignitionConfigOverride. Some values must be updated. See DiskPartitionContainer.md for more details
+        # disk partition at `/var/lib/containers` with ignitionConfigOverride. Some values must be updated. See DiskPartitionContainer.md in argocd folder for more details
         ignitionConfigOverride: |
           {
             "ignition": {
@@ -85,7 +85,7 @@ spec:
             "storage": {
               "disks": [
                 {
-                  "device": "/dev/disk/by-id/wwn-0x6b07b250ebb9d0002a33509f24af1f62",
+                  "device": "/dev/disk/by-path/pci-0000:01:00.0-scsi-0:2:0:0",
                   "partitions": [
                     {
                       "label": "var-lib-containers",

--- a/telco-ran/install/clusterinstance/example-sno.yaml
+++ b/telco-ran/install/clusterinstance/example-sno.yaml
@@ -73,7 +73,7 @@ spec:
       bootMode: "UEFISecureBoot"
       rootDeviceHints:
         deviceName: "/dev/disk/by-path/pci-0000:01:00.0-scsi-0:2:0:0"
-      # disk partition at `/var/lib/containers` with ignitionConfigOverride. Some values must be updated. See DiskPartitionContainer.md for more details
+      # disk partition at `/var/lib/containers` with ignitionConfigOverride. Some values must be updated. See DiskPartitionContainer.md in argocd folder for more details
       ignitionConfigOverride: |
         {
           "ignition": {
@@ -82,7 +82,7 @@ spec:
           "storage": {
             "disks": [
               {
-                "device": "/dev/disk/by-id/wwn-0x6b07b250ebb9d0002a33509f24af1f62",
+                "device": "/dev/disk/by-path/pci-0000:01:00.0-scsi-0:2:0:0",
                 "partitions": [
                   {
                     "label": "var-lib-containers",

--- a/telco-ran/install/siteconfig/example-sno.yaml
+++ b/telco-ran/install/siteconfig/example-sno.yaml
@@ -76,7 +76,7 @@ spec:
         bootMode: "UEFISecureBoot"
         rootDeviceHints:
           deviceName: "/dev/disk/by-path/pci-0000:01:00.0-scsi-0:2:0:0"
-        # disk partition at `/var/lib/containers` with ignitionConfigOverride. Some values must be updated. See DiskPartitionContainer.md for more details
+        # disk partition at `/var/lib/containers` with ignitionConfigOverride. Some values must be updated. See DiskPartitionContainer.md in argocd folder for more details
         ignitionConfigOverride: |
           {
             "ignition": {
@@ -85,7 +85,7 @@ spec:
             "storage": {
               "disks": [
                 {
-                  "device": "/dev/disk/by-id/wwn-0x6b07b250ebb9d0002a33509f24af1f62",
+                  "device": "/dev/disk/by-path/pci-0000:01:00.0-scsi-0:2:0:0",
                   "partitions": [
                     {
                       "label": "var-lib-containers",


### PR DESCRIPTION
This PR updates the disk references in the install config (siteconfig,clusterinstance) examples to use disk-by-path instead of id (wwn)