### PR TITLE
CNF-19212: Enforce cluster-compare architecture-aware performance profiles

### DIFF
--- a/telco-ran/configuration/kube-compare-reference/fetch-only/Node.yaml
+++ b/telco-ran/configuration/kube-compare-reference/fetch-only/Node.yaml
@@ -1,0 +1,7 @@
+# This is present in cluster-compare to ensure Node objects are available to the `lookupCRs` function
+apiVersion: v1
+kind: Node
+metadata:
+  {{- .metadata | default dict | toYaml | nindent 2 }}
+spec:
+  {{- .spec | default dict | toYaml | nindent 2 }}

--- a/telco-ran/configuration/kube-compare-reference/hack/compare.sh
+++ b/telco-ran/configuration/kube-compare-reference/hack/compare.sh
@@ -108,6 +108,7 @@ helm_per_arch() {
       done
     done
   done
+  return $errors
 }
 
 helmconvert() {
@@ -119,7 +120,7 @@ helmconvert() {
   echo "Converting reference files from $metadata with values $values to helm chart in $chart_dir"
   helm-convert -r "$metadata" -n "$chart_dir" -v "$values" || return 1
   if [[ -n $archdir && -d $archdir ]]; then
-    helm_per_arch "$chart_dir" "$rendered_dir" "$archdir"
+    helm_per_arch "$chart_dir" "$rendered_dir" "$archdir" || return 1
   else
     echo "Rendering helm chart into $rendered_dir"
     helm template rendered "$chart_dir" --output-dir "$rendered_dir" || return 1

--- a/telco-ran/configuration/kube-compare-reference/hack/compare_ignore
+++ b/telco-ran/configuration/kube-compare-reference/hack/compare_ignore
@@ -74,6 +74,9 @@ extra-manifest/image-registry-partition-mc.yaml.tmpl
 # Exists in the reference only, to enforce version compatibility
 version-check/ClusterVersionOperator.yaml
 
+# Fetch-only objects
+fetch-only/Node.yaml
+
 # Reference only to ensure default has not been changed
 machine-config/cgroup-check.yaml
 machine-config/container-runtime.yaml

--- a/telco-ran/configuration/kube-compare-reference/hack/default_value.yaml
+++ b/telco-ran/configuration/kube-compare-reference/hack/default_value.yaml
@@ -359,3 +359,11 @@ sriov_operator_SriovOperatorConfigForSNO:
 sriov_operator_SriovSubscription:
   - spec:
       source: redhat-operators-disconnected
+global:
+  lookup_substitutions:
+    lookupCRs_v1_Node:
+      - metadata:
+          name: node
+          labels:
+            kubernetes.io/arch: any
+        spec: spec

--- a/telco-ran/configuration/kube-compare-reference/metadata.yaml
+++ b/telco-ran/configuration/kube-compare-reference/metadata.yaml
@@ -321,6 +321,13 @@ parts:
       - name: console-disable
         allOrNoneOf:
           - path: cluster-tuning/console-disable/ConsoleOperatorDisable.yaml
+  - name: fetch-only
+    description: |-
+      These objects are only included so they are available to 'lookupCRs' functions in other templates; contents is not validated.
+    components:
+      - name: fetch-only
+        anyOf:
+          - path: fetch-only/Node.yaml
 
 templateFunctionFiles:
   - functions/validate_node_selector.tmpl

--- a/telco-ran/configuration/kube-compare-reference/node-tuning-operator/PerformanceProfile.yaml
+++ b/telco-ran/configuration/kube-compare-reference/node-tuning-operator/PerformanceProfile.yaml
@@ -1,3 +1,39 @@
+{{- /* Architecture detection loop: /* -}}
+{{- /* Find the architecture of the node which matches this object's nodeSelector */ -}}
+{{- $arch := "" }}
+{{- $profileSelectors := (keys .spec.nodeSelector) }}
+{{- $nodes := lookupCRs "v1" "Node" "" "" }}
+{{- range $node := $nodes }}
+  {{- /* Skip any nodes that do not match our nodeSelector criteria */ -}}
+  {{- range $selector := $profileSelectors }}
+    {{- if not (hasKey ($node.metadata.labels | default dict) $selector) }}
+      {{- continue }}
+    {{- end }}
+  {{- end }}
+  {{- /* Found the first matching node; record its architecture */ -}}
+  {{- $arch = index $node.metadata.labels "kubernetes.io/arch" }}
+  {{- /* MachineConfig operator already enforces that all machines in a given pool must be the same architecture */ -}}
+  {{- break }}
+{{- end }}
+{{- if ._arch }}
+  {{- /* Allow manual override override from telco-ran reference generator (if present) */ -}}
+  {{- $arch = ._arch }}
+{{- end }}
+{{- /* Normalize architecture names; the Node object uses "amd64" and "arm64" instead of "x86_64" and "aarch64" */ -}}
+{{- if eq $arch "amd64" }}
+  {{- $arch = "x86_64" }}
+{{- else if eq $arch "arm64" }}
+  {{- $arch = "aarch64" }}
+{{- end }}
+{{- if not $arch }}
+architecture_detection: |-
+  WARNING
+  -------
+  Architecture could not be detected for any nodes matching PerformanceProfile "{{ .metadata.name }}"
+  Tuning recommendations may not be accurate.
+  Ensure the cluster's Node records are available to cluster-compare.
+{{- end }}
+
 apiVersion: performance.openshift.io/v2
 kind: PerformanceProfile
 metadata:
@@ -27,7 +63,7 @@ metadata:
       {{- template "kubeletconfigExperimentalSysctls" (list (index (.metadata.annotations | default dict) "kubeletconfig.experimental") (list)  $allowedSysctls) }}
     {{- end }}
 spec:
-  {{- if eq ._arch "aarch64" }}
+  {{- if eq $arch "aarch64" }}
   # Note: The defaults here are for Grace Hopper systems. Other systems may alternative PCI or iommu settings such as:
   #       - pci=realloc (instead of pci=realloc-off)
   #       - iommu.passthrough=1
@@ -35,20 +71,34 @@ spec:
   additionalKernelArgs:
     {{- $requiredArgs := list
       "efi=runtime"
-      "module_blacklist=irdma"
       "rcupdate.rcu_normal_after_boot=0"
     }}
     {{- $optionalArgs := list
-      "vfio_pci.disable_idle_d3=1"
-      "vfio_pci.enable_sriov=1"
-      "iommu.passthrough=1"
-      "acpi_power_meter.force_cap_on=y"
       "console=.*"
       "earlycon"
-      "module_blacklist=nouveau"
-      "pci=realloc=off"
-      "pci=pcie_bus_safe"
     }}
+    {{- if eq $arch "x86_64" }}
+      {{- $requiredArgs = concat $requiredArgs ( list
+        "module_blacklist=irdma"
+      ) }}
+      {{- $optionalArgs = concat $optionalArgs ( list 
+        "vfio_pci.disable_idle_d3=1"
+        "vfio_pci.enable_sriov=1"
+      ) }}
+    {{- else if eq $arch "aarch64" }}
+      {{- $nonghKernelArgs := list
+        "iommu.passthrough=1"
+        "pci=realloc"
+        "pci=realloc=on"
+      }}
+      {{- $ghKernelArgs := list
+        "acpi_power_meter.force_cap_on=y"
+        "module_blacklist=nouveau"
+        "pci=realloc=off"
+        "pci=pcie_bus_safe"
+      }}
+      {{- $optionalArgs = concat $optionalArgs $nonghKernelArgs $ghKernelArgs }}
+    {{- end }}
     {{- if .spec.workloadHints.perPodPowerManagement }}
       {{- $optionalArgs = append $optionalArgs "cpufreq.default_governor=.*" }}
     {{- end }}

--- a/telco-ran/configuration/source-crs/node-tuning-operator/aarch64/PerformanceProfile-SetSelector.yaml
+++ b/telco-ran/configuration/source-crs/node-tuning-operator/aarch64/PerformanceProfile-SetSelector.yaml
@@ -22,7 +22,6 @@ spec:
     - module_blacklist=nouveau
     - pci=realloc=off
     - pci=pcie_bus_safe
-    - module_blacklist=irdma
   cpu:
   #  isolated: 4-$lastcpu
   #  reserved: 0-3

--- a/telco-ran/configuration/source-crs/node-tuning-operator/aarch64/PerformanceProfile.yaml
+++ b/telco-ran/configuration/source-crs/node-tuning-operator/aarch64/PerformanceProfile.yaml
@@ -22,7 +22,6 @@ spec:
     - module_blacklist=nouveau
     - pci=realloc=off
     - pci=pcie_bus_safe
-    - module_blacklist=irdma
   cpu:
     isolated: 4-$lastcpu
     reserved: 0-3


### PR DESCRIPTION
This ensures x86-only and arm-only arguments are enforced by
cluster-compare and in our example profiles.
