### PR TITLE
Main hub to 4.19

### DIFF
--- a/telco-hub/configuration/reference-crs/required/acm/acmAgentServiceConfig.yaml
+++ b/telco-hub/configuration/reference-crs/required/acm/acmAgentServiceConfig.yaml
@@ -34,11 +34,6 @@ spec:
   # Replace <http-server-address:port> with the address of the local web server that stores the RHCOS images.
   # The images can be downloaded from "https://mirror.openshift.com/pub/openshift-v4/x86_64/dependencies/rhcos/".
   - cpuArchitecture: "x86_64"
-    openshiftVersion: "4.16"
-    rootFSUrl: https://<http-server-address:port>/rhcos-4.16.0-x86_64-live-rootfs.x86_64.img
-    url: https://<http-server-address:port>/rhcos-4.16.0-x86_64-live.x86_64.iso
-    version: "416.94.202406172220-0"
-  - cpuArchitecture: "x86_64"
     openshiftVersion: "4.17"
     rootFSUrl: http://<http-server-address:port>/rhcos-4.17.0-x86_64-live-rootfs.x86_64.img
     url: http://<http-server-address:port>/rhcos-4.17.0-x86_64-live.x86_64.iso

--- a/telco-hub/configuration/reference-crs/required/acm/acmAgentServiceConfig.yaml
+++ b/telco-hub/configuration/reference-crs/required/acm/acmAgentServiceConfig.yaml
@@ -48,3 +48,8 @@ spec:
     rootFSUrl: http://<http-server-address:port>/rhcos-4.18.0-x86_64-live-rootfs.x86_64.img
     url: http://<http-server-address:port>/rhcos-4.18.0-x86_64-live.x86_64.iso
     version: "418.94.202502100215-0"
+  - cpuArchitecture: "x86_64"
+    openshiftVersion: "4.19"
+    rootFSUrl: http://<http-server-address:port>/rhcos-4.19.0-x86_64-live-rootfs.x86_64.img
+    url: http://<http-server-address:port>/rhcos-4.19.0-x86_64-live.x86_64.iso
+    version: "9.6.20250530-0"

--- a/telco-hub/configuration/reference-crs/required/acm/acmPerfSearch.yaml
+++ b/telco-hub/configuration/reference-crs/required/acm/acmPerfSearch.yaml
@@ -1,3 +1,4 @@
+---
 apiVersion: search.open-cluster-management.io/v1alpha1
 kind: Search
 metadata:

--- a/telco-hub/configuration/reference-crs/required/acm/acmPerfSearch.yaml
+++ b/telco-hub/configuration/reference-crs/required/acm/acmPerfSearch.yaml
@@ -1,4 +1,3 @@
----
 apiVersion: search.open-cluster-management.io/v1alpha1
 kind: Search
 metadata:

--- a/telco-hub/configuration/reference-crs/required/acm/observabilityMCO.yaml
+++ b/telco-hub/configuration/reference-crs/required/acm/observabilityMCO.yaml
@@ -15,11 +15,10 @@ spec:
   # based on the data provided by acm-capacity tool
   # https://github.com/stolostron/capacity-planning/blob/main/calculation/ObsSizingTemplate-Rev1.ipynb
   # for an scenario with:
-  # 3500SNOs, 125 pods and 4 Namespaces (apart from Openshift NS)
-  # storage retention 15 days
+  # 3500SNOs, 125 pods and 5 Namespaces (apart from Openshift NS)
+  # storage retention 365 days
   # downsampling disabled
   # default MCO Addon configuration samples_per_hour, pv_retention_hrs.
-  # More on how to stimate: https://access.redhat.com/articles/7103886
   advanced:
     retentionConfig:
       blockDuration: 2h
@@ -35,6 +34,8 @@ spec:
     alertmanagerStorageSize: 10Gi
     compactStorageSize: 100Gi
     metricObjectStorage:
+      # buckets storage should provide a capacity
+      # of at least 2.5TB
       key: thanos.yaml
       name: thanos-object-storage
     receiveStorageSize: 10Gi

