### PR TITLE
Add sh linter; improve Makefile(s)

### DIFF
--- a/.github/workflows/pre-main.yml
+++ b/.github/workflows/pre-main.yml
@@ -1,0 +1,27 @@
+name: Shell Format Check
+
+on:
+  pull_request:
+    paths:
+      - '**/*.sh'
+  push:
+    branches:
+      - main
+    paths:
+      - '**/*.sh'
+
+jobs:
+  shfmt:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Install shfmt
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y shfmt
+          
+      - name: Run shfmt check
+        run: |
+          find . -type f -name '*.sh' -print0 | xargs -0 shfmt -d -i 2

--- a/hack/install-markdownlint.sh
+++ b/hack/install-markdownlint.sh
@@ -4,16 +4,16 @@
 cat /etc/redhat-release || echo "No /etc/redhat-release"
 
 if grep -q 'Red Hat Enterprise Linux' /etc/redhat-release; then
-    # install the config file for the RPM repository with node 14
-    # steps taken from https://rpm.nodesource.com/setup_14.x
-    yum module disable -y nodejs
-    curl -sL -o '/tmp/nodesource.rpm' 'https://rpm.nodesource.com/pub_14.x/el/8/x86_64/nodesource-release-el8-1.noarch.rpm'
-    rpm -i --nosignature --force /tmp/nodesource.rpm
-    yum -y install nodejs
+  # install the config file for the RPM repository with node 14
+  # steps taken from https://rpm.nodesource.com/setup_14.x
+  yum module disable -y nodejs
+  curl -sL -o '/tmp/nodesource.rpm' 'https://rpm.nodesource.com/pub_14.x/el/8/x86_64/nodesource-release-el8-1.noarch.rpm'
+  rpm -i --nosignature --force /tmp/nodesource.rpm
+  yum -y install nodejs
 else
-    # Fedora has a module we can use
-    dnf -y module enable nodejs:16
-    dnf -y install nodejs
+  # Fedora has a module we can use
+  dnf -y module enable nodejs:16
+  dnf -y install nodejs
 fi
 
 npm install -g markdownlint@v0.25.1 markdownlint-cli2@v0.4.0

--- a/hack/markdownlint.sh
+++ b/hack/markdownlint.sh
@@ -5,14 +5,14 @@
 trap 'handle_exit $?' EXIT
 
 function handle_exit {
-    # If the exit code we were given indicates an error, suggest that
-    # the author run the linter locally.
-    if [ "$1" != "0" ]; then
+  # If the exit code we were given indicates an error, suggest that
+  # the author run the linter locally.
+  if [ "$1" != "0" ]; then
     cat - <<EOF
 To run the linter on a Linux system with podman, run "make markdownlint"
 after committing your changes locally.
 EOF
-    fi
+  fi
 }
 
 markdownlint-cli2 '**/*.md' !'vendor/**/*.md'

--- a/telco-core/configuration/compare.sh
+++ b/telco-core/configuration/compare.sh
@@ -25,22 +25,22 @@ function compare_cr {
   local exclusionfile=$3
   local status=0
 
-  read_dir "$rendered_dir" |grep yaml  > rendered_file
-  read_dir "$source_dir" |grep yaml  > source_file
+  read_dir "$rendered_dir" | grep yaml >rendered_file
+  read_dir "$source_dir" | grep yaml >source_file
 
   local source_cr rendered
   while IFS= read -r source_cr; do
     while IFS= read -r rendered; do
       if [ "${source_cr##*/}" = "${rendered##*/}" ]; then
-        echo "$source_cr" >> same_file
+        echo "$source_cr" >>same_file
       fi
-    done < rendered_file
-  done < source_file
+    done <rendered_file
+  done <source_file
 
   # Filter out files with a source-cr/reference match from the full list of potentiol source-crs/reference files
   while IFS= read -r file; do
     [[ ${file::1} != "#" ]] || continue # Skip any comment lines in the exclusionfile
-    [[ -n ${file} ]] || continue # Skip empty lines
+    [[ -n ${file} ]] || continue        # Skip empty lines
     sed -i "/${file##*/}/d" source_file
     sed -i "/${file##*/}/d" rendered_file
   done < <(cat same_file "$exclusionfile")
@@ -55,103 +55,103 @@ function compare_cr {
 }
 
 sync_cr() {
-    local rendered_dir=$1
-    local source_dir=$2
-    local exclusionfile=$3
-    local status=0
+  local rendered_dir=$1
+  local source_dir=$2
+  local exclusionfile=$3
+  local status=0
 
-    local -a renderedFiles
-    readarray -t renderedFiles < <(read_dir "$rendered_dir" | grep yaml)
+  local -a renderedFiles
+  readarray -t renderedFiles < <(read_dir "$rendered_dir" | grep yaml)
 
-    local -a sourceFiles
-    readarray -t sourceFiles < <(read_dir "$source_dir" | grep yaml)
+  local -a sourceFiles
+  readarray -t sourceFiles < <(read_dir "$source_dir" | grep yaml)
 
-    local -a excludedFiles
-    readarray -t excludedFiles < <(grep -v '^#' "$exclusionfile" | grep -v '^$')
+  local -a excludedFiles
+  readarray -t excludedFiles < <(grep -v '^#' "$exclusionfile" | grep -v '^$')
 
-    local source rendered excluded found
-    for rendered in "${renderedFiles[@]}"; do
-        found=0
-        for source in "${sourceFiles[@]}"; do
-            if [ "${source##*/}" = "${rendered##*/}" ]; then
-                # Match found!
-                found=1
-                break
-            fi
-        done
-        if [[ $found == 0 ]]; then
-            source="$source_dir/${rendered##*/}"
-        fi
-
-        # Replace the CR with the rendered copy (minus the helm-rendered heading)
-        tail -n +3 "$rendered" >"$source"
-        git add "$source"
-    done
-
+  local source rendered excluded found
+  for rendered in "${renderedFiles[@]}"; do
+    found=0
     for source in "${sourceFiles[@]}"; do
-        found=0
-        for rendered in "${renderedFiles[@]}"; do
-            if [ "${source##*/}" = "${rendered##*/}" ]; then
-                # Match found!
-                found=1
-                break
-            fi
-        done
-        for excluded in "${excludedFiles[@]}"; do
-            if [ "${source##*/}" = "${excluded##*/}" ]; then
-                # Match found!
-                found=1
-                break
-            fi
-        done
-        if [[ $found == 0 ]]; then
-            git rm -f "$source"
-        fi
+      if [ "${source##*/}" = "${rendered##*/}" ]; then
+        # Match found!
+        found=1
+        break
+      fi
     done
+    if [[ $found == 0 ]]; then
+      source="$source_dir/${rendered##*/}"
+    fi
 
-    git diff --cached --stat --exit-code
+    # Replace the CR with the rendered copy (minus the helm-rendered heading)
+    tail -n +3 "$rendered" >"$source"
+    git add "$source"
+  done
+
+  for source in "${sourceFiles[@]}"; do
+    found=0
+    for rendered in "${renderedFiles[@]}"; do
+      if [ "${source##*/}" = "${rendered##*/}" ]; then
+        # Match found!
+        found=1
+        break
+      fi
+    done
+    for excluded in "${excludedFiles[@]}"; do
+      if [ "${source##*/}" = "${excluded##*/}" ]; then
+        # Match found!
+        found=1
+        break
+      fi
+    done
+    if [[ $found == 0 ]]; then
+      git rm -f "$source"
+    fi
+  done
+
+  git diff --cached --stat --exit-code
 }
 
 usage() {
-    echo "$(basename "$0") [--sync] sourceDir renderDir"
-    echo
-    echo "Compares the rendered reference-based CRs to the CRs in the compare directory"
+  echo "$(basename "$0") [--sync] sourceDir renderDir"
+  echo
+  echo "Compares the rendered reference-based CRs to the CRs in the compare directory"
 }
 
 DOSYNC=0
 for arg in "$@"; do
-    case "$arg" in
-        -h | --help)
-            usage
-            exit 0
-            ;;
-        --sync)
-            DOSYNC=1
-            shift
-            ;;
-    esac
+  case "$arg" in
+  -h | --help)
+    usage
+    exit 0
+    ;;
+  --sync)
+    DOSYNC=1
+    shift
+    ;;
+  esac
 done
 SOURCEDIR=$1
 if [[ ! -d $SOURCEDIR ]]; then
-    echo "No such source directory $SOURCEDIR"
-    usage
-    exit 1
+  echo "No such source directory $SOURCEDIR"
+  usage
+  exit 1
 fi
 RENDERDIR=$2
 if [[ ! -d $RENDERDIR ]]; then
-    echo "No such source directory $RENDERDIR"
-    usage
-    exit 1
+  echo "No such source directory $RENDERDIR"
+  usage
+  exit 1
 fi
 IGNORE=$3
 if [[ ! -f $IGNORE ]]; then
-    echo "No such ignorefile $IGNORE"
-    usage
-    exit 1
+  echo "No such ignorefile $IGNORE"
+  usage
+  exit 1
 fi
 
 if [[ $DOSYNC == 1 ]]; then
-    sync_cr "$RENDERDIR" "$SOURCEDIR" "$IGNORE"
+  sync_cr "$RENDERDIR" "$SOURCEDIR" "$IGNORE"
 else
