### PR TITLE
CNF-18819: Add kustomization file for logging optional component

### DIFF
--- a/telco-hub/configuration/reference-crs/optional/logging/kustomization.yaml
+++ b/telco-hub/configuration/reference-crs/optional/logging/kustomization.yaml
@@ -1,0 +1,7 @@
+---
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - clusterLogNS.yaml
+  - clusterLogOperGroup.yaml
+  - clusterLogSubscription.yaml


### PR DESCRIPTION
## Summary
Add missing kustomization.yaml file for the logging optional component in telco-hub pattern configuration. Fixes [CNF-18819](https://issues.redhat.com/browse/CNF-18819).

## Changes
- Add `telco-hub/configuration/reference-crs/optional/logging/kustomization.yaml`
- Include references to all logging component resources:
  - clusterLogNS.yaml
  - clusterLogOperGroup.yaml
  - clusterLogSubscription.yaml

## Context
As part of the validated pattern integration effort (CNF-13631), all optional components need proper kustomization support to enable flexible deployment configurations. This adds the missing kustomization file for the logging component following the same structure and conventions as other optional components.

## Testing
- [x] Validated kustomization syntax is correct
- [x] All referenced resources exist in the logging directory
- [x] File follows established pattern conventions

Signed-off-by: Leonardo Ochoa-Aday [lochoa@redhat.com](mailto:lochoa@redhat.com)