### PR TITLE
OCPBUGS-48672: Fix avoidBuggyIPs typo

### DIFF
--- a/telco-core/configuration/reference-crs-kube-compare/required/networking/metallb/addr-pool.yaml
+++ b/telco-core/configuration/reference-crs-kube-compare/required/networking/metallb/addr-pool.yaml
@@ -15,6 +15,6 @@ spec:
   autoAssign: {{ .spec.autoAssign }}
 {{ end }}
 {{ if .spec.avoidBuggyIPs }}
-  avoidBuggyIps: {{ .spec.avoidBuggyIPs }}
+  avoidBuggyIPs: {{ .spec.avoidBuggyIPs }}
 {{ end }}
   ##############


### PR DESCRIPTION
Signed-off-by: Jim Ramsay <jramsay@redhat.com>