-    compare_cr "$RENDERDIR" "$SOURCEDIR" "$IGNORE"
+  compare_cr "$RENDERDIR" "$SOURCEDIR" "$IGNORE"
 fi

--- a/telco-hub/configuration/reference-crs-kube-compare/compare.sh
+++ b/telco-hub/configuration/reference-crs-kube-compare/compare.sh
@@ -31,40 +31,40 @@ function compare_cr {
     DIFF="diff"
   fi
 
-  read_dir "$rendered_dir" |grep yaml  > rendered_file
-  read_dir "$source_dir" |grep yaml  > source_file
+  read_dir "$rendered_dir" | grep yaml >rendered_file
+  read_dir "$source_dir" | grep yaml >source_file
 
   # Apply ignore filtering before comparison
   while IFS= read -r file; do
     [[ ${file::1} != "#" ]] || continue # Skip any comment lines in the exclusionfile
-    [[ -n ${file} ]] || continue # Skip empty lines
+    [[ -n ${file} ]] || continue        # Skip empty lines
     sed -i "/${file##*/}/d" source_file
     sed -i "/${file##*/}/d" rendered_file
-  done < "$exclusionfile"
+  done <"$exclusionfile"
 
   local source_cr rendered
   while IFS= read -r source_cr; do
     while IFS= read -r rendered; do
       if [ "${source_cr##*/}" = "${rendered##*/}" ]; then
         # helm adds a yaml doc header (---) and a leading comment to every source_cr file; so remove those lines
-        tail -n +3 "$rendered" > "$rendered.fixed"
+        tail -n +3 "$rendered" >"$rendered.fixed"
         mv "$rendered.fixed" "$rendered"
 
         # Check the differences
         if ! "$DIFF" -u "$source_cr" "$rendered"; then
-            status=$(( status || 1 ))
-            printf "\n\n**********************************************************************************\n\n"
+          status=$((status || 1))
+          printf "\n\n**********************************************************************************\n\n"
         fi
         # cleanup
-        echo "$source_cr" >> same_file
+        echo "$source_cr" >>same_file
       fi
-    done < rendered_file
-  done < source_file
+    done <rendered_file
+  done <source_file
 
   # Filter out files with a source-cr/reference match from the full list of potentiol source-crs/reference files
   while IFS= read -r file; do
     [[ ${file::1} != "#" ]] || continue # Skip any comment lines in the exclusionfile
-    [[ -n ${file} ]] || continue # Skip empty lines
+    [[ -n ${file} ]] || continue        # Skip empty lines
     sed -i "/${file##*/}/d" source_file
     sed -i "/${file##*/}/d" rendered_file
   done < <(cat same_file "$exclusionfile")
@@ -79,97 +79,97 @@ function compare_cr {
 }
 
 sync_cr() {
-    local rendered_dir=$1
-    local source_dir=$2
-    local exclusionfile=$3
-    local status=0
+  local rendered_dir=$1
+  local source_dir=$2
+  local exclusionfile=$3
+  local status=0
 
-    local -a renderedFiles
-    readarray -t renderedFiles < <(read_dir "$rendered_dir" | grep yaml)
+  local -a renderedFiles
+  readarray -t renderedFiles < <(read_dir "$rendered_dir" | grep yaml)
 
-    local -a sourceFiles
-    readarray -t sourceFiles < <(read_dir "$source_dir" | grep yaml)
+  local -a sourceFiles
+  readarray -t sourceFiles < <(read_dir "$source_dir" | grep yaml)
 
-    local -a excludedFiles
-    readarray -t excludedFiles < <(grep -v '^#' "$exclusionfile" | grep -v '^$')
+  local -a excludedFiles
+  readarray -t excludedFiles < <(grep -v '^#' "$exclusionfile" | grep -v '^$')
 
-    local source rendered excluded found
-    for rendered in "${renderedFiles[@]}"; do
-        found=0
-        for source in "${sourceFiles[@]}"; do
-            if [ "${source##*/}" = "${rendered##*/}" ]; then
-                # Match found!
-                found=1
-                break
-            fi
-        done
-        if [[ $found == 0 ]]; then
-            source="$source_dir/${rendered##*/}"
-        fi
-
-        # Replace the CR with the rendered copy (minus the helm-rendered heading)
-        tail -n +3 "$rendered" >"$source"
-        git add "$source"
-    done
-
+  local source rendered excluded found
+  for rendered in "${renderedFiles[@]}"; do
+    found=0
     for source in "${sourceFiles[@]}"; do
-        found=0
-        for rendered in "${renderedFiles[@]}"; do
-            if [ "${source##*/}" = "${rendered##*/}" ]; then
-                # Match found!
-                found=1
-                break
-            fi
-        done
-        for excluded in "${excludedFiles[@]}"; do
-            if [ "${source##*/}" = "${excluded##*/}" ]; then
-                # Match found!
-                found=1
-                break
-            fi
-        done
-        if [[ $found == 0 ]]; then
-            git rm -f "$source"
-        fi
+      if [ "${source##*/}" = "${rendered##*/}" ]; then
+        # Match found!
+        found=1
+        break
+      fi
     done
+    if [[ $found == 0 ]]; then
+      source="$source_dir/${rendered##*/}"
+    fi
 
-    git diff --cached --stat --exit-code
+    # Replace the CR with the rendered copy (minus the helm-rendered heading)
+    tail -n +3 "$rendered" >"$source"
+    git add "$source"
+  done
+
+  for source in "${sourceFiles[@]}"; do
+    found=0
+    for rendered in "${renderedFiles[@]}"; do
+      if [ "${source##*/}" = "${rendered##*/}" ]; then
+        # Match found!
+        found=1
+        break
+      fi
+    done
+    for excluded in "${excludedFiles[@]}"; do
+      if [ "${source##*/}" = "${excluded##*/}" ]; then
+        # Match found!
+        found=1
+        break
+      fi
+    done
+    if [[ $found == 0 ]]; then
+      git rm -f "$source"
+    fi
+  done
+
+  git diff --cached --stat --exit-code
 }
 
 usage() {
-    echo "$(basename "$0") [--sync] sourceDir renderDir"
-    echo
-    echo "Compares the rendered reference-based CRs to the CRs in the compare directory"
+  echo "$(basename "$0") [--sync] sourceDir renderDir"
+  echo
+  echo "Compares the rendered reference-based CRs to the CRs in the compare directory"
 }
 
 DOSYNC=0
 for arg in "$@"; do
-    case "$arg" in
-        -h | --help)
-            usage
-            exit 0
-            ;;
-        --sync)
-            DOSYNC=1
-            shift
-            ;;
-    esac
+  case "$arg" in
+  -h | --help)
+    usage
+    exit 0
+    ;;
+  --sync)
+    DOSYNC=1
+    shift
+    ;;
+  esac
 done
 SOURCEDIR=$1
 if [[ ! -d $SOURCEDIR ]]; then
-    echo "No such source directory $SOURCEDIR"
-    usage
-    exit 1
+  echo "No such source directory $SOURCEDIR"
+  usage
+  exit 1
 fi
 RENDERDIR=$2
 if [[ ! -d $RENDERDIR ]]; then
-    echo "No such source directory $RENDERDIR"
-    usage
-    exit 1
+  echo "No such source directory $RENDERDIR"
+  usage
+  exit 1
 fi
 
 if [[ $DOSYNC == 1 ]]; then
-    sync_cr "$RENDERDIR" "$SOURCEDIR" compare_ignore
+  sync_cr "$RENDERDIR" "$SOURCEDIR" compare_ignore
 else
-    compare_cr "$RENDERDIR" "$SOURCEDIR" compare_ignore
+  compare_cr "$RENDERDIR" "$SOURCEDIR" compare_ignore
 fi

--- a/telco-hub/configuration/reference-crs/required/gitops/get_ztp_installation.sh
+++ b/telco-hub/configuration/reference-crs/required/gitops/get_ztp_installation.sh
@@ -23,6 +23,6 @@ find ./ztp-installation/ -name "*.yaml" -exec yq -i eval '.metadata.annotations.
 echo " - Patch ztp-site-generate version"
 sed -i 's|quay.io/openshift-kni/ztp-site-generator:latest|registry.redhat.io/openshift4/ztp-site-generate-rhel8:v4.20|g' ztp-installation/argocd-openshift-gitops-patch.json
 
-echo  " - Adding elements to the whitelist"
+echo " - Adding elements to the whitelist"
 yq '.spec.namespaceResourceWhitelist += {"group": "'metal3.io'", "kind": "DataImage"}' ztp-installation/app-project.yaml
 yq '.spec.namespaceResourceWhitelist += {"group": "'extensions.hive.openshift.io'", "kind": "ImageClusterInstall"}' ztp-installation/app-project.yaml

--- a/telco-hub/scripts/check_current_versions.sh
+++ b/telco-hub/scripts/check_current_versions.sh
@@ -15,42 +15,42 @@ for tool in yq cat grep find; do
   fi
 done
 
