### PR TITLE
[telco-hub] Fix mirror-registry-config CM in kube-compare reference

### DIFF
--- a/telco-hub/configuration/example-overlays-config/acm/acmMirrorRegistryCM-patch.yaml
+++ b/telco-hub/configuration/example-overlays-config/acm/acmMirrorRegistryCM-patch.yaml
@@ -10,7 +10,7 @@
     -----END CERTIFICATE-----
 - op: replace
   path: /data/registries.conf
-  value: |
+  value: |-
     unqualified-search-registries = ["registry.access.redhat.com", "docker.io"]
     [[registry]]
       prefix = ""

--- a/telco-hub/configuration/reference-crs-kube-compare/required/acm/acmMirrorRegistryCM.yaml
+++ b/telco-hub/configuration/reference-crs-kube-compare/required/acm/acmMirrorRegistryCM.yaml
@@ -15,6 +15,6 @@ data:
 {{ index .data "ca-bundle.crt" | trimSuffix "\n" | indent 4 }}
   # The registries.conf field has been populated using the registries.conf file found in "/etc/containers/registries.conf" on each node.
   # Replace <registry.example.com:8443> with the mirror registry's address.
-  registries.conf: |
+  registries.conf: |-
 {{ index .data "registries.conf" | trimSuffix "\n" | indent 4 }}
 {{- end }}

--- a/telco-hub/configuration/reference-crs/required/acm/acmMirrorRegistryCM.yaml
+++ b/telco-hub/configuration/reference-crs/required/acm/acmMirrorRegistryCM.yaml
@@ -19,7 +19,7 @@ data:
     -----END CERTIFICATE-----
   # The registries.conf field has been populated using the registries.conf file found in "/etc/containers/registries.conf" on each node.
   # Replace <registry.example.com:8443> with the mirror registry's address.
-  registries.conf: |
+  registries.conf: |-
     unqualified-search-registries = ["registry.access.redhat.com", "docker.io"]
     [[registry]]
       prefix = ""


### PR DESCRIPTION
## Summary

This PR fixes the YAML literal block indicator for the registries.conf field in the ACM mirror registry ConfigMap from | to |- to properly strip trailing newlines.

## Technical Details

When doing cluster-compare directly against the kustomize-patched CRs, the following drift can be seen:

```diff
Cluster CR: v1_ConfigMap_multicluster-engine_mirror-registry-config
Reference File: required/acm/acmMirrorRegistryCM.yaml
Description:
  https://docs.redhat.com/en/documentation/openshift_container_platform/4.18/html/scalability_and_performance/telco-hub-ref-design-specs#telco-hub-red-hat-advanced-cluster-management-rhacm_telco-hub
Diff Output: diff -u -N /tmp/MERGED-3791155115/v1_configmap_multicluster-engine_mirror-registry-config /tmp/LIVE-304292392/v1_configmap_multicluster-engine_mirror-registry-config
--- /tmp/MERGED-3791155115/v1_configmap_multicluster-engine_mirror-registry-config      2025-08-21 10:24:49.766111819 +0200
+++ /tmp/LIVE-304292392/v1_configmap_multicluster-engine_mirror-registry-config 2025-08-21 10:24:49.766111819 +0200
@@ -35,7 +35,7 @@
     \ prefix = \"\"\n  location = \"quay.io/openshift-release-dev/ocp-release\"\n
     \ mirror-by-digest-only = true\n\n  [[registry.mirror]]\n    location = \"jumphost.inbound.bos2.lab:8443/ocp4/openshift/release\"
     \n\n[[registry]]\n  prefix = \"\"\n  location = \"quay.io/openshift-release-dev/ocp-release\"\n
-    \ mirror-by-digest-only = true\n\n  [[registry.mirror]]\n    location = \"jumphost.inbound.bos2.lab:8443/ocp4/openshift/release-images\"\n"
+    \ mirror-by-digest-only = true\n\n  [[registry.mirror]]\n    location = \"jumphost.inbound.bos2.lab:8443/ocp4/openshift/release-images\""
 kind: ConfigMap
 metadata:
   labels:
```

The change from `|` to `|-` in YAML literal blocks ensures that trailing newlines are stripped from the `registries.conf` data field. This prevents potential issues that could arise from unexpected newline characters in the container registry configuration.

## Changes

- Updated acmMirrorRegistryCM-patch.yaml in example overlays config
- Updated acmMirrorRegistryCM.yaml in reference CRs
- Updated acmMirrorRegistryCM.yaml in kube-compare reference CRs

Signed-off-by: Leonardo Ochoa-Aday lochoa@redhat.com