### PR TITLE
OCPBUGS-60446: fix(oadp): [telco-hub] add apiVersion to DataProtectionApplication manifest

### DIFF
--- a/telco-hub/configuration/reference-crs/optional/backup-recovery/dataProtectionApplication.yaml
+++ b/telco-hub/configuration/reference-crs/optional/backup-recovery/dataProtectionApplication.yaml
@@ -1,4 +1,5 @@
 ---
+apiVersion: oadp.openshift.io/v1alpha1
 kind: DataProtectionApplication
 metadata:
   name: hub-backup


### PR DESCRIPTION
## Summary
Fixes a validation error in the telco-hub OADP DataProtectionApplication manifest by adding the missing `apiVersion` field.

## Problem
The `DataProtectionApplication` CR in `telco-hub/configuration/reference-crs/optional/backup-recovery/dataProtectionApplication.yaml` was missing the required `apiVersion` field, causing:
- Kubernetes validation failures during apply
- Argo CD sync errors
- Inability to create the DPA resource

## Solution
Added `apiVersion: oadp.openshift.io/v1alpha1` to align with the OADP CRD version used elsewhere in the repository (specifically matching `telco-ran/configuration/source-crs/OadpDataProtectionApplication.yaml`).

## Changes
- **Modified:** `telco-hub/configuration/reference-crs/optional/backup-recovery/dataProtectionApplication.yaml`
  - Added `apiVersion: oadp.openshift.io/v1alpha1` after the document separator

## Testing
- [x] apiVersion matches other OADP resources in the repo
- [x] No functional changes to the DPA specification

## Impact
- **Scope:** Single file, minimal change
- **Risk:** Low - only adds required metadata field
- **Fixes:** OADP backup configuration deployment in telco-hub scenarios

## Related Issues
- [OCPBUGS-60446](https://issues.redhat.com/browse/OCPBUGS-60446)

Signed-off-by: Leonardo Ochoa-Aday <lochoa@redhat.com>