### PR TITLE
CNF-18888: telco-hub: add ClusterLogForwarder for centralized logging

### DIFF
--- a/telco-hub/configuration/example-overlays-config/logging/README.md
+++ b/telco-hub/configuration/example-overlays-config/logging/README.md
@@ -1,0 +1,25 @@
+# Logging Overlay Configuration Example
+
+Example overlay for customizing the telco-hub ClusterLogForwarder.
+
+## ClusterLogForwarder Patch
+
+The `cluster-log-forwarder-patch.yaml` customizes (not limited to):
+
+1. **Kafka endpoint**: Hub-specific server with cluster claim templating
+2. **Labels**: Hub-specific OpenShift labels
+
+## Testing
+
+```bash
+# Test the overlay
+kubectl kustomize telco-hub/configuration/example-overlays-config/logging/
+
+# Apply the overlay
+kubectl apply -k telco-hub/configuration/example-overlays-config/logging/
+```
+
+## Key Configuration
+
+- **Kafka URL**: Update `jumphost.inbound.lab:9092` to your Kafka broker
+- **Labels**: Customize `openshiftLabels` for your environment

--- a/telco-hub/configuration/example-overlays-config/logging/cluster-log-forwarder-patch.yaml
+++ b/telco-hub/configuration/example-overlays-config/logging/cluster-log-forwarder-patch.yaml
@@ -1,0 +1,13 @@
+---
+# patching ClusterLogForwarder for hub-specific configuration
+- op: replace
+  path: /spec/outputs/0/kafka/url
+  value: tcp://jumphost.inbound.lab:9092/endpoint
+
+# Optional: Add additional filter configuration with specific labels
+- op: add
+  path: /spec/filters/0/openshiftLabels
+  value:
+    cluster-role: hub
+    environment: production
+    telco-component: management

--- a/telco-hub/configuration/example-overlays-config/logging/kustomization.yaml
+++ b/telco-hub/configuration/example-overlays-config/logging/kustomization.yaml
@@ -1,0 +1,15 @@
+---
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+resources:
+  - ../../reference-crs/optional/logging/
+
+patches:
+  # Customize ClusterLogForwarder for hub-specific configuration
+  - target:
+      group: observability.openshift.io
+      version: v1
+      kind: ClusterLogForwarder
+      name: instance
+    path: cluster-log-forwarder-patch.yaml

--- a/telco-hub/configuration/reference-crs/optional/logging/clusterLogForwarder.yaml
+++ b/telco-hub/configuration/reference-crs/optional/logging/clusterLogForwarder.yaml
@@ -1,0 +1,49 @@
+---
+# ClusterLogForwarder for Telco Hub
+# Forwards audit and infrastructure logs to Kafka with hub-specific labeling
+apiVersion: observability.openshift.io/v1
+kind: ClusterLogForwarder
+metadata:
+  name: instance
+  namespace: openshift-logging
+  annotations:
+    # Deploy after cluster logging operator is ready
+    argocd.argoproj.io/sync-wave: "10"
+    # Ignore controller-managed status differences in ArgoCD
+    argocd.argoproj.io/compare-options: IgnoreExtraneous
+spec:
+  # Filters add metadata labels to log records for identification
+  filters:
+  - name: telco-hub-labels
+    type: openshiftLabels
+    # Add these labels to all forwarded log records
+    openshiftLabels:
+      cluster-role: hub                # Identifies this as hub cluster logs
+      environment: production          # Environment designation
+      telco-component: management      # Component categorization
+
+  # Output destinations for log forwarding
+  outputs:
+  - name: hub-kafka-output
+    type: kafka
+    kafka:
+      # Kafka broker endpoint -> update for your environment!
+      url: tcp://$kafka-server:9092/endpoint
+
+  # Pipelines define which logs go where with what processing
+  pipelines:
+  - name: telco-hub-logs
+    # Log types to forward (excludes application logs for hub)
+    inputRefs:
+    - audit           # OpenShift API audit logs
+    - infrastructure  # Container runtime and system logs
+    # Where to send the logs
+    outputRefs:
+    - hub-kafka-output
+    # Apply labeling filter to identify log source
+    filterRefs:
+    - telco-hub-labels
+
+  # Service account for log collection
+  serviceAccount:
+    name: collector

--- a/telco-hub/configuration/reference-crs/optional/logging/clusterLogServiceAccount.yaml
+++ b/telco-hub/configuration/reference-crs/optional/logging/clusterLogServiceAccount.yaml
@@ -1,0 +1,8 @@
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: collector
+  namespace: openshift-logging
+  annotations:
+    argocd.argoproj.io/sync-wave: "2"

--- a/telco-hub/configuration/reference-crs/optional/logging/clusterLogServiceAccountAuditBinding.yaml
+++ b/telco-hub/configuration/reference-crs/optional/logging/clusterLogServiceAccountAuditBinding.yaml
@@ -1,0 +1,15 @@
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: logcollector-audit-logs-binding
+  annotations:
+    argocd.argoproj.io/sync-wave: "2"
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: collect-audit-logs
+subjects:
+- kind: ServiceAccount
+  name: collector
+  namespace: openshift-logging

--- a/telco-hub/configuration/reference-crs/optional/logging/clusterLogServiceAccountInfrastructureBinding.yaml
+++ b/telco-hub/configuration/reference-crs/optional/logging/clusterLogServiceAccountInfrastructureBinding.yaml
@@ -1,0 +1,15 @@
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: logcollector-infrastructure-logs-binding
+  annotations:
+    argocd.argoproj.io/sync-wave: "2"
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: collect-infrastructure-logs
+subjects:
+- kind: ServiceAccount
+  name: collector
+  namespace: openshift-logging

--- a/telco-hub/configuration/reference-crs/optional/logging/kustomization.yaml
+++ b/telco-hub/configuration/reference-crs/optional/logging/kustomization.yaml
@@ -5,3 +5,7 @@ resources:
   - clusterLogNS.yaml
   - clusterLogOperGroup.yaml
   - clusterLogSubscription.yaml
+  - clusterLogServiceAccount.yaml
+  - clusterLogServiceAccountAuditBinding.yaml
+  - clusterLogServiceAccountInfrastructureBinding.yaml
+  - clusterLogForwarder.yaml


### PR DESCRIPTION
## Summary
Implements ClusterLogForwarder configuration for telco-hub overlays to enable centralized log forwarding to Kafka with hub-specific labeling. Fixes [CNF-18888](https://issues.redhat.com/browse/CNF-18888).

## Changes
- **ClusterLogForwarder resource**: Added to `telco-hub/configuration/reference-crs/optional/logging/`
- **Example overlays**: Created `example-overlays-config/logging/` with kustomize patches
- **Pattern integration**: Updated `values-hub.yaml` with logging component patches
- **Documentation**: Added comprehensive comments and configuration examples

## Features
- ✅ Forwards audit and infrastructure logs to Kafka
- ✅ Hub-specific metadata labels for log identification
- ✅ ArgoCD-compatible with proper sync annotations
- ✅ Environment-specific customization via kustomize patches
- ✅ Example configurations for different scenarios

## Testing
- ClusterLogForwarder validates successfully
- ArgoCD deployment shows synced status

Signed-off-by: Leonardo Ochoa <lochoa@redhat.com>