### PR TITLE
Fix default holdover value for 2 port Ordinary clock

### DIFF
--- a/telco-ran/configuration/kube-compare-reference/default_value.yaml
+++ b/telco-ran/configuration/kube-compare-reference/default_value.yaml
@@ -79,7 +79,7 @@ optional_ptp_config_PtpConfigDualFollower:
 - spec:
     profile:
     - ptpClockThreshold:
-        holdOverTimeout: 65
+        holdOverTimeout: 5
         maxOffsetThreshold: 100
         minOffsetThreshold: -100
     recommend:

--- a/telco-ran/configuration/source-crs/PtpConfigDualFollower.yaml
+++ b/telco-ran/configuration/source-crs/PtpConfigDualFollower.yaml
@@ -122,7 +122,7 @@ spec:
     ptpSchedulingPolicy: SCHED_FIFO
     ptpSchedulingPriority: 10
     ptpClockThreshold:
-      holdOverTimeout: 65
+      holdOverTimeout: 5
       maxOffsetThreshold: 100
       minOffsetThreshold: -100
   recommend:


### PR DESCRIPTION
Change the default value from 65 seconds to 5 seconds