### PR TITLE
telco-hub: add overlay for ACM mirror registry config

### DIFF
--- a/telco-hub/configuration/example-overlays-config/acm/acmMirrorRegistryCM-patch.yaml
+++ b/telco-hub/configuration/example-overlays-config/acm/acmMirrorRegistryCM-patch.yaml
@@ -1,0 +1,132 @@
+- op: replace
+  path: /data/ca-bundle.crt
+  value: |
+    -----BEGIN CERTIFICATE-----
+    MIIDzTCCArWgAwIBAgkx...
+    -----END CERTIFICATE-----
+    -----BEGIN CERTIFICATE-----
+    MIIEGTCCAwGgAwIBAgIU...
+    -----END CERTIFICATE-----
+- op: replace
+  path: /data/registries.conf
+  value: |
+    unqualified-search-registries = ["registry.access.redhat.com", "docker.io"]
+    [[registry]]
+      prefix = ""
+      location = "quay.io/openshift-release-dev/ocp-release"
+
+      [[registry.mirror]]
+        location = "<registry.example.com:8443>/openshift/release-images"
+        pull-from-mirror = "digest-only"
+
+    [[registry]]
+      prefix = ""
+      location = "quay.io/openshift-release-dev/ocp-v4.0-art-dev"
+
+      [[registry.mirror]]
+        location = "<registry.example.com:8443>/openshift/release"
+        pull-from-mirror = "digest-only"
+
+    [[registry]]
+      prefix = ""
+      location = "registry.redhat.io/multicluster-engine"
+
+      [[registry.mirror]]
+        location = "<registry.example.com:8443>/multicluster-engine"
+        pull-from-mirror = "digest-only"
+
+    [[registry]]
+      prefix = ""
+      location = "registry.redhat.io/odf4"
+
+      [[registry.mirror]]
+        location = "<registry.example.com:8443>/odf4"
+        pull-from-mirror = "digest-only"
+
+    [[registry]]
+      prefix = ""
+      location = "registry.redhat.io/openshift4"
+
+      [[registry.mirror]]
+        location = "<registry.example.com:8443>/openshift4"
+        pull-from-mirror = "digest-only"
+
+    [[registry]]
+      prefix = ""
+      location = "registry.redhat.io/rhacm2"
+
+      [[registry.mirror]]
+        location = "<registry.example.com:8443>/rhacm2"
+        pull-from-mirror = "digest-only"
+
+    [[registry]]
+      prefix = ""
+      location = "registry.redhat.io/rhceph"
+
+      [[registry.mirror]]
+        location = "<registry.example.com:8443>/rhceph"
+        pull-from-mirror = "digest-only"
+
+    [[registry]]
+      prefix = ""
+      location = "registry.redhat.io/rhel8"
+
+      [[registry.mirror]]
+        location = "<registry.example.com:8443>/rhel8"
+        pull-from-mirror = "digest-only"
+
+    [[registry]]
+      prefix = ""
+      location = "registry.redhat.io/rhel9"
+
+      [[registry.mirror]]
+        location = "<registry.example.com:8443>/rhel9"
+        pull-from-mirror = "digest-only"
+
+    [[registry]]
+      prefix = ""
+      location = "registry.redhat.io/ubi9"
+
+      [[registry.mirror]]
+        location = "<registry.example.com:8443>/ubi9"
+        pull-from-mirror = "tag-only"
+
+    [[registry]]
+      prefix = ""
+      location = "registry.redhat.io/ubi8"
+
+      [[registry.mirror]]
+        location = "<registry.example.com:8443>/ubi8"
+        pull-from-mirror = "tag-only"
+
+    [[registry]]
+      prefix = ""
+      location = "registry.redhat.io/oadp"
+
+      [[registry.mirror]]
+        location = "<registry.example.com:8443>/oadp"
+        pull-from-mirror = "digest-only"
+
+    [[registry]]
+      prefix = ""
+      location = "registry.redhat.io/openshift-gitops-1"
+
+      [[registry.mirror]]
+        location = "<registry.example.com:8443>/openshift-gitops-1"
+        pull-from-mirror = "digest-only"
+
+    [[registry]]
+      prefix = ""
+      location = "registry.redhat.io/rh-sso-7"
+
+      [[registry.mirror]]
+        location = "<registry.example.com:8443>/rh-sso-7"
+        pull-from-mirror = "digest-only"
+
+    [[registry]]
+      prefix = ""
+      location = "registry.redhat.io/openshift-logging"
+
+      [[registry.mirror]]
+        location = "<registry.example.com:8443>/openshift-logging"
+        pull-from-mirror = "digest-only"

--- a/telco-hub/configuration/example-overlays-config/acm/kustomization.yaml
+++ b/telco-hub/configuration/example-overlays-config/acm/kustomization.yaml
@@ -22,3 +22,11 @@ patches:
       kind: AgentServiceConfig
       name: agent
     path: options-agentserviceconfig-patch.yaml
+
+  # configure mirror registry for ACM
+  - target:
+      group: ""
+      version: v1
+      kind: ConfigMap
+      name: mirror-registry-config
+    path: acmMirrorRegistryCM-patch.yaml


### PR DESCRIPTION
This PR adds an overlay configuration for ACM mirror registry ConfigMap, allowing users to easily configure their mirror registry settings without modifying the base configuration files.

The overlay includes:
- acmMirrorRegistryCM-patch.yaml - A patch file for customizing the ACM mirror registry configuration
- Updated kustomization.yaml to include the new patch