### PR TITLE
OCPBUGS-56873: core RDS: Allow 'avoidBuggyIps' in metallb IpAddressPools

### DIFF
--- a/telco-core/configuration/reference-crs-kube-compare/required/networking/metallb/addr-pool.yaml
+++ b/telco-core/configuration/reference-crs-kube-compare/required/networking/metallb/addr-pool.yaml
@@ -11,5 +11,10 @@ spec:
 {{ .spec.addresses | toYaml | indent 2}}
 {{ end }}
   #- 3.3.3.0/24
-  autoAssign: true
+{{ if .spec.autoAssign }}
+  autoAssign: {{ .spec.autoAssign }}
+{{ end }}
+{{ if .spec.avoidBuggyIPs }}
+  avoidBuggyIps: {{ .spec.avoidBuggyIPs }}
+{{ end }}
   ##############


### PR DESCRIPTION
Signed-off-by: Jim Ramsay <jramsay@redhat.com>
