### PR TITLE
CNF-18775: telco-hub: add VaultSecret support to ZTP AppProject

### DIFF
--- a/telco-hub/configuration/reference-crs/required/gitops/ztp-installation/app-project.yaml
+++ b/telco-hub/configuration/reference-crs/required/gitops/ztp-installation/app-project.yaml
@@ -30,7 +30,7 @@ spec:
       kind: NMStateConfig
     - group: 'extensions.hive.openshift.io'
       kind: AgentClusterInstall
-    - group: extensions.hive.openshift.io
+    - group: 'extensions.hive.openshift.io'
       kind: ImageClusterInstall
     - group: 'hive.openshift.io'
       kind: ClusterDeployment
@@ -38,7 +38,7 @@ spec:
       kind: BareMetalHost
     - group: 'metal3.io'
       kind: HostFirmwareSettings
-    - group: metal3.io
+    - group: 'metal3.io'
       kind: DataImage
     - group: 'agent.open-cluster-management.io'
       kind: KlusterletAddonConfig
@@ -48,5 +48,7 @@ spec:
       kind: SiteConfig
     - group: 'siteconfig.open-cluster-management.io'
       kind: ClusterInstance
+    - group: 'redhatcop.redhat.io'
+      kind: VaultSecret
   sourceRepos:
     - '*'


### PR DESCRIPTION
## Summary

Add VaultSecret resource support to GitOps AppProject for vault-based secret management during ZTP operations. Fixes: [CNF-18775](https://issues.redhat.com/browse/CNF-18775).

## Changes

- **Added**: `redhatcop.redhat.io/VaultSecret` to namespaceResourceWhitelist in app-project.yaml
- **Updated**: ZTP installation AppProject to support vault-based secret resources

## Motivation

Some telco deployments require Vault for managing sensitive data and secrets during cluster provisioning. The previous GitOps configuration was missing support for VaultSecret resources, causing:

- ArgoCD deployment failures when configurations included vault-based secrets
- Manual workarounds or configuration bypasses
- Incompatibility with validated patterns requiring vault integration
- Limited security options for sensitive data management

The new approach enables:

- **Automated vault integration**: VaultSecret resources are managed automatically by ArgoCD
- **Enhanced security**: Vault-based secret management during ZTP operations
- **Validated pattern support**: Compatibility with patterns requiring vault integration
- **Zero manual intervention**: No additional configuration steps needed for vault deployments

## Technical Details

The updated AppProject now automatically:

- Recognizes and manages VaultSecret resources during ZTP operations
- Allows ArgoCD to deploy configurations containing vault-based secrets
- Maintains backward compatibility with existing non-vault deployments
- Supports the redhatcop.redhat.io/VaultSecret API for secure secret management

This enables vault-based secret management in telco hub deployments without requiring manual AppProject modifications or workarounds.

Signed-off-by: Leonardo Ochoa-Aday <lochoa@redhat.com>