### PR TITLE
added missing yamls to gitops kustomization

### DIFF
--- a/telco-hub/configuration/reference-crs/required/gitops/kustomization.yaml
+++ b/telco-hub/configuration/reference-crs/required/gitops/kustomization.yaml
@@ -13,3 +13,7 @@ resources:
   - gitopsOperatorGroup.yaml
   - gitopsSubscription.yaml
   - addPluginsPolicy.yaml
+  - addPluginsMCSB.yaml
+  - addPluginsPolicyNS.yaml
+  - addPluginsPolicyPlacementBinding.yaml
+  - addPluginsPolicyPlacement.yaml


### PR DESCRIPTION
I dont know when we missed this. But, looks that the kustomization is missing some manifests to configure the Policies correctly. 