### PR TITLE
CLO channel should be stable-6.2

### DIFF
--- a/telco-hub/configuration/reference-crs/optional/logging/clusterLogSubscription.yaml
+++ b/telco-hub/configuration/reference-crs/optional/logging/clusterLogSubscription.yaml
@@ -5,7 +5,7 @@ metadata:
   name: cluster-logging
   namespace: openshift-logging
 spec:
-  channel: "stable"
+  channel: "stable-6.2"
   name: cluster-logging
   source: redhat-operators-disconnected
   sourceNamespace: openshift-marketplace


### PR DESCRIPTION
Actually, I think this operator have no packages on stable channel for 4.18. And the CLO version to be used should be 6.2:

https://github.com/openshift-kni/telco-reference/blob/main/telco-ran/configuration/source-crs/ClusterLogSubscription.yaml