### PR TITLE
OCPBUGS-59420: Add cgroup check to reference check

### DIFF
--- a/telco-core/configuration/Makefile
+++ b/telco-core/configuration/Makefile
@@ -9,7 +9,7 @@ compare_crs:
 		echo "kubectl-cluster_compare tool isn't installed; please download it from https://github.com/openshift/kube-compare"; \
 		exit 1; \
 	fi; \
-	$${CLUSTER_COMPARE} -r ./reference-crs-kube-compare/metadata.yaml -f ./reference-crs -R -p ./reference-crs-kube-compare/comparison-overrides.yaml
+	$${CLUSTER_COMPARE} -r ./reference-crs-kube-compare/metadata.yaml -f ./reference-crs,./hack/cluster-default-crs -R -p ./reference-crs-kube-compare/comparison-overrides.yaml
 
 
 .PHONY: missing_crs

--- a/telco-core/configuration/hack/cluster-default-crs/README
+++ b/telco-core/configuration/hack/cluster-default-crs/README
@@ -1,0 +1,4 @@
+# This directory contains CRs which are validated by the reference-crs-kube-compare but 
+# for which there are no corresponding CRs in the reference-crs. This occurs when the 
+# reference explicitly validates CRs which are either default or managed by controllers 
+# and not directly configured through the reference-crs.

--- a/telco-core/configuration/hack/cluster-default-crs/node.config.yaml
+++ b/telco-core/configuration/hack/cluster-default-crs/node.config.yaml
@@ -1,0 +1,5 @@
+apiVersion: config.openshift.io/v1
+kind: Node
+metadata:
+  name: cluster
+spec: {}

--- a/telco-core/configuration/reference-crs-kube-compare/compare_ignore
+++ b/telco-core/configuration/reference-crs-kube-compare/compare_ignore
@@ -5,6 +5,10 @@ comparison-overrides.yaml
 # Used in the reference only for version compliance checks
 ReferenceVersionCheck.yaml
 
+# Reference only to ensure default has not been changed
+required/machine-config/cgroup-check.yaml
+required/machine-config/container-runtime.yaml
+
 # Utility objects used to migrate from CLO5->CLO6
 ClusterLogging5Cleanup.yaml
 ClusterLogOperatorStatus.yaml

--- a/telco-core/configuration/reference-crs-kube-compare/metadata.yaml
+++ b/telco-core/configuration/reference-crs-kube-compare/metadata.yaml
@@ -12,6 +12,18 @@ parts:
               ignore-unspecified-fields: true
               fieldsToOmitRefs:
                 - allowStatusCheck
+  - name: defaults-check
+    description: |-
+      A mismatch here means you are overriding expected default
+      values in Openshift configuration
+    components:
+      - name: defaults-required
+        allOf:
+          - path: required/machine-config/cgroup-check.yaml
+      - name: defaults-optional
+        # If the matching CR exists it needs to match expected content
+        anyOf:
+          - path: required/machine-config/container-runtime.yaml
   - name: networking
     description: |-
       https://docs.openshift.com/container-platform/4.20/scalability_and_performance/telco_ref_design_specs/core/telco-core-ref-design-components.html#telco-core-networking_core-ref-design-components

--- a/telco-core/configuration/reference-crs-kube-compare/required/machine-config/cgroup-check.yaml
+++ b/telco-core/configuration/reference-crs-kube-compare/required/machine-config/cgroup-check.yaml
@@ -1,0 +1,10 @@
+apiVersion: config.openshift.io/v1
+kind: Node
+metadata:
+  name: cluster
+spec:
+  {{ if .spec.cgroupMode -}}
+  cgroupMode: "v2"
+  {{- else -}}
+  {}
+  {{- end -}}