-print_section(){
+print_section() {
   printf "\n###########################################################\n"
   printf "%s\n" "$1"
   printf "###########################################################\n\n"
 
 }
-print_subscriptions(){
+print_subscriptions() {
   print_section "Following a list of the different configured subscriptions"
 
-  find ./configuration/reference-crs/ -type f \( -name "*.yaml" -o -name "*.yml" \) \
-      | xargs cat - \
-      | yq -r 'select(.kind == "Subscription") | .metadata.name + " channel " + .spec.channel'
+  find ./configuration/reference-crs/ -type f \( -name "*.yaml" -o -name "*.yml" \) |
+    xargs cat - |
+    yq -r 'select(.kind == "Subscription") | .metadata.name + " channel " + .spec.channel'
 }
 
-print_argocd_ztp_image(){
+print_argocd_ztp_image() {
   print_section "ztp-site-generate version inside ArgoCD"
 
   grep -E 'ztp-site-generator|ztp-site-generate' ./configuration/reference-crs/required/gitops/addPluginsPolicy.yaml || true
 }
 
-print_disconnected_imageset_channels(){
+print_disconnected_imageset_channels() {
   print_section "Disconnected imageset platform channels"
 
   yq '.mirror.platform.channels' ./install/mirror-registry/imageset-config.yaml
 }
 
-print_disconnected_imageset_operators(){
+print_disconnected_imageset_operators() {
   print_section "Disconnected imageset version of operators"
 
   yq '.mirror.operators[].packages[] | .name + " " + .channels[].name' ./install/mirror-registry/imageset-config.yaml
 }
 
-print_agentservice_images(){
+print_agentservice_images() {
   print_section "AgentServiceConfig configured images"
 
-  yq '.spec.osImages[].openshiftVersion'  ./configuration/reference-crs/required/acm/acmAgentServiceConfig.yaml
+  yq '.spec.osImages[].openshiftVersion' ./configuration/reference-crs/required/acm/acmAgentServiceConfig.yaml
 }
 
 print_subscriptions

--- a/telco-ran/configuration/argocd/example/optional-extra-manifest/ipsec/configure-ipsec.sh
+++ b/telco-ran/configuration/argocd/example/optional-extra-manifest/ipsec/configure-ipsec.sh
@@ -3,71 +3,71 @@
 FILESDIR=${FILESDIR:-$(pwd)}
 
 for role in master worker; do
-  cat > "99-ipsec-${role}-endpoint-config.bu" <<-EOF
-  variant: openshift
-  version: 4.14.0
-  metadata:
-    name: 99-ipsec-${role}-import-certs-enable-svc-os-ext
-    labels:
-      machineconfiguration.openshift.io/role: ${role}
-  systemd:
-    units:
-    - name: ipsec-import.service
-      enabled: true
-      contents: |
-        [Unit]
-        Description=Import external certs into ipsec NSS
-        Before=ipsec.service
+  cat >"99-ipsec-${role}-endpoint-config.bu" <<-EOF
+		  variant: openshift
+		  version: 4.14.0
+		  metadata:
+		    name: 99-ipsec-${role}-import-certs-enable-svc-os-ext
+		    labels:
+		      machineconfiguration.openshift.io/role: ${role}
+		  systemd:
+		    units:
+		    - name: ipsec-import.service
+		      enabled: true
+		      contents: |
+		        [Unit]
+		        Description=Import external certs into ipsec NSS
+		        Before=ipsec.service
 
-        [Service]
-        Type=oneshot
-        ExecStart=/usr/local/bin/ipsec-addcert.sh
-        RemainAfterExit=false
-        StandardOutput=journal
+		        [Service]
+		        Type=oneshot
+		        ExecStart=/usr/local/bin/ipsec-addcert.sh
+		        RemainAfterExit=false
+		        StandardOutput=journal
 
-        [Install]
-        WantedBy=multi-user.target
-    - name: ipsec-configure.service
-      enabled: true
-      contents: |
-        [Unit]
-        Description=Apply ipsec config
-        After=NetworkManager.service ovs-configuration.service ipsec.service
+		        [Install]
+		        WantedBy=multi-user.target
+		    - name: ipsec-configure.service
+		      enabled: true
+		      contents: |
+		        [Unit]
+		        Description=Apply ipsec config
+		        After=NetworkManager.service ovs-configuration.service ipsec.service
 
-        [Service]
-        Type=oneshot
-        ExecStart=nmstatectl apply /root/ipsec-endpoint-config.yml
+		        [Service]
+		        Type=oneshot
+		        ExecStart=nmstatectl apply /root/ipsec-endpoint-config.yml
 
-        [Install]
-        WantedBy=multi-user.target
-  storage:
-    files:
-    - path: /etc/pki/certs/ca.pem
-      mode: 0400
-      overwrite: true
-      contents:
-        local: ca.pem
-    - path: /etc/pki/certs/left_server.p12
-      mode: 0400
-      overwrite: true
-      contents:
-        local: left_server.p12
-    - path: /root/ipsec-endpoint-config.yml
-      mode: 0400
-      overwrite: true
-      contents:
-        local: ipsec-endpoint-config.yml
-    - path: /usr/local/bin/ipsec-addcert.sh
-      mode: 0740
-      overwrite: true
-      contents:
-        inline: |
-          #!/bin/bash -e
-          echo "importing cert to NSS"
-          certutil -A -n "CA" -t "CT,C,C" -d /var/lib/ipsec/nss/ -i /etc/pki/certs/ca.pem
-          pk12util -W "" -i /etc/pki/certs/left_server.p12 -d /var/lib/ipsec/nss/
-          certutil -M -n "left_server" -t "u,u,u" -d /var/lib/ipsec/nss/
-EOF
+		        [Install]
+		        WantedBy=multi-user.target
+		  storage:
+		    files:
+		    - path: /etc/pki/certs/ca.pem
+		      mode: 0400
+		      overwrite: true
+		      contents:
+		        local: ca.pem
+		    - path: /etc/pki/certs/left_server.p12
+		      mode: 0400
+		      overwrite: true
+		      contents:
+		        local: left_server.p12
+		    - path: /root/ipsec-endpoint-config.yml
+		      mode: 0400
+		      overwrite: true
+		      contents:
+		        local: ipsec-endpoint-config.yml
+		    - path: /usr/local/bin/ipsec-addcert.sh
+		      mode: 0740
+		      overwrite: true
+		      contents:
+		        inline: |
+		          #!/bin/bash -e
+		          echo "importing cert to NSS"
+		          certutil -A -n "CA" -t "CT,C,C" -d /var/lib/ipsec/nss/ -i /etc/pki/certs/ca.pem
+		          pk12util -W "" -i /etc/pki/certs/left_server.p12 -d /var/lib/ipsec/nss/
+		          certutil -M -n "left_server" -t "u,u,u" -d /var/lib/ipsec/nss/
+	EOF
 done
 
 for role in master worker; do

--- a/telco-ran/configuration/argocd/example/optional-extra-manifest/ipsec/import-certs.sh
+++ b/telco-ran/configuration/argocd/example/optional-extra-manifest/ipsec/import-certs.sh
@@ -3,53 +3,53 @@
 FILESDIR=${FILESDIR:-$(pwd)}
 
 for role in master worker; do
-  cat > "99-ipsec-${role}-import-certs.bu" <<-EOF
-  variant: openshift
-  version: 4.14.0
-  metadata:
-    name: 99-ipsec-${role}-import-certs
-    labels:
-      machineconfiguration.openshift.io/role: ${role}
-  systemd:
-    units:
-    - name: ipsec-import.service
-      enabled: true
-      contents: |
-        [Unit]
-        Description=Import external certs into ipsec NSS
-        Before=ipsec.service
+  cat >"99-ipsec-${role}-import-certs.bu" <<-EOF
+		  variant: openshift
+		  version: 4.14.0
+		  metadata:
+		    name: 99-ipsec-${role}-import-certs
+		    labels:
+		      machineconfiguration.openshift.io/role: ${role}
+		  systemd:
+		    units:
+		    - name: ipsec-import.service
+		      enabled: true
+		      contents: |
+		        [Unit]
+		        Description=Import external certs into ipsec NSS
+		        Before=ipsec.service
 
-        [Service]
-        Type=oneshot
-        ExecStart=/usr/local/bin/ipsec-addcert.sh
-        RemainAfterExit=false
-        StandardOutput=journal
+		        [Service]
+		        Type=oneshot
+		        ExecStart=/usr/local/bin/ipsec-addcert.sh
+		        RemainAfterExit=false
+		        StandardOutput=journal
 
-        [Install]
-        WantedBy=multi-user.target
-  storage:
-    files:
-    - path: /etc/pki/certs/ca.pem
-      mode: 0400
-      overwrite: true
-      contents:
-        local: ca.pem
-    - path: /etc/pki/certs/left_server.p12
-      mode: 0400
-      overwrite: true
-      contents:
-        local: left_server.p12
-    - path: /usr/local/bin/ipsec-addcert.sh
-      mode: 0740
-      overwrite: true
-      contents:
-        inline: |
-          #!/bin/bash -e
-          echo "importing cert to NSS"
-          certutil -A -n "CA" -t "CT,C,C" -d /var/lib/ipsec/nss/ -i /etc/pki/certs/ca.pem
-          pk12util -W "" -i /etc/pki/certs/left_server.p12 -d /var/lib/ipsec/nss/
-          certutil -M -n "left_server" -t "u,u,u" -d /var/lib/ipsec/nss/
-EOF
+		        [Install]
+		        WantedBy=multi-user.target
+		  storage:
+		    files:
+		    - path: /etc/pki/certs/ca.pem
+		      mode: 0400
+		      overwrite: true
+		      contents:
+		        local: ca.pem
+		    - path: /etc/pki/certs/left_server.p12
+		      mode: 0400
+		      overwrite: true
+		      contents:
+		        local: left_server.p12
+		    - path: /usr/local/bin/ipsec-addcert.sh
+		      mode: 0740
+		      overwrite: true
+		      contents:
+		        inline: |
+		          #!/bin/bash -e
+		          echo "importing cert to NSS"
+		          certutil -A -n "CA" -t "CT,C,C" -d /var/lib/ipsec/nss/ -i /etc/pki/certs/ca.pem
+		          pk12util -W "" -i /etc/pki/certs/left_server.p12 -d /var/lib/ipsec/nss/
+		          certutil -M -n "left_server" -t "u,u,u" -d /var/lib/ipsec/nss/
+	EOF
 done
 
 for role in master worker; do

--- a/telco-ran/configuration/extra-manifests-builder/01-container-mount-ns-and-kubelet-conf/build.sh
+++ b/telco-ran/configuration/extra-manifests-builder/01-container-mount-ns-and-kubelet-conf/build.sh
@@ -14,9 +14,9 @@ MCPROLE=${MCPROLE:-master}
 #  Eviction : 10s
 
 ${MCMAKER} -name container-mount-namespace-and-kubelet-conf -mcp ${MCPROLE} -stdout \
-        file -source extractExecStart -path /usr/local/bin/extractExecStart -mode 0755 \
-        file -source nsenterCmns -path /usr/local/bin/nsenterCmns -mode 0755 \
-        unit -source container-mount-namespace.service -enable=false \
-        dropin -source 90-container-mount-namespace.conf -for crio.service \
-        dropin -source 90-container-mount-namespace-kubelet.conf -name 90-container-mount-namespace.conf -for kubelet.service \
-        dropin -source 30-kubelet-interval-tuning.conf -for kubelet.service
+  file -source extractExecStart -path /usr/local/bin/extractExecStart -mode 0755 \
+  file -source nsenterCmns -path /usr/local/bin/nsenterCmns -mode 0755 \
+  unit -source container-mount-namespace.service -enable=false \
+  dropin -source 90-container-mount-namespace.conf -for crio.service \
+  dropin -source 90-container-mount-namespace-kubelet.conf -name 90-container-mount-namespace.conf -for kubelet.service \
+  dropin -source 30-kubelet-interval-tuning.conf -for kubelet.service

--- a/telco-ran/configuration/extra-manifests-builder/01-container-mount-ns-and-kubelet-conf/test.sh
+++ b/telco-ran/configuration/extra-manifests-builder/01-container-mount-ns-and-kubelet-conf/test.sh
@@ -1,27 +1,27 @@
 #!/bin/bash
 
 fatal() {
-    echo "FATAL: $@"
-    exit 1
+  echo "FATAL: $@"
+  exit 1
 }
 
 export TMPDIR=$(mktemp -d)
 
 cleanup() {
-    rm -rf $TMPDIR
+  rm -rf $TMPDIR
 }
 trap cleanup EXIT
 
 # Mock for 'systemctl`; mimics the actual output as best we can.
 systemctl() {
-    local action=$1 arg=$2
-    local file=$TMPDIR/$arg
-    if [[ ! -f $file ]]; then
-        echo "No files found for $arg." >&2
-        return 1
-    fi
-    echo "# $file"
-    cat $file
+  local action=$1 arg=$2
+  local file=$TMPDIR/$arg
+  if [[ ! -f $file ]]; then
+    echo "No files found for $arg." >&2
+    return 1
+  fi
+  echo "# $file"
+  cat $file
 }
 export -f systemctl
 

--- a/telco-ran/configuration/extra-manifests-builder/01-disk-encryption-pcr-rebind/build.sh
+++ b/telco-ran/configuration/extra-manifests-builder/01-disk-encryption-pcr-rebind/build.sh
@@ -7,13 +7,13 @@ MCMAKER=${MCMAKER:-${GOBIN}/mcmaker}
 MCPROLE=${MCPROLE:-master}
 
 ${MCMAKER} -stdout -name 01-disk-encryption-rebind -mcp "${MCPROLE}" \
-	file -source luks-helpers.sh -path /usr/local/bin/luks-helpers.sh -mode 0755 \
-	file -source disablePcrOnRebootOrShutdown.sh -path /usr/local/bin/disablePcrOnRebootOrShutdown.sh -mode 0755 \
-	file -source rebindDiskOnBoot.sh -path /usr/local/bin/rebindDiskOnBoot.sh -mode 0755 \
-	file -source hwupgrade-detection-methods/file.sh -path /usr/local/bin/hwupgrade-detection-methods/file.sh -mode 0755 \
-	file -source hwupgrade-detection-methods/fwup.sh -path /usr/local/bin/hwupgrade-detection-methods/fwup.sh -mode 0755 \
-	file -source hwupgrade-detection-methods/ostree.sh -path /usr/local/bin/hwupgrade-detection-methods/ostree.sh -mode 0755 \
-	file -source hwupgrade-detection-methods/talm.sh -path /usr/local/bin/hwupgrade-detection-methods/talm.sh -mode 0755 \
-	file -source order.conf -path /etc/systemd/system/crio-.scope.d/order.conf -mode 0644 \
-	unit -source pcr-rebind-boot.service \
-	unit -source pcr-disable-shutdown.service
+  file -source luks-helpers.sh -path /usr/local/bin/luks-helpers.sh -mode 0755 \
+  file -source disablePcrOnRebootOrShutdown.sh -path /usr/local/bin/disablePcrOnRebootOrShutdown.sh -mode 0755 \
+  file -source rebindDiskOnBoot.sh -path /usr/local/bin/rebindDiskOnBoot.sh -mode 0755 \
+  file -source hwupgrade-detection-methods/file.sh -path /usr/local/bin/hwupgrade-detection-methods/file.sh -mode 0755 \
+  file -source hwupgrade-detection-methods/fwup.sh -path /usr/local/bin/hwupgrade-detection-methods/fwup.sh -mode 0755 \
+  file -source hwupgrade-detection-methods/ostree.sh -path /usr/local/bin/hwupgrade-detection-methods/ostree.sh -mode 0755 \
+  file -source hwupgrade-detection-methods/talm.sh -path /usr/local/bin/hwupgrade-detection-methods/talm.sh -mode 0755 \
+  file -source order.conf -path /etc/systemd/system/crio-.scope.d/order.conf -mode 0644 \
+  unit -source pcr-rebind-boot.service \
+  unit -source pcr-disable-shutdown.service

--- a/telco-ran/configuration/extra-manifests-builder/01-disk-encryption-pcr-rebind/disablePcrOnRebootOrShutdown.sh
+++ b/telco-ran/configuration/extra-manifests-builder/01-disk-encryption-pcr-rebind/disablePcrOnRebootOrShutdown.sh
@@ -7,9 +7,9 @@ source "$SCRIPT_DIR"/luks-helpers.sh
 logInfo "Shutting down or rebooting"
 initUpgradeDetectionMethods
 if isSystemUpdating; then
-	logInfo "System HW update detected, disabling PCR protection on all PCR protected LUKS partitions"
-	processPCRentriesOnly addReservedSlot
-	exit 0
+  logInfo "System HW update detected, disabling PCR protection on all PCR protected LUKS partitions"
+  processPCRentriesOnly addReservedSlot
+  exit 0
 fi
 
 logInfo "No System HW update detected, continue"

--- a/telco-ran/configuration/extra-manifests-builder/01-disk-encryption-pcr-rebind/hwupgrade-detection-methods/file.sh
+++ b/telco-ran/configuration/extra-manifests-builder/01-disk-encryption-pcr-rebind/hwupgrade-detection-methods/file.sh
@@ -2,11 +2,11 @@
 set -o errexit -o nounset -o pipefail
 
 isCustomFileUpdating() {
-	if [ -f "/etc/host-hw-Updating.flag" ]; then
-		return "$TRUE"
-	else
-		return "$FALSE"
-	fi
+  if [ -f "/etc/host-hw-Updating.flag" ]; then
+    return "$TRUE"
+  else
+    return "$FALSE"
+  fi
 }
 
 # Add a new function to the array of update detection methods

--- a/telco-ran/configuration/extra-manifests-builder/01-disk-encryption-pcr-rebind/hwupgrade-detection-methods/fwup.sh
+++ b/telco-ran/configuration/extra-manifests-builder/01-disk-encryption-pcr-rebind/hwupgrade-detection-methods/fwup.sh
@@ -2,19 +2,19 @@
 set -o errexit -o nounset -o pipefail
 
 isFwupUpdating() {
-	local EFI NEXT_BOOT
+  local EFI NEXT_BOOT
 
-	EFI=$(efibootmgr)
-	NEXT_BOOT=$(echo "$EFI" | grep "BootNext:" | awk '{ print $2 }')
-	if [ "$NEXT_BOOT" == "" ]; then
-		return 1
-	fi
-	echo "$EFI" | grep "Boot$NEXT_BOOT" | grep "fwupd"
-	# if the next boot line contains the text "fwupd"
-	if [ $? ]; then
-		return "$TRUE"
-	fi
-	return "$FALSE"
+  EFI=$(efibootmgr)
+  NEXT_BOOT=$(echo "$EFI" | grep "BootNext:" | awk '{ print $2 }')
+  if [ "$NEXT_BOOT" == "" ]; then
+    return 1
+  fi
+  echo "$EFI" | grep "Boot$NEXT_BOOT" | grep "fwupd"
+  # if the next boot line contains the text "fwupd"
+  if [ $? ]; then
+    return "$TRUE"
+  fi
+  return "$FALSE"
 }
 
 # Add a new function to the array of update detection methods

--- a/telco-ran/configuration/extra-manifests-builder/01-disk-encryption-pcr-rebind/hwupgrade-detection-methods/ostree.sh
+++ b/telco-ran/configuration/extra-manifests-builder/01-disk-encryption-pcr-rebind/hwupgrade-detection-methods/ostree.sh
@@ -2,14 +2,14 @@
 set -o errexit -o nounset -o pipefail
 
 isOstreeUpdating() {
-	local RESULT
+  local RESULT
 
-	RESULT=$(ostree admin status | grep -E "staged|pending")
-	if [ "$RESULT" != "" ]; then
-		return "$TRUE"
-	else
-		return "$FALSE"
-	fi
+  RESULT=$(ostree admin status | grep -E "staged|pending")
+  if [ "$RESULT" != "" ]; then
+    return "$TRUE"
+  else
+    return "$FALSE"
+  fi
 }
 
 # Add a new function to the array of update detection methods

--- a/telco-ran/configuration/extra-manifests-builder/01-disk-encryption-pcr-rebind/hwupgrade-detection-methods/talm.sh
+++ b/telco-ran/configuration/extra-manifests-builder/01-disk-encryption-pcr-rebind/hwupgrade-detection-methods/talm.sh
@@ -7,57 +7,57 @@ HUB_SECRET_NAME=hub-kubeconfig-secret
 
 # retrieves the kubeconfig for this spoke's cluster
 getHubKubeconfig() {
-	local kubeConfigPath namespace secretName KUBECONFIG_DATA TLS_KEY TLS_CRT
+  local kubeConfigPath namespace secretName KUBECONFIG_DATA TLS_KEY TLS_CRT
 
-	kubeConfigPath="$1"
-	namespace="$2"
-	secretName="$3"
-	KUBECONFIG_DATA=$(oc --kubeconfig "$kubeConfigPath" get secret -n "$namespace" "$secretName" -o json | jq .data.kubeconfig | sed 's/"//g' | base64 -d)
-	if [ -z "$KUBECONFIG_DATA" ]; then
-		return "$FALSE"
-	fi
-	TLS_KEY=$(oc --kubeconfig "$kubeConfigPath" get secret -n "$namespace" "$secretName" -o json | jq '.data."tls.key"' | sed 's/"//g')
-	TLS_CRT=$(oc --kubeconfig "$kubeConfigPath" get secret -n "$namespace" "$secretName" -o json | jq '.data."tls.crt"' | sed 's/"//g')
-	echo "$KUBECONFIG_DATA" | sed -e "s/client-certificate: tls.crt/client-certificate-data: $TLS_CRT/g" | sed -e "s/client-key: tls.key/client-key-data: $TLS_KEY/g" >/tmp/kubeconfig-hub
-	return "$TRUE"
+  kubeConfigPath="$1"
+  namespace="$2"
+  secretName="$3"
+  KUBECONFIG_DATA=$(oc --kubeconfig "$kubeConfigPath" get secret -n "$namespace" "$secretName" -o json | jq .data.kubeconfig | sed 's/"//g' | base64 -d)
+  if [ -z "$KUBECONFIG_DATA" ]; then
+    return "$FALSE"
+  fi
+  TLS_KEY=$(oc --kubeconfig "$kubeConfigPath" get secret -n "$namespace" "$secretName" -o json | jq '.data."tls.key"' | sed 's/"//g')
+  TLS_CRT=$(oc --kubeconfig "$kubeConfigPath" get secret -n "$namespace" "$secretName" -o json | jq '.data."tls.crt"' | sed 's/"//g')
+  echo "$KUBECONFIG_DATA" | sed -e "s/client-certificate: tls.crt/client-certificate-data: $TLS_CRT/g" | sed -e "s/client-key: tls.key/client-key-data: $TLS_KEY/g" >/tmp/kubeconfig-hub
+  return "$TRUE"
 }
 
 # Retreives TALM's state in the hub cluster's managedCluster object. Takes one argument:
 # done -> return $TRUE if the ztp-done label is set, $FALSE otherwise
 # running -> return $TRUE if the ztp-running label is set, $FALSE otherwise
 isZtpState() {
-	local talmState RESULT
+  local talmState RESULT
 
-	talmState="$1"
-	RESULT=$FALSE
+  talmState="$1"
+  RESULT=$FALSE
 
-	clusterName=$(oc --kubeconfig "$SPOKE_KUBECONFIG_PATH" get klusterlet klusterlet -ojsonpath='{.spec.clusterName}')
-	case "$talmState" in
-	"running")
-		RESULT=$(KUBECONFIG=/tmp/kubeconfig-hub oc get managedcluster "$clusterName" -ojson | jq '.metadata.labels["ztp-running"]!=null')
-		;;
-	"done")
-		RESULT=$(KUBECONFIG=/tmp/kubeconfig-hub oc get managedcluster "$clusterName" -ojson | jq '.metadata.labels["ztp-done"]!=null')
-		;;
-	*)
-		# Code to execute when no patterns match
-		;;
-	esac
-	if [ "$RESULT" == "false" ]; then
-		logDebug "TALM $talmState state is $RESULT"
-		return "$FALSE"
-	fi
-	logDebug "TALM $talmState state is $RESULT"
-	return "$TRUE"
+  clusterName=$(oc --kubeconfig "$SPOKE_KUBECONFIG_PATH" get klusterlet klusterlet -ojsonpath='{.spec.clusterName}')
+  case "$talmState" in
+  "running")
+    RESULT=$(KUBECONFIG=/tmp/kubeconfig-hub oc get managedcluster "$clusterName" -ojson | jq '.metadata.labels["ztp-running"]!=null')
+    ;;
+  "done")
+    RESULT=$(KUBECONFIG=/tmp/kubeconfig-hub oc get managedcluster "$clusterName" -ojson | jq '.metadata.labels["ztp-done"]!=null')
+    ;;
+  *)
+    # Code to execute when no patterns match
+    ;;
+  esac
+  if [ "$RESULT" == "false" ]; then
+    logDebug "TALM $talmState state is $RESULT"
+    return "$FALSE"
+  fi
+  logDebug "TALM $talmState state is $RESULT"
+  return "$TRUE"
 }
 
 isTALMUpdating() {
-	if ! getHubKubeconfig $SPOKE_KUBECONFIG_PATH $HUB_SECRET_NAMESPACE $HUB_SECRET_NAME; then
-		logInfo "TALM not available or hub kubeconfig is no ready yet at $SPOKE_KUBECONFIG_PATH path, cannot get spoke secret $HUB_SECRET_NAME in $HUB_SECRET_NAMESPACE namespace"
-		return "$FALSE"
-	fi
-	isZtpState "running"
-	return $?
+  if ! getHubKubeconfig $SPOKE_KUBECONFIG_PATH $HUB_SECRET_NAMESPACE $HUB_SECRET_NAME; then
+    logInfo "TALM not available or hub kubeconfig is no ready yet at $SPOKE_KUBECONFIG_PATH path, cannot get spoke secret $HUB_SECRET_NAME in $HUB_SECRET_NAMESPACE namespace"
+    return "$FALSE"
+  fi
+  isZtpState "running"
+  return $?
 }
 
 # Add a new function to the array of update detection methods

