### PR TITLE
Drop nodeSelector from NetworkAttachmentDefinition CR

### DIFF
--- a/telco-core/configuration/reference-crs-kube-compare/optional/networking/networkAttachmentDefinition.yaml
+++ b/telco-core/configuration/reference-crs-kube-compare/optional/networking/networkAttachmentDefinition.yaml
@@ -6,10 +6,6 @@ metadata:
   name: {{ .metadata.name }}
   namespace: {{ .metadata.namespace }}
 spec:
-  {{ if .spec.nodeSelector }}
-  nodeSelector:
-    {{ .spec.nodeSelector | toYaml | indent 4 }}
-  {{ end }}
   config: {{ .spec.config | toJson }}
 {{- $configWarnings := list }}
 {{- if .spec.config }}

--- a/telco-core/configuration/reference-crs/optional/networking/networkAttachmentDefinition.yaml
+++ b/telco-core/configuration/reference-crs/optional/networking/networkAttachmentDefinition.yaml
@@ -7,8 +7,6 @@ metadata:
   name: $name
   namespace: $ns
 spec:
-  nodeSelector:
-    kubernetes.io/hostname: $nodeName
   config: $config
   # eg
   # config: '{


### PR DESCRIPTION
`nodeSelector` isn't a valid option for CR and causes issues like:
```bash
`NetworkAttachmentDefinition in version "v1" cannot be handled as a NetworkAttachmentDefinition:
        strict decoding error: unknown field "spec.nodeSelector"`
```