### PR TITLE
add .containerignore

### DIFF
--- a/.containerignore
+++ b/.containerignore
@@ -1,1 +1,2 @@
 telco-core/Dockerfile.telco-core
+telco-hub/Dockerfile.telco-hub


### PR DESCRIPTION
This is needed to ensure the telco hub dockerfile is not being copied to the build image.