### PR TITLE
Remove duplicate ns and mcsb creation for hub-policies

### DIFF
--- a/telco-hub/configuration/reference-crs/required/acm/thanosSecret.yaml
+++ b/telco-hub/configuration/reference-crs/required/acm/thanosSecret.yaml
@@ -2,11 +2,6 @@
 # the generated Object Bucket Claim into the necessary secret for
 # observability to connect to thanos.
 ---
-apiVersion: v1
-kind: Namespace
-metadata:
-  name: hub-policies
----
 apiVersion: policy.open-cluster-management.io/v1
 kind: Policy
 metadata:
@@ -95,17 +90,6 @@ subjects:
   - name: obs-thanos-secret
     apiGroup: policy.open-cluster-management.io
     kind: Policy
----
-apiVersion: cluster.open-cluster-management.io/v1beta2
-kind: ManagedClusterSetBinding
-metadata:
-  name: default
-  namespace: hub-policies
-  annotations:
-    argocd.argoproj.io/sync-wave: "8"
-    argocd.argoproj.io/sync-options: SkipDryRunOnMissingResource=true
-spec:
-  clusterSet: default
 
 # For reference this is the secret which is being generated (with
 # approriate values in the fields):


### PR DESCRIPTION
After adding those resources with https://github.com/openshift-kni/telco-reference/commit/ef5f2480acebe4f2d0000a633d6baa2e39af71e1 gitops deployment precedes the acm configuration, so we need to remove duplicates to avoid git application sync issues