--- a/telco-hub/configuration/reference-crs/required/gitops/get_ztp_installation.sh
+++ b/telco-hub/configuration/reference-crs/required/gitops/get_ztp_installation.sh
@@ -1,16 +1,26 @@
 #! /bin/bash
+set -euo pipefail
 
 # This script is only needed to create the ztp-installation manifest
 # once per each Minor version.
 
-#CURRENT_OCP_VERSION=4.18
-#ZTP_SITE_GENERATE_IMAGE=ztp-site-generate-rhel8:v${CURRENT_OCP_VERSION}
-#podman run --log-driver=none --rm registry.redhat.io/openshift4/${ZTP_SITE_GENERATE_IMAGE=ztp-site-generate-rhel8} extract /home/ztp/argocd/deployment --tar | tar x -C "ztp-installation"
-
 rm ztp-installation/*
+
+# we create the manifests from the 'telco-ran/configuration/argocd/deployment/'"
+
 cp ../../../../../telco-ran/configuration/argocd/deployment/* ztp-installation/
 echo "Manifests created from 'telco-ran/configuration/argocd/deployment/'"
+
 # some generated manifests are not needed
 echo " - Removing some manifests not needed: allow-acm-managedcluster-control.json, disable-cluster-proxy-addon.json, openshift-gitops-operator.yaml"
 rm ztp-installation/allow-acm-managedcluster-control.json ztp-installation/disable-cluster-proxy-addon.json ztp-installation/openshift-gitops-operator.yaml
+
+# following changes are temporal, these should come from the original source
+# we add some needed waves
+echo " - Adding ztp-waves."
+find ./ztp-installation/ -name "*.yaml" -exec yq -i eval '.metadata.annotations."argocd.argoproj.io/sync-wave" = "100"' {} \;
+
+# patch the ztp-site-generate version
+echo " - Patch ztp-site-generate version"
+sed -i 's|quay.io/openshift-kni/ztp-site-generator:latest|registry.redhat.io/openshift4/ztp-site-generate-rhel8:v4.19|g' ztp-installation/argocd-openshift-gitops-patch.json
 

--- a/telco-hub/configuration/reference-crs/required/gitops/get_ztp_installation.sh
+++ b/telco-hub/configuration/reference-crs/required/gitops/get_ztp_installation.sh
@@ -1,16 +1,15 @@
 #! /bin/bash
-set -euo pipefail
 
 # This script is only needed to create the ztp-installation manifest
 # once per each Minor version.
 
+#CURRENT_OCP_VERSION=4.18
+#ZTP_SITE_GENERATE_IMAGE=ztp-site-generate-rhel8:v${CURRENT_OCP_VERSION}
+#podman run --log-driver=none --rm registry.redhat.io/openshift4/${ZTP_SITE_GENERATE_IMAGE=ztp-site-generate-rhel8} extract /home/ztp/argocd/deployment --tar | tar x -C "ztp-installation"
+
 rm ztp-installation/*
-
-# we create the manifests from the 'telco-ran/configuration/argocd/deployment/'"
-
 cp ../../../../../telco-ran/configuration/argocd/deployment/* ztp-installation/
 echo "Manifests created from 'telco-ran/configuration/argocd/deployment/'"
-
 # some generated manifests are not needed
 echo " - Removing some manifests not needed: allow-acm-managedcluster-control.json, disable-cluster-proxy-addon.json, openshift-gitops-operator.yaml"
 rm ztp-installation/allow-acm-managedcluster-control.json ztp-installation/disable-cluster-proxy-addon.json ztp-installation/openshift-gitops-operator.yaml

--- a/telco-hub/configuration/reference-crs/required/gitops/gitopsSubscription.yaml
+++ b/telco-hub/configuration/reference-crs/required/gitops/gitopsSubscription.yaml
@@ -5,7 +5,7 @@ metadata:
   name: openshift-gitops-operator
   namespace: openshift-gitops-operator
 spec:
-  channel: gitops-1.15
+  channel: gitops-1.16
   installPlanApproval: Automatic
   name: openshift-gitops-operator
   source: redhat-operators-disconnected

--- a/telco-hub/configuration/reference-crs/required/gitops/ztp-installation/app-project.yaml
+++ b/telco-hub/configuration/reference-crs/required/gitops/ztp-installation/app-project.yaml
@@ -8,45 +8,41 @@ metadata:
     argocd.argoproj.io/sync-wave: "100"
 spec:
   clusterResourceWhitelist:
-  - group: 'hive.openshift.io'
-    kind: ClusterImageSet
-  - group: 'cluster.open-cluster-management.io'
-    kind: ManagedCluster
-  - group: ''
-    kind: Namespace
+    - group: 'hive.openshift.io'
+      kind: ClusterImageSet
+    - group: 'cluster.open-cluster-management.io'
+      kind: ManagedCluster
+    - group: ''
+      kind: Namespace
   destinations:
-  - namespace: '*'
-    server: '*'
+    - namespace: '*'
+      server: '*'
   namespaceResourceWhitelist:
-  - group: ''
-    kind: ConfigMap
-  - group: ''
-    kind: Namespace
-  - group: ''
-    kind: Secret
-  - group: 'agent-install.openshift.io'
-    kind: InfraEnv
-  - group: 'agent-install.openshift.io'
-    kind: NMStateConfig
-  - group: 'extensions.hive.openshift.io'
-    kind: AgentClusterInstall
-  - group: 'extensions.hive.openshift.io'
-    kind: ImageClusterInstall
-  - group: 'hive.openshift.io'
-    kind: ClusterDeployment
-  - group: 'metal3.io'
-    kind: BareMetalHost
-  - group: 'metal3.io'
-    kind: HostFirmwareSettings
-  - group: 'metal3.io'
-    kind: DataImage
-  - group: 'agent.open-cluster-management.io'
-    kind: KlusterletAddonConfig
-  - group: 'cluster.open-cluster-management.io'
-    kind: ManagedCluster
-  - group: 'ran.openshift.io'
-    kind: SiteConfig
-  - group: 'siteconfig.open-cluster-management.io'
-    kind: ClusterInstance
+    - group: ''
+      kind: ConfigMap
+    - group: ''
+      kind: Namespace
+    - group: ''
+      kind: Secret
+    - group: 'agent-install.openshift.io'
+      kind: InfraEnv
+    - group: 'agent-install.openshift.io'
+      kind: NMStateConfig
+    - group: 'extensions.hive.openshift.io'
+      kind: AgentClusterInstall
+    - group: 'hive.openshift.io'
+      kind: ClusterDeployment
+    - group: 'metal3.io'
+      kind: BareMetalHost
+    - group: 'metal3.io'
+      kind: HostFirmwareSettings
+    - group: 'agent.open-cluster-management.io'
+      kind: KlusterletAddonConfig
+    - group: 'cluster.open-cluster-management.io'
+      kind: ManagedCluster
+    - group: 'ran.openshift.io'
+      kind: SiteConfig
+    - group: 'siteconfig.open-cluster-management.io'
+      kind: ClusterInstance
   sourceRepos:
-  - '*'
+    - '*'

--- a/telco-hub/configuration/reference-crs/required/gitops/ztp-installation/argocd-openshift-gitops-patch.json
+++ b/telco-hub/configuration/reference-crs/required/gitops/ztp-installation/argocd-openshift-gitops-patch.json
@@ -40,7 +40,7 @@
             }
           ],
           "terminationMessagePolicy": "File",
-          "image": "registry.redhat.io/openshift4/ztp-site-generate-rhel8:v4.18"
+          "image": "registry.redhat.io/openshift4/ztp-site-generate-rhel8:v4.19"
         },
         {
           "args": [

--- a/telco-hub/configuration/reference-crs/required/gitops/ztp-installation/clusters-app.yaml
+++ b/telco-hub/configuration/reference-crs/required/gitops/ztp-installation/clusters-app.yaml
@@ -22,19 +22,20 @@ spec:
     path: ztp/gitops-subscriptions/argocd/example/siteconfig
     repoURL: https://github.com/openshift-kni/cnf-features-deploy
     targetRevision: master
-  # uncomment the below plugin if you will be adding the plugin binaries in the same repo->dir where
-  # the sitconfig.yaml exist AND use the ../../hack/patch-argocd-dev.sh script to re-patch the deployment-repo-server
+    # uncomment the below plugin if you will be adding the plugin binaries in the same repo->dir where
+    # the sitconfig.yaml exist AND use the ../../hack/patch-argocd-dev.sh script to re-patch the deployment-repo-server
   #    plugin:
   #      name: kustomize-with-local-plugins
-  ignoreDifferences:  # recommended way to allow ACM controller to manage its fields. alternative approach documented below (1)
+
+  ignoreDifferences: # recommended way to allow ACM controller to manage its fields. alternative approach documented below (1)
     - group: cluster.open-cluster-management.io
       kind: ManagedCluster
       managedFieldsManagers:
         - controller
-  # (1) alternatively you can choose to ignore a specific path like so (replace managedFieldsManagers with jsonPointers)
-  #      jsonPointers:
-  #        - /metadata/labels/cloud
-  #        - /metadata/labels/vendor
+        # (1) alternatively you can choose to ignore a specific path like so (replace managedFieldsManagers with jsonPointers)
+        #      jsonPointers:
+        #        - /metadata/labels/cloud
+        #        - /metadata/labels/vendor
   syncPolicy:
     automated:
       prune: true

--- a/telco-hub/configuration/reference-crs/required/gitops/ztp-installation/gitops-cluster-rolebinding.yaml
+++ b/telco-hub/configuration/reference-crs/required/gitops/ztp-installation/gitops-cluster-rolebinding.yaml
@@ -10,6 +10,6 @@ roleRef:
   kind: ClusterRole
   name: cluster-admin
 subjects:
-- kind: ServiceAccount
-  name: openshift-gitops-argocd-application-controller
-  namespace: openshift-gitops
+  - kind: ServiceAccount
+    name: openshift-gitops-argocd-application-controller
+    namespace: openshift-gitops

--- a/telco-hub/configuration/reference-crs/required/gitops/ztp-installation/gitops-policy-rolebinding.yaml
+++ b/telco-hub/configuration/reference-crs/required/gitops/ztp-installation/gitops-policy-rolebinding.yaml
@@ -10,6 +10,6 @@ roleRef:
   kind: ClusterRole
   name: open-cluster-management:cluster-manager-admin
 subjects:
-- kind: ServiceAccount
-  name: openshift-gitops-argocd-application-controller
-  namespace: openshift-gitops
+  - kind: ServiceAccount
+    name: openshift-gitops-argocd-application-controller
+    namespace: openshift-gitops

--- a/telco-hub/configuration/reference-crs/required/gitops/ztp-installation/kustomization.yaml
+++ b/telco-hub/configuration/reference-crs/required/gitops/ztp-installation/kustomization.yaml
@@ -1,7 +1,6 @@
 ---
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
-
 resources:
   - app-project.yaml
   - policies-app-project.yaml
@@ -9,3 +8,6 @@ resources:
   - gitops-cluster-rolebinding.yaml
   - clusters-app.yaml
   - policies-app.yaml
+metadata:
+  annotations:
+    argocd.argoproj.io/sync-wave: "100"

--- a/telco-hub/configuration/reference-crs/required/gitops/ztp-installation/policies-app-project.yaml
+++ b/telco-hub/configuration/reference-crs/required/gitops/ztp-installation/policies-app-project.yaml
@@ -8,35 +8,35 @@ metadata:
     argocd.argoproj.io/sync-wave: "100"
 spec:
   clusterResourceWhitelist:
-  - group: ''
-    kind: Namespace
-  - group: 'hive.openshift.io'
-    kind: ClusterImageSet
+    - group: ''
+      kind: Namespace
+    - group: 'hive.openshift.io'
+      kind: ClusterImageSet
   destinations:
-  - namespace: 'ztp*'
-    server: '*'
-  - namespace: 'policies-sub'
-    server: '*'
+    - namespace: 'ztp*'
+      server: '*'
+    - namespace: 'policies-sub'
+      server: '*'
   namespaceResourceWhitelist:
-  - group: ''
-    kind: ConfigMap
-  - group: ''
-    kind: Namespace
-  - group: 'apps.open-cluster-management.io'
-    kind: PlacementRule
-  - group: 'policy.open-cluster-management.io'
-    kind: Policy
-  - group: 'policy.open-cluster-management.io'
-    kind: PlacementBinding
-  - group: 'ran.openshift.io'
-    kind: PolicyGenTemplate
-  - group: cluster.open-cluster-management.io
-    kind: Placement
-  - group: policy.open-cluster-management.io
-    kind: PolicyGenerator
-  - group: policy.open-cluster-management.io
-    kind: PolicySet
-  - group: cluster.open-cluster-management.io
-    kind: ManagedClusterSetBinding
+    - group: ''
+      kind: ConfigMap
+    - group: ''
+      kind: Namespace
+    - group: 'apps.open-cluster-management.io'
+      kind: PlacementRule
+    - group: 'policy.open-cluster-management.io'
+      kind: Policy
+    - group: 'policy.open-cluster-management.io'
+      kind: PlacementBinding
+    - group: 'ran.openshift.io'
+      kind: PolicyGenTemplate
+    - group: cluster.open-cluster-management.io
+      kind: Placement
+    - group: policy.open-cluster-management.io
+      kind: PolicyGenerator
+    - group: policy.open-cluster-management.io
+      kind: PolicySet
+    - group: cluster.open-cluster-management.io
+      kind: ManagedClusterSetBinding
   sourceRepos:
-  - '*'
+    - '*'

--- a/telco-hub/configuration/reference-crs/required/gitops/ztp-installation/policies-app.yaml
+++ b/telco-hub/configuration/reference-crs/required/gitops/ztp-installation/policies-app.yaml
@@ -31,4 +31,4 @@ spec:
       prune: true
       selfHeal: true
     syncOptions:
-    - CreateNamespace=true
+      - CreateNamespace=true

--- a/telco-hub/install/mirror-registry/imageset-config.yaml
+++ b/telco-hub/install/mirror-registry/imageset-config.yaml
@@ -4,12 +4,12 @@ apiVersion: mirror.openshift.io/v2alpha1
 mirror:
   platform:
     channels:
-    - name: stable-4.18
+    - name: stable-4.19
       type: ocp
-      minVersion: 4.18.11
-      maxVersion: 4.18.11
+      minVersion: 4.19.0
+      maxVersion: 4.19.0
   operators:
-  - catalog: registry.redhat.io/redhat/redhat-operator-index:v4.18
+  - catalog: registry.redhat.io/redhat/redhat-operator-index:v4.19
     targetCatalog: openshift-marketplace/redhat-operators-disconnected
     packages:
     - name: advanced-cluster-management
@@ -25,9 +25,6 @@ mirror:
       channels:
       - name: stable
     - name: odf-operator
-      channels:
-      - name: stable-4.18
-    - name: odf-dependencies
       channels:
       - name: stable-4.18
     - name: odf-csi-addons-operator
@@ -63,13 +60,7 @@ mirror:
     - name: recipe
       channels:
       - name: stable-4.18
-    - name: openshift-gitops-operator
-      channels:
-      - name: gitops-1.15
-    - name: redhat-oadp-operator
-      channels:
-      - name: stable-1.4
   additionalImages:
   - name: registry.redhat.io/ubi8/ubi:latest
-  - name: registry.redhat.io/openshift4/ztp-site-generate-rhel8:v4.18.0
-  - name: registry.redhat.io/rhel8/support-tools:8.9-7
+  - name: registry.redhat.io/openshift4/ztp-site-generate-rhel8:v4.19
+  helm: {}


### PR DESCRIPTION
The telco-hub main branch is currently not clear about which versions contains. This PR should convert the main into 4.19.
After that, it should be easier to have the branch `release-4.19` and updated branch, with all the needed 4.19 content. 