### PR TITLE
CNF-13398: merge ACM observability with RAN config

### DIFF
--- a/telco-ran/configuration/kube-compare-reference/default_value.yaml
+++ b/telco-ran/configuration/kube-compare-reference/default_value.yaml
@@ -303,6 +303,12 @@ required_cluster_tuning_operator_hub_DisconnectedIDMS:
 - metadata:
     name: fec-disconnected-idms
   spec: {}
+required_cluster_tuning_monitoring_configuration_ReduceMonitoringFootprint:
+- metadata:
+    name: cluster-monitoring-config
+  captureGroup_defaults:
+    alertmanager_endpoint: "{{ `{{ (regexFind \"alertmanager-endpoint(.*)\" ((fromSecret \"open-cluster-management-addon-observability\" \"hub-info-secret\" \"hub-info.yaml\") | base64dec)) | replace \"alertmanager-endpoint: https://\" \"\" }}` }}"
+    managed_cluster: "{{ `{{ fromClusterClaim \"id.openshift.io\" }}` }}"
 required_lca_LcaSubscription:
 - spec:
     source: redhat-operators-disconnected

--- a/telco-ran/configuration/kube-compare-reference/metadata.yaml
+++ b/telco-ran/configuration/kube-compare-reference/metadata.yaml
@@ -49,6 +49,10 @@ parts:
             config:
               ignore-unspecified-fields: true
           - path: required/cluster-tuning/monitoring-configuration/ReduceMonitoringFootprint.yaml
+            config:
+              perField:
+                - pathToKey: data."config.yaml"
+                  inlineDiffFunc: capturegroups
           - path: required/cluster-tuning/operator-hub/DefaultCatsrc.yaml
           - path: required/cluster-tuning/09-openshift-marketplace-ns.yaml
           - path: required/cluster-tuning/operator-hub/DisconnectedIDMS.yaml

--- a/telco-ran/configuration/kube-compare-reference/required/cluster-tuning/monitoring-configuration/ReduceMonitoringFootprint.yaml
+++ b/telco-ran/configuration/kube-compare-reference/required/cluster-tuning/monitoring-configuration/ReduceMonitoringFootprint.yaml
@@ -11,5 +11,31 @@ data:
       enabled: false
     telemeterClient:
       enabled: false
+    nodeExporter:
+      collectors:
+        buddyinfo: {}
+        cpufreq: {}
+        ksmd: {}
+        mountstats: {}
+        netclass: {}
+        netdev: {}
+        processes: {}
+        systemd: {}
+        tcpstat: {}
     prometheusK8s:
-       retention: 24h
+      additionalAlertmanagerConfigs:
+      - apiVersion: v2
+        bearerToken:
+          key: token
+          name: observability-alertmanager-accessor
+        scheme: https
+        staticConfigs:
+        - (?<alertmanager_endpoint>.*)
+        tlsConfig:
+          ca:
+            key: service-ca.crt
+            name: hub-alertmanager-router-ca
+          insecureSkipVerify: false
+      externalLabels:
+        managed_cluster: (?<managed_cluster>.*)
+      retention: 24h

--- a/telco-ran/configuration/source-crs/ReduceMonitoringFootprint.yaml
+++ b/telco-ran/configuration/source-crs/ReduceMonitoringFootprint.yaml
@@ -11,5 +11,31 @@ data:
       enabled: false
     telemeterClient:
       enabled: false
+    nodeExporter:
+      collectors:
+        buddyinfo: {}
+        cpufreq: {}
+        ksmd: {}
+        mountstats: {}
+        netclass: {}
+        netdev: {}
+        processes: {}
+        systemd: {}
+        tcpstat: {}
     prometheusK8s:
-       retention: 24h
+      additionalAlertmanagerConfigs:
+      - apiVersion: v2
+        bearerToken:
+          key: token
+          name: observability-alertmanager-accessor
+        scheme: https
+        staticConfigs:
+        - {{ (regexFind "alertmanager-endpoint(.*)" ((fromSecret "open-cluster-management-addon-observability" "hub-info-secret" "hub-info.yaml") | base64dec)) | replace "alertmanager-endpoint: https://" "" }}
+        tlsConfig:
+          ca:
+            key: service-ca.crt
+            name: hub-alertmanager-router-ca
+          insecureSkipVerify: false
+      externalLabels:
+        managed_cluster: {{ fromClusterClaim "id.openshift.io" }}
+      retention: 24h


### PR DESCRIPTION
Updated the observability part on the Reduce monitoring footprint file in response to [CNF-13398](https://issues.redhat.com/browse/CNF-13398)

Includes update to kube-compare reference with inline capture group for parsing fromSecret and fromClusterClaim values

cc: @sabbir-47 @imiller0 