### PR TITLE
telco-core: OCPBUGS-60170: installPlanApproval in NROPSubscription

### DIFF
--- a/telco-core/configuration/reference-crs-kube-compare/required/scheduling/NROPSubscription.yaml
+++ b/telco-core/configuration/reference-crs-kube-compare/required/scheduling/NROPSubscription.yaml
@@ -10,3 +10,4 @@ spec:
   name: numaresources-operator
   source: {{ if .spec.source }} {{ .spec.source }} {{ else }} "redhat-operators-disconnected " {{ end }}
   sourceNamespace: {{ if .spec.sourceNamespace }} {{ .spec.sourceNamespace }} {{ else }} "openshift-marketplace" {{ end }}
+  installPlanApproval: Manual

--- a/telco-core/configuration/reference-crs/required/scheduling/NROPSubscription.yaml
+++ b/telco-core/configuration/reference-crs/required/scheduling/NROPSubscription.yaml
@@ -11,5 +11,6 @@ spec:
   name: numaresources-operator
   source: redhat-operators-disconnected
   sourceNamespace: openshift-marketplace
+  installPlanApproval: Manual
 status:
   state: AtLatestKnown


### PR DESCRIPTION
This PR adds installPlanApproval to NROPSubscription CR, which was previously causing deviation in cluster-compare tool