--- a/telco-ran/configuration/extra-manifests-builder/01-disk-encryption-pcr-rebind/luks-helpers.sh
+++ b/telco-ran/configuration/extra-manifests-builder/01-disk-encryption-pcr-rebind/luks-helpers.sh
@@ -15,199 +15,199 @@ FALSE=1
 # log level: debug or info
 # string to print
 log() {
-	local logLevel logText
+  local logLevel logText
 
-	logLevel="$1"
-	logText="$2"
-	case $logLevel in
-	"debug")
-		echo "DEBUG - $logText" >&2
-		;;
-	"info")
-		echo "INFO - $logText" >&2
-		;;
-	*)
-		# Code to execute when no patterns match
-		;;
-	esac
+  logLevel="$1"
+  logText="$2"
+  case $logLevel in
+  "debug")
+    echo "DEBUG - $logText" >&2
+    ;;
+  "info")
+    echo "INFO - $logText" >&2
+    ;;
+  *)
+    # Code to execute when no patterns match
+    ;;
+  esac
 }
 
 # logs a string with a debug level
 logDebug() {
-	local logText="$1"
-	if ! [ -v DEBUG ] || { [ -v DEBUG ] && [ "$DEBUG" == "true" ]; }; then
-		log "debug" "$logText"
-	fi
+  local logText="$1"
+  if ! [ -v DEBUG ] || { [ -v DEBUG ] && [ "$DEBUG" == "true" ]; }; then
+    log "debug" "$logText"
+  fi
 }
 
 # logs a string with a info level
 logInfo() {
-	local logText
+  local logText
 
-	logText="$1"
-	log "info" "$logText"
+  logText="$1"
+  log "info" "$logText"
 }
 
 # return $TRUE id the temporary reserved slot is configured with a key (to disable PCR protection), returns $FALSE otherwise
 isReservedSlotPresent() {
-	local devicePath
+  local devicePath
 
-	devicePath="$1"
-	RESULT=$($CLEVIS luks list -d "$devicePath" -s $RESERVED_SLOT || true)
-	if [ -n "$RESULT" ] && [ "$RESULT" == "$CLEVIS_CONFIG_RESERVED_SLOT" ]; then
-		logDebug "reserved slot $RESERVED_SLOT is present"
-		return $TRUE
-	fi
-	logDebug "reserved slot $RESERVED_SLOT is not present"
-	return $FALSE
+  devicePath="$1"
+  RESULT=$($CLEVIS luks list -d "$devicePath" -s $RESERVED_SLOT || true)
+  if [ -n "$RESULT" ] && [ "$RESULT" == "$CLEVIS_CONFIG_RESERVED_SLOT" ]; then
+    logDebug "reserved slot $RESERVED_SLOT is present"
+    return $TRUE
+  fi
+  logDebug "reserved slot $RESERVED_SLOT is not present"
+  return $FALSE
 }
 
 # create a temporary key in the reserved slot to disable PCR protection
 addReservedSlot() {
-	local reservedSlotPresent devicePath slot pcrIDs clevisConfig
+  local reservedSlotPresent devicePath slot pcrIDs clevisConfig
 
-	reservedSlotPresent="$1"
-	devicePath="$2"
-	slot="$3"
-	pcrIDs="$4"
-	clevisConfig="$5"
-	logInfo "reservedSlotPresent=$reservedSlotPresent device=$devicePath slot=$slot with PCR IDs=$pcrIDs and $CLEVIS config=$clevisConfig"
-	if [ "$reservedSlotPresent" == "$TRUE" ]; then
-		logInfo "reserve slot already present, no need to add again"
-		$CLEVIS luks list -d "$devicePath" || true
-		return
-	fi
-	logInfo "adding reserved slot on device=$devicePath"
-	ANYPASS=$(openssl rand -base64 21)
-	echo -e "$ANYPASS\n" | $CLEVIS luks bind -s $RESERVED_SLOT -d "$devicePath" tpm2 '{}' || true
-	$CLEVIS luks list -d "$devicePath" || true
+  reservedSlotPresent="$1"
+  devicePath="$2"
+  slot="$3"
+  pcrIDs="$4"
+  clevisConfig="$5"
+  logInfo "reservedSlotPresent=$reservedSlotPresent device=$devicePath slot=$slot with PCR IDs=$pcrIDs and $CLEVIS config=$clevisConfig"
+  if [ "$reservedSlotPresent" == "$TRUE" ]; then
+    logInfo "reserve slot already present, no need to add again"
+    $CLEVIS luks list -d "$devicePath" || true
+    return
+  fi
+  logInfo "adding reserved slot on device=$devicePath"
+  ANYPASS=$(openssl rand -base64 21)
+  echo -e "$ANYPASS\n" | $CLEVIS luks bind -s $RESERVED_SLOT -d "$devicePath" tpm2 '{}' || true
+  $CLEVIS luks list -d "$devicePath" || true
 }
 
 # remove the temporary key in the reserved slot to enable PCR protection
 removeReservedSlot() {
-	local devicePath
+  local devicePath
 
-	devicePath="$1"
-	logInfo "removing luks reserved slot 31 in disk $devicePath"
-	# do not change this line. There is a very weird behavior where variable 
-	# substitution does not work for the clevis luks unbind command
-	echo "sudo $CLEVIS luks unbind -s $RESERVED_SLOT -d $devicePath -f" | bash || true
+  devicePath="$1"
+  logInfo "removing luks reserved slot 31 in disk $devicePath"
+  # do not change this line. There is a very weird behavior where variable
+  # substitution does not work for the clevis luks unbind command
+  echo "sudo $CLEVIS luks unbind -s $RESERVED_SLOT -d $devicePath -f" | bash || true
 }
 
 #gets the list of luks devices in the system
 getLUKSDevices() {
-	local results
-	results=$($LSBLK -o NAME,FSTYPE -l | grep crypto_LUKS | awk '{printf "/dev/" $1 "|"}')
-	logDebug "got luks devices across all drives: $results"
-	echo "$results"
+  local results
+  results=$($LSBLK -o NAME,FSTYPE -l | grep crypto_LUKS | awk '{printf "/dev/" $1 "|"}')
+  logDebug "got luks devices across all drives: $results"
+  echo "$results"
 }
 
 # create a list of slot configuration for all encrypted devices in the system
 parseClevisConfig() {
-	local luksDevices IFS
+  local luksDevices IFS
 
-	luksDevices="$1"
-	IFS="|"
-	for device in $luksDevices; do
-		logDebug "device=$device"
-		isReservedSlotPresent "$device"
-		isReserved="$?"
-		pcrSlots=$(getPcrSlotsForDevice "$device")
-		logDebug "pcrSlots=$pcrSlots"
-		parseClevisRegex "$pcrSlots" "$isReserved" "$device"
-	done
+  luksDevices="$1"
+  IFS="|"
+  for device in $luksDevices; do
+    logDebug "device=$device"
+    isReservedSlotPresent "$device"
+    isReserved="$?"
+    pcrSlots=$(getPcrSlotsForDevice "$device")
+    logDebug "pcrSlots=$pcrSlots"
+    parseClevisRegex "$pcrSlots" "$isReserved" "$device"
+  done
 }
 
 getPcrSlotsForDevice() {
-	local devicePath
+  local devicePath
 
-	devicePath="$1"
+  devicePath="$1"
 
-	logDebug "getPcrSlotsForDevice, device=$devicePath"
-	$CLEVIS luks list -d "$devicePath" | grep -v "$RESERVED_SLOT:" | grep pcr_ids || true
+  logDebug "getPcrSlotsForDevice, device=$devicePath"
+  $CLEVIS luks list -d "$devicePath" | grep -v "$RESERVED_SLOT:" | grep pcr_ids || true
 }
 
 parseClevisRegex() {
-	local clevisSlotsOutputWithPCR isReserved devicePath IFS
+  local clevisSlotsOutputWithPCR isReserved devicePath IFS
 
-	clevisSlotsOutputWithPCR="$1"
-	isReserved="$2"
-	devicePath="$3"
-	IFS=$'\n'
-	for line in $clevisSlotsOutputWithPCR; do
-		logDebug "line=$line"
-		echo "$line" | sed -E 's@([0-9]+)(:\s+.*+\s+'\'')(\{)(.*?"pcr_ids":")([^"]*)(".*)(.*)('\''.*)@'"$isReserved"'|'"$devicePath"'|\1|\5|\3\4\5\6\7@'
-	done
+  clevisSlotsOutputWithPCR="$1"
+  isReserved="$2"
+  devicePath="$3"
+  IFS=$'\n'
+  for line in $clevisSlotsOutputWithPCR; do
+    logDebug "line=$line"
+    echo "$line" | sed -E 's@([0-9]+)(:\s+.*+\s+'\'')(\{)(.*?"pcr_ids":")([^"]*)(".*)(.*)('\''.*)@'"$isReserved"'|'"$devicePath"'|\1|\5|\3\4\5\6\7@'
+  done
 }
 
 # executes a function pointer passed argument "functionToRun" for each slot configured with PCR and
 # for every device in the system
 processPCRentriesOnly() {
-	local luksDevices parsedClevis functionToRun
-	functionToRun="$1"
-	luksDevices=$(getLUKSDevices)
-	parsedClevis=$(parseClevisConfig "$luksDevices")
+  local luksDevices parsedClevis functionToRun
+  functionToRun="$1"
+  luksDevices=$(getLUKSDevices)
+  parsedClevis=$(parseClevisConfig "$luksDevices")
 
-	if [ "$parsedClevis" == "" ]; then
-		logInfo "no pcr config detected, nothing to do for $functionToRun"
-		return
-	fi
-	logInfo "parsed clevis for all drives: $parsedClevis"
-	echo "$parsedClevis" | while IFS= read -r line; do
-		logDebug "$line"
-		IFS="|" read -ra values <<<"$line"
-		reservedSlotPresent=${values[0]}
-		device=${values[1]}
-		slotNumber=${values[2]}
-		pcrIDs=${values[3]}
-		clevisConfig=${values[4]}
-		logInfo "reservedSlot=$reservedSlotPresent device=$device slot=$slotNumber with PCR IDs=$pcrIDs and clevis config=$clevisConfig"
-		if [ -n "$pcrIDs" ]; then
-			logDebug "before applying command: $(/usr/bin/tpm2_pcrread sha256:"$pcrIDs")"
-			"$functionToRun" "$reservedSlotPresent" "$device" "$slotNumber" "$pcrIDs" "$clevisConfig" || true
-			logDebug "after applying command: $(/usr/bin/tpm2_pcrread sha256:"$pcrIDs")"
-		fi
-	done
+  if [ "$parsedClevis" == "" ]; then
+    logInfo "no pcr config detected, nothing to do for $functionToRun"
+    return
+  fi
+  logInfo "parsed clevis for all drives: $parsedClevis"
+  echo "$parsedClevis" | while IFS= read -r line; do
+    logDebug "$line"
+    IFS="|" read -ra values <<<"$line"
+    reservedSlotPresent=${values[0]}
+    device=${values[1]}
+    slotNumber=${values[2]}
+    pcrIDs=${values[3]}
+    clevisConfig=${values[4]}
+    logInfo "reservedSlot=$reservedSlotPresent device=$device slot=$slotNumber with PCR IDs=$pcrIDs and clevis config=$clevisConfig"
+    if [ -n "$pcrIDs" ]; then
+      logDebug "before applying command: $(/usr/bin/tpm2_pcrread sha256:"$pcrIDs")"
+      "$functionToRun" "$reservedSlotPresent" "$device" "$slotNumber" "$pcrIDs" "$clevisConfig" || true
+      logDebug "after applying command: $(/usr/bin/tpm2_pcrread sha256:"$pcrIDs")"
+    fi
+  done
 }
 
 # initialize the array of upgrade detection methods serverUpdateDetectionMethods
 initUpgradeDetectionMethods() {
-	# shellcheck source=hwupgrade-detection-methods/file.sh
-	for f in "$SCRIPT_DIR"/hwupgrade-detection-methods/*.sh; do source "$f"; done
-	logInfo "detected system upgrade detection plugins:"
-	for element in "${serverUpdateDetectionMethods[@]}"; do echo "$element"; done
+  # shellcheck source=hwupgrade-detection-methods/file.sh
+  for f in "$SCRIPT_DIR"/hwupgrade-detection-methods/*.sh; do source "$f"; done
+  logInfo "detected system upgrade detection plugins:"
+  for element in "${serverUpdateDetectionMethods[@]}"; do echo "$element"; done
 }
 
 # execute all hw upgrade detection functions in hwupgrade-detection-methods directory
 # returns true if a hw upgrade is detected
 # false otherwise
 isSystemUpdating() {
-	local isUpdating
+  local isUpdating
 
-	isUpdating=$FALSE
-	# Iterate through the updated array and call each function
-	for func in "${serverUpdateDetectionMethods[@]}"; do
-		if $func; then
-			isUpdating=$TRUE
-			logInfo "detected update via $func"
-		else
-			logInfo "no update detected via $func"
-		fi
-	done
-	return $isUpdating
+  isUpdating=$FALSE
+  # Iterate through the updated array and call each function
+  for func in "${serverUpdateDetectionMethods[@]}"; do
+    if $func; then
+      isUpdating=$TRUE
+      logInfo "detected update via $func"
+    else
+      logInfo "no update detected via $func"
+    fi
+  done
+  return $isUpdating
 }
 
 #rebinds a given key slot that is configured with PCR for a given device
 rebindPCRentriesOnly() {
-	local reservedSlotPresent devicePath slot pcrIDs clevisConfig
+  local reservedSlotPresent devicePath slot pcrIDs clevisConfig
 
-	reservedSlotPresent="$1"
-	devicePath="$2"
-	slot="$3"
-	pcrIDs="$4"
-	clevisConfig="$5"
+  reservedSlotPresent="$1"
+  devicePath="$2"
+  slot="$3"
+  pcrIDs="$4"
+  clevisConfig="$5"
 
-	logInfo "Rebinding reservedSlotPresent=$reservedSlotPresent device=$devicePath slot=$slot with PCR IDs=$pcrIDs and clevis config=$clevisConfig"
-	clevis-luks-regen -d "$devicePath" -s "$slot" -q || true
-	removeReservedSlot "$devicePath"
+  logInfo "Rebinding reservedSlotPresent=$reservedSlotPresent device=$devicePath slot=$slot with PCR IDs=$pcrIDs and clevis config=$clevisConfig"
+  clevis-luks-regen -d "$devicePath" -s "$slot" -q || true
+  removeReservedSlot "$devicePath"
 }

--- a/telco-ran/configuration/extra-manifests-builder/01-disk-encryption-pcr-rebind/test.sh
+++ b/telco-ran/configuration/extra-manifests-builder/01-disk-encryption-pcr-rebind/test.sh
@@ -7,30 +7,30 @@ DEBUG="false"
 
 # *** TEST isReservedSlotPresent ***"
 clevisTestReservedSlot() {
-	echo "$RESERVED_SLOT: tpm2 '{\"hash\":\"sha256\",\"key\":\"ecc\"}'"
+  echo "$RESERVED_SLOT: tpm2 '{\"hash\":\"sha256\",\"key\":\"ecc\"}'"
 }
 
 testIsReservedSlotPresent() {
-	local EXPECTED results
-	echo "*** TEST isReservedSlotPresent ***"
-	CLEVIS=clevisTestReservedSlot
-	EXPECTED=0
+  local EXPECTED results
+  echo "*** TEST isReservedSlotPresent ***"
+  CLEVIS=clevisTestReservedSlot
+  EXPECTED=0
 
-	isReservedSlotPresent "/dev/sda"
-	results=$?
-	if [ "$results" = "$EXPECTED" ]; then
-		echo "PASS"
-		return "$TRUE"
-	fi
-	echo "FAILED"
-	echo "$results"
-	return "$FALSE"
+  isReservedSlotPresent "/dev/sda"
+  results=$?
+  if [ "$results" = "$EXPECTED" ]; then
+    echo "PASS"
+    return "$TRUE"
+  fi
+  echo "FAILED"
+  echo "$results"
+  return "$FALSE"
 }
 
 # *** TEST getLUKSDevices ***"
 lsblkSlF() {
-	# lsblk -o NAME,FSTYPE -l
-	echo "nvme0n1                                   
+  # lsblk -o NAME,FSTYPE -l
+  echo "nvme0n1                                   
 nvme0n1p1                                 vfat
 nvme0n1p2                                 ext4
 nvme0n1p3                                 crypto_LUKS
@@ -38,83 +38,83 @@ nvme0n1p3                                 crypto_LUKS
 }
 
 testGetLUKSDevices() {
-	local LSBLK EXPECTED results
-	LSBLK=lsblkSlF
+  local LSBLK EXPECTED results
+  LSBLK=lsblkSlF
 
-	echo "*** TEST getLUKSDevices ***"
-	EXPECTED="/dev/nvme0n1p3|"
+  echo "*** TEST getLUKSDevices ***"
+  EXPECTED="/dev/nvme0n1p3|"
 
-	results=$(getLUKSDevices)
-	if [ "$results" = "$EXPECTED" ]; then
-		echo "PASS"
-		return "$TRUE"
-	fi
-	echo "FAILED"
-	echo "$results"
-	return "$FALSE"
+  results=$(getLUKSDevices)
+  if [ "$results" = "$EXPECTED" ]; then
+    echo "PASS"
+    return "$TRUE"
+  fi
+  echo "FAILED"
+  echo "$results"
+  return "$FALSE"
 }
 
 # *** TEST getPcrSlotsForDevice ***
 clevisTestPcrSlotsForDevice() {
-	local out
+  local out
 
-	read -r -d '' out <<EOM || true
+  read -r -d '' out <<EOM || true
 1: tpm2 '{"hash":"sha256","key":"ecc","pcr_bank":"sha256","pcr_ids":"1,7"}'
 2: tpm2 '{"hash":"sha256","key":"ecc","pcr_bank":"sha256"}'
 3: sss '{"t":2,"pins":{"tpm2":[{"hash":"sha256","key":"ecc","pcr_bank":"sha256","pcr_ids":"1,7,8"}],"sss":{"t":1,"pins":{"tang":[{"url":"http://192.168.28.12:8081"}]}}}}'
 EOM
-	echo "$out"
+  echo "$out"
 }
 
 testGetPcrSlotsForDevice() {
-	local CLEVIS EXPECTED results
-	CLEVIS=clevisTestPcrSlotsForDevice
+  local CLEVIS EXPECTED results
+  CLEVIS=clevisTestPcrSlotsForDevice
 
-	echo "*** TEST getPcrSlotsForDevice ***"
-	read -r -d '' EXPECTED <<EOM || true
+  echo "*** TEST getPcrSlotsForDevice ***"
+  read -r -d '' EXPECTED <<EOM || true
 1: tpm2 '{"hash":"sha256","key":"ecc","pcr_bank":"sha256","pcr_ids":"1,7"}'
 3: sss '{"t":2,"pins":{"tpm2":[{"hash":"sha256","key":"ecc","pcr_bank":"sha256","pcr_ids":"1,7,8"}],"sss":{"t":1,"pins":{"tang":[{"url":"http://192.168.28.12:8081"}]}}}}'
 EOM
-	results=$(getPcrSlotsForDevice "/dev/sda")
-	if [ "$results" = "$EXPECTED" ]; then
-		echo "PASS"
-		return "$TRUE"
-	fi
-	echo "FAILED"
-	echo "$results"
-	return "$FALSE"
+  results=$(getPcrSlotsForDevice "/dev/sda")
+  if [ "$results" = "$EXPECTED" ]; then
+    echo "PASS"
+    return "$TRUE"
+  fi
+  echo "FAILED"
+  echo "$results"
+  return "$FALSE"
 }
 
 # *** TEST parseClevisConfig ***
 clevisParseClevisConfig() {
-	local out
+  local out
 
-	read -r -d '' out <<EOM || true
+  read -r -d '' out <<EOM || true
 1: tpm2 '{"hash":"sha256","key":"ecc","pcr_bank":"sha256","pcr_ids":"1,7"}'
 2: tpm2 '{"hash":"sha256","key":"ecc","pcr_bank":"sha256","pcr_ids":"1,7"}'
 3: sss '{"t":2,"pins":{"tpm2":[{"hash":"sha256","key":"ecc","pcr_bank":"sha256","pcr_ids":"1,7,8"}],"sss":{"t":1,"pins":{"tang":[{"url":"http://192.168.28.12:8081"}]}}}}'
 EOM
-	echo "$out"
+  echo "$out"
 }
 
 testParseClevisConfig() {
-	local CLEVIS EXPECTED results
-	CLEVIS=clevisParseClevisConfig
+  local CLEVIS EXPECTED results
+  CLEVIS=clevisParseClevisConfig
 
-	echo "*** TEST parseClevisConfig ***"
-	read -r -d '' EXPECTED <<EOM || true
+  echo "*** TEST parseClevisConfig ***"
+  read -r -d '' EXPECTED <<EOM || true
 1|/dev/sda4|1|1,7|{"hash":"sha256","key":"ecc","pcr_bank":"sha256","pcr_ids":"1,7"}
 1|/dev/sda4|2|1,7|{"hash":"sha256","key":"ecc","pcr_bank":"sha256","pcr_ids":"1,7"}
 1|/dev/sda4|3|1,7,8|{"t":2,"pins":{"tpm2":[{"hash":"sha256","key":"ecc","pcr_bank":"sha256","pcr_ids":"1,7,8"}],"sss":{"t":1,"pins":{"tang":[{"url":"http://192.168.28.12:8081"}]}}}}
 EOM
-	results=$(parseClevisConfig "/dev/sda4")
-	if [ "$results" = "$EXPECTED" ]; then
-		echo "PASS"
-		return "$TRUE"
-	fi
-	echo "FAILED"
-	echo "$results"
-	return "$FALSE"
+  results=$(parseClevisConfig "/dev/sda4")
+  if [ "$results" = "$EXPECTED" ]; then
+    echo "PASS"
+    return "$TRUE"
+  fi
+  echo "FAILED"
+  echo "$results"
+  return "$FALSE"
 }
 
 testIsReservedSlotPresent

--- a/telco-ran/configuration/extra-manifests-builder/08-set-rcu-normal/build.sh
+++ b/telco-ran/configuration/extra-manifests-builder/08-set-rcu-normal/build.sh
@@ -6,5 +6,5 @@ MCMAKER=${MCMAKER:-${GOBIN}/mcmaker}
 MCPROLE=${MCPROLE:-master}
 
 ${MCMAKER} -stdout -name 08-set-rcu-normal -mcp ${MCPROLE} \
-	file -source set-rcu-normal.sh -path /usr/local/bin/set-rcu-normal.sh -mode 0755 \
-	unit -source set-rcu-normal.service
+  file -source set-rcu-normal.sh -path /usr/local/bin/set-rcu-normal.sh -mode 0755 \
+  unit -source set-rcu-normal.service

--- a/telco-ran/configuration/extra-manifests-builder/08-set-rcu-normal/set-rcu-normal.sh
+++ b/telco-ran/configuration/extra-manifests-builder/08-set-rcu-normal/set-rcu-normal.sh
@@ -32,25 +32,25 @@ STEADY_STATE_MINIMUM=${STEADY_STATE_MINIMUM:-0}
 within() {
   local last=$1 current=$2 threshold=$3
   local delta=0 pchange
-  delta=$(( current - last ))
+  delta=$((current - last))
   if [[ $current -eq $last ]]; then
     pchange=0
   elif [[ $last -eq 0 ]]; then
     pchange=1000000
   else
-    pchange=$(( ( "$delta" * 100) / last ))
+    pchange=$((("$delta" * 100) / last))
   fi
   echo -n "last:$last current:$current delta:$delta pchange:${pchange}%: "
   local absolute limit
   case $threshold in
-    *%)
-      absolute=${pchange##-} # absolute value
-      limit=${threshold%%%}
-      ;;
-    *)
-      absolute=${delta##-} # absolute value
-      limit=$threshold
-      ;;
+  *%)
+    absolute=${pchange##-} # absolute value
+    limit=${threshold%%%}
+    ;;
+  *)
+    absolute=${delta##-} # absolute value
+    limit=$threshold
+    ;;
   esac
   if [[ $absolute -le $limit ]]; then
     echo "within (+/-)$threshold"
@@ -99,7 +99,7 @@ waitForReady() {
 
 setRcuNormal() {
   echo "Setting rcu_normal to 1"
-  echo 1 > /sys/kernel/rcu_normal
+  echo 1 >/sys/kernel/rcu_normal
 }
 
 main() {

--- a/telco-ran/configuration/extra-manifests-builder/08-set-rcu-normal/test.sh
+++ b/telco-ran/configuration/extra-manifests-builder/08-set-rcu-normal/test.sh
@@ -12,7 +12,8 @@ rc=$?
 echo Ok
 
 test_within() {
-  local expected=$1; shift
+  local expected=$1
+  shift
   within "$@"
   rc=$?
   [[ $rc -eq $expected ]] || fatal "within failed: Expected rc $expected != $rc"

--- a/telco-ran/configuration/extra-manifests-builder/Makefile
+++ b/telco-ran/configuration/extra-manifests-builder/Makefile
@@ -12,7 +12,7 @@ GEN_TGTS := $(foreach role,master worker,$(patsubst %/,$(DST)/%-$(role).yaml,$(G
 CHK_TGTS := $(foreach role,master worker,$(patsubst %/,$(CHK)/%-$(role).diff,$(GEN_DIRS)))
 TESTS := $(wildcard */test.sh)
 