--- a/telco-core/configuration/reference-crs-kube-compare/required/machine-config/container-runtime.yaml
+++ b/telco-core/configuration/reference-crs-kube-compare/required/machine-config/container-runtime.yaml
@@ -1,0 +1,19 @@
+apiVersion: machineconfiguration.openshift.io/v1
+kind: ContainerRuntimeConfig
+metadata:
+  name: {{ .metadata.name }}
+spec:
+  # mcp selector is expected or runtime binds to no pools
+  machineConfigPoolSelector:
+  {{- nindent 4 (.spec.machineConfigPoolSelector | default "value required" | toYaml) }}
+
+  {{- if .spec.containerRuntimeConfig }}
+  containerRuntimeConfig:
+    {{- range $key, $value := .spec.containerRuntimeConfig }}
+    {{- if eq (toString $key) "defaultRuntime" }}
+    defaultRuntime: "crun"
+    {{- else }}
+    {{ $key }}: {{ $value }}
+    {{- end }}
+    {{- end }}
+  {{- end }}

--- a/telco-ran/configuration/kube-compare-reference/compare_ignore
+++ b/telco-ran/configuration/kube-compare-reference/compare_ignore
@@ -77,3 +77,7 @@ extra-manifest/image-registry-partition-mc.yaml.tmpl
 
 # Exists in the reference only, to enforce version compatibility
 ClusterVersionOperator.yaml
+
+# Reference only to ensure default has not been changed
+required/machine-config/cgroup-check.yaml
+required/machine-config/container-runtime.yaml

--- a/telco-ran/configuration/kube-compare-reference/metadata.yaml
+++ b/telco-ran/configuration/kube-compare-reference/metadata.yaml
@@ -12,6 +12,18 @@ parts:
               ignore-unspecified-fields: true
               fieldsToOmitRefs:
                 - allowStatusCheck
+  - name: defaults-check
+    description: |-
+      A mismatch here means you are overriding expected default
+      values in Openshift configuration
+    components:
+      - name: defaults-required
+        allOf:
+          - path: required/machine-config/cgroup-check.yaml
+      - name: defaults-optional
+        # If the matching CR exists it needs to match expected content
+        anyOf:
+          - path: required/machine-config/container-runtime.yaml
   - name: required-cluster-logging
     description: |-
       https://docs.openshift.com/container-platform/4.20/scalability_and_performance/telco_ref_design_specs/ran/telco-ran-ref-du-components.html#telco-ran-logging_ran-ref-design-components

--- a/telco-ran/configuration/kube-compare-reference/required/machine-config/cgroup-check.yaml
+++ b/telco-ran/configuration/kube-compare-reference/required/machine-config/cgroup-check.yaml
@@ -1,0 +1,10 @@
+apiVersion: config.openshift.io/v1
+kind: Node
+metadata:
+  name: cluster
+spec:
+  {{ if .spec.cgroupMode -}}
+  cgroupMode: "v2"
+  {{- else -}}
+  {}
+  {{- end -}}

--- a/telco-ran/configuration/kube-compare-reference/required/machine-config/container-runtime.yaml
+++ b/telco-ran/configuration/kube-compare-reference/required/machine-config/container-runtime.yaml
@@ -1,0 +1,19 @@
+apiVersion: machineconfiguration.openshift.io/v1
+kind: ContainerRuntimeConfig
+metadata:
+  name: {{ .metadata.name }}
+spec:
+  # mcp selector is expected or runtime binds to no pools
+  machineConfigPoolSelector:
+  {{- nindent 4 (.spec.machineConfigPoolSelector | default "value required" | toYaml) }}
+
+  {{- if .spec.containerRuntimeConfig }}
+  containerRuntimeConfig:
+    {{- range $key, $value := .spec.containerRuntimeConfig }}
+    {{- if eq (toString $key) "defaultRuntime" }}
+    defaultRuntime: "crun"
+    {{- else }}
+    {{ $key }}: {{ $value }}
+    {{- end }}
+    {{- end }}
+  {{- end }}


### PR DESCRIPTION
All workloads should be moving to cgroup v2. Add a required check for cgroup. If users remain on cgroup v1 the check serves as a reminder that workloads must be moved to v2.