### PR TITLE
OCPBUGS-56367: core cluster-compare: Repair NMState template when spec is not empty

### DIFF
--- a/telco-core/configuration/reference-crs-kube-compare/required/networking/NMState.yaml
+++ b/telco-core/configuration/reference-crs-kube-compare/required/networking/NMState.yaml
@@ -2,10 +2,5 @@ apiVersion: nmstate.io/v1
 kind: NMState
 metadata:
   name: nmstate
-
-{{- if  eq (len (or .spec dict )) 0 }}
-spec: {}
-{{- else -}}
 spec:
-{{ .spec | toYaml | indent 2 }}
-{{ end }}
+{{ .spec | default dict | toYaml | indent 2 }}


### PR DESCRIPTION
Signed-off-by: Jim Ramsay <jramsay@redhat.com>