-.PHONY: all clean force cleanchk check test
+.PHONY: all clean force cleanchk check test lint
 
 all: test $(GEN_TGTS)
 
@@ -25,6 +25,10 @@ cleanchk:
 	rm -rf $(CHK)
 
 check: cleanchk $(CHK_TGTS) test
+
+lint:
+	@command -v shfmt >/dev/null 2>&1 || { echo >&2 "shfmt is not installed. Please install it to run lint."; exit 1; }
+	@find . -type f -name '*.sh' -print0 | xargs -0 shfmt -d
 
 define GENERATOR_TEMPLATE =
 $(1)/%-$(2).yaml: %/build.sh %/*


### PR DESCRIPTION
Notable changes: 
- Adding a Github Actions workflow for linting shell scripts in this repo.
- Ran `shfmt -w` against the shell scripts in this repo so they pass the linter.
- Added some Makefile lint paths.

### Shell Formatting Enhancements:
* [`.github/workflows/pre-main.yml`](diffhunk://#diff-86d0e085d25794165165c5c4a8ada1e89ffa9d9e05724f710a26d5c2d28fb886R1-R27): Added a new GitHub Actions workflow named "Shell Format Check" to validate shell script formatting using `shfmt` on pull requests and pushes to the `main` branch.

### Makefile Updates:
* [`telco-ran/configuration/Makefile`](diffhunk://#diff-6460edb57c38c8c8c03b7f9c8415aa432f57330b7afe582429e401e75f17052fR44-R47): Introduced a new `lint` target to check shell script formatting with `shfmt`.
* [`telco-ran/configuration/extra-manifests-builder/Makefile`](diffhunk://#diff-87e93fd00129f37adda845f0e11d73fa8bd3b83d3a92bc53c4ae067b4b767a48L15-R15): Added a `lint` target for shell formatting checks and updated `.PHONY` to include `lint`. [[1]](diffhunk://#diff-87e93fd00129f37adda845f0e11d73fa8bd3b83d3a92bc53c4ae067b4b767a48L15-R15) [[2]](diffhunk://#diff-87e93fd00129f37adda845f0e11d73fa8bd3b83d3a92bc53c4ae067b4b767a48R29-R32)

### Code Style Improvements:
* [`telco-ran/configuration/extra-manifests-builder/08-set-rcu-normal/test.sh`](diffhunk://#diff-fd9274aae5d891c1959f9089a9cf9dcc4daa2ed39e0c1c16f9b8ddc69522c47cL15-R16): Adjusted indentation and spacing for better readability and consistency.
* [`telco-ran/configuration/Makefile`](diffhunk://#diff-6460edb57c38c8c8c03b7f9c8415aa432f57330b7afe582429e401e75f17052fL11-R16): Simplified and standardized conditional checks in the `checkSourceCRsAnnotation` target.

These changes collectively aim to improve code quality, enforce consistent formatting, and streamline development workflows.