### PR TITLE
Add below files for telco-hub 4.18

### DIFF
--- a/telco-hub/configuration/reference-crs/ReferenceVersionCheck.yaml
+++ b/telco-hub/configuration/reference-crs/ReferenceVersionCheck.yaml
@@ -1,0 +1,7 @@
+apiVersion: config.openshift.io/v1
+kind: ClusterVersion
+metadata:
+  name: version
+status:
+  desired:
+    version: {{ template "versionMatch" (list .status.desired.version "4.18") }}

--- a/telco-hub/configuration/reference-crs/metadata.yaml
+++ b/telco-hub/configuration/reference-crs/metadata.yaml
@@ -1,0 +1,139 @@
+---
+apiVersion: v2
+parts:
+  - name: version-check
+    description: |-
+      A mismatch here means you may be using the wrong reference.
+      This reference was designed for OpenShift 4.18.
+    components:
+      - name: version-check
+        allOf:
+          - path: ReferenceVersionCheck.yaml
+            config:
+              ignore-unspecified-fields: true
+              fieldsToOmitRefs:
+                - allowStatusCheck
+  - name: optional-storage
+    components:
+      - name: local-storage-operator
+        description: |-
+          Local Storage Operator configuration for telco hub
+        allOrNoneOf:
+          - path: optional/lso/lsoNS.yaml
+          - path: optional/lso/lsoOperatorGroup.yaml
+          - path: optional/lso/lsoSubscription.yaml
+          - path: optional/lso/lsoLocalVolume.yaml
+      - name: odf-internal-operator
+        description: |-
+          OpenShift Data Foundation internal operator configuration
+        allOrNoneOf:
+          - path: optional/odf-internal/odfNS.yaml
+          - path: optional/odf-internal/odfOperatorGroup.yaml
+          - path: optional/odf-internal/odfSubscription.yaml
+          - path: optional/odf-internal/storageCluster.yaml
+            config:
+              ignore-unspecified-fields: true
+  - name: optional-quay
+    description: |-
+      Quay registry operator configuration
+    components:
+      - name: quay-operator
+        allOrNoneOf:
+          - path: optional/quay/quayNS.yaml
+          - path: optional/quay/quayOperatorGroup.yaml
+          - path: optional/quay/quaySubscription.yaml
+  - name: required-talm
+    description: |-
+      Topology Aware Lifecycle Manager configuration
+    components:
+      - name: talm-operator
+        allOf:
+          - path: required/talm/talmSubscription.yaml
+  - name: required-acm
+    description: |-
+      Red Hat Advanced Cluster Management configuration
+    components:
+      - name: acm-operator
+        allOf:
+          - path: required/acm/acmNS.yaml
+          - path: required/acm/acmOperGroup.yaml
+          - path: required/acm/acmSubscription.yaml
+          - path: required/acm/acmMCH.yaml
+          - path: required/acm/acmProvisioning.yaml
+            config:
+              ignore-unspecified-fields: true
+          - path: required/acm/acmAgentServiceConfig.yaml
+          - path: required/acm/observabilityMCO.yaml
+            config:
+              ignore-unspecified-fields: true
+          - path: required/acm/observatilityNS.yaml
+  - name: required-gitops
+    description: |-
+      GitOps and ArgoCD configuration
+    components:
+      - name: gitops-operator
+        allOf:
+          - path: required/gitops/gitopsNS.yaml
+          - path: required/gitops/gitopsOperatorGroup.yaml
+          - path: required/gitops/gitopsSubscription.yaml
+          - path: required/gitops/ztp-repo.yaml
+          - path: required/gitops/argocd-ssh-known-hosts-cm.yaml
+  - name: optional-logging
+    description: |-
+      Cluster logging operator configuration
+    components:
+      - name: cluster-logging-operator
+        allOrNoneOf:
+          - path: optional/logging/clusterLogNS.yaml
+          - path: optional/logging/clusterLogOperGroup.yaml
+          - path: optional/logging/clusterLogSubscription.yaml
+
+templateFunctionFiles:
+  - version_match.tmpl
+
+fieldsToOmit:
+  defaultOmitRef: all
+  items:
+    defaults:
+      - pathToKey: metadata.annotations."kubectl.kubernetes.io/last-applied-configuration"
+      - pathToKey: metadata.annotations."openshift.io/sa.scc.uid-range"
+      - pathToKey: metadata.annotations."openshift.io/sa.scc.mcs"
+      - pathToKey: metadata.annotations."openshift.io/sa.scc.supplemental-groups"
+      - pathToKey: metadata.annotations."olm.providedAPIs"
+      - pathToKey: metadata.annotations."argocd.argoproj.io"
+        isPrefix: true
+      - pathToKey: metadata.annotations."installer.multicluster.openshift.io"
+        isPrefix: true
+      - pathToKey: metadata.annotations."installer.open-cluster-management.io"
+        isPrefix: true
+      - pathToKey: metadata.annotations."security.openshift.io/MinimallySufficientPodSecurityStandard"
+      - pathToKey: metadata.labels."kubernetes.io/metadata.name"
+      - pathToKey: metadata.labels."security.openshift.io/scc.podSecurityLabelSync"
+      - pathToKey: metadata.labels."operators.coreos.com/local-storage-operator.openshift-local-storage"
+      - pathToKey: metadata.labels."operators.coreos.com/odf-operator.openshift-storage"
+      - pathToKey: metadata.labels."operators.coreos.com/topology-aware-lifecycle-manager.openshift-operators"
+      - pathToKey: metadata.labels."operators.coreos.com/advanced-cluster-management.open-cluster-management"
+      - pathToKey: metadata.labels."agent-install.openshift.io/watch"
+      - pathToKey: metadata.labels."cluster.open-cluster-management.io/backup"
+      - pathToKey: metadata.labels."pod-security.kubernetes.io"
+        isPrefix: true
+      - pathToKey: metadata.labels."olm.operatorgroup.uid"
+        isPrefix: true
+      - pathToKey: metadata.labels."app.kubernetes.io/instance"
+      - pathToKey: metadata.labels."installer.name"
+      - pathToKey: metadata.labels."installer.namespace"
+      - pathToKey: metadata.labels."multiclusterhubs.operator.open-cluster-management.io/managed-by"
+      - pathToKey: metadata.creationTimestamp
+      - pathToKey: metadata.finalizers
+      - pathToKey: metadata.generation
+      - pathToKey: metadata.resourceVersion
+      - pathToKey: metadata.uid
+      - pathToKey: metadata.ownerReferences
+      - pathToKey: spec.finalizers
+    allowStatusCheck:
+      - include: defaults
+    templates:
+      - pathToKey: spec.policy-templates
+    all:
+      - include: defaults
+      - pathToKey: status 

--- a/telco-hub/configuration/reference-crs/version_match.tmpl
+++ b/telco-hub/configuration/reference-crs/version_match.tmpl
@@ -1,0 +1,9 @@
+{{- define "versionMatch" }}
+  {{- $version := semver (index . 0 | default "0.0.0") }}
+  {{- $target := semver (index . 1) }}
+  {{- $result := print ($target.Original) ".*" }}
+  {{- if and (eq $version.Major $target.Major) (eq $version.Minor $target.Minor) }}
+    {{- $result = $version.Original }}
+  {{- end }}
+  {{- $result }}
+{{- end }}


### PR DESCRIPTION
- Add metadata.yaml with 4.18-specific telco-hub component definitions
- Add ReferenceVersionCheck.yaml for OpenShift 4.18 version validation
- Add version_match.tmpl template function for version checking
- Enables automated configuration drift detection for telco-hub deployments

Resolves missing kubectl cluster-compare functionality for telco-hub reference design.