### PR TITLE
CNF-18869: ACM: correct MultiClusterHub namespace to open-cluster-management

### DIFF
--- a/telco-hub/configuration/reference-crs/required/acm/acmMCH.yaml
+++ b/telco-hub/configuration/reference-crs/required/acm/acmMCH.yaml
@@ -58,14 +58,3 @@ spec:
       enabled: false
       name: edge-manager-preview
   separateCertificateManagement: false
----
-apiVersion: cluster.open-cluster-management.io/v1beta2
-kind: ManagedClusterSetBinding
-metadata:
-  annotations:
-    argocd.argoproj.io/sync-wave: "4"
-    argocd.argoproj.io/sync-options: SkipDryRunOnMissingResource=true
-  name: global
-  namespace: openshift-storage
-spec:
-  clusterSet: global

--- a/telco-hub/configuration/reference-crs/required/acm/pull-secret-copy.yaml
+++ b/telco-hub/configuration/reference-crs/required/acm/pull-secret-copy.yaml
@@ -74,7 +74,7 @@ metadata:
   annotations:
     argocd.argoproj.io/sync-wave: "9"
     argocd.argoproj.io/sync-options: SkipDryRunOnMissingResource=true
-  name: global
+  name: default
   namespace: open-cluster-management-observability
 spec:
-  clusterSet: global
+  clusterSet: default


### PR DESCRIPTION
- Remove ManagedClusterSetBinding 'global' from openshift-storage namespace, which was incorrectly placed outside the ACM namespace scope.
- Update ManagedClusterSetBinding in observability to use 'default' clusterSet instead of 'global' for consistency.

Signed-off-by: Leonardo Ochoa-Aday <lochoa@redhat.com>