### PR TITLE
RAN Hardening: Low Severity (dmesg restrict)

### DIFF
--- a/telco-ran/configuration/machineconfigs/sysctl/75-sysctl_kernel_dmesg_restrict-low-combo.yaml
+++ b/telco-ran/configuration/machineconfigs/sysctl/75-sysctl_kernel_dmesg_restrict-low-combo.yaml
@@ -1,0 +1,22 @@
+# Combined from the following remediations for /etc/sysctl.d/75-sysctl_kernel_dmesg_restrict.conf (all roles) | severity: low:
+#   - low/rhcos4-e8-master-sysctl-kernel-dmesg-restrict.yaml
+#   - low/rhcos4-e8-worker-sysctl-kernel-dmesg-restrict.yaml
+apiVersion: machineconfiguration.openshift.io/v1
+kind: MachineConfig
+spec:
+  config:
+    ignition:
+      version: 3.1.0
+    storage:
+      files:
+        - contents:
+            # The following lines are the deduplicated, combined plaintext contents from all related MachineConfig remediations.
+            # kernel.dmesg_restrict=1
+            source: data:,kernel.dmesg_restrict%3D1%0A
+          mode: 384
+          overwrite: true
+          path: /etc/sysctl.d/75-sysctl_kernel_dmesg_restrict.conf
+metadata:
+  name: 75-sysctl_kernel_dmesg_restrict-low-combo
+  labels:
+    machineconfiguration.openshift.io/role: worker


### PR DESCRIPTION
This is the only low level compliance failure I'm seeing in the compliance operator that stands alone in its own `path`: `/etc/sysctl.d/75-sysctl_kernel_dmesg_restrict.conf`

Enabling `kernel.dmesg_restrict=1` is safe for Kubernetes and OpenShift because neither the control plane components nor workloads rely on direct access to dmesg for logging or operations. These platforms use systemd journals, CRI runtimes, and container stdout/stderr for log collection, so blocking user access to the kernel ring buffer has no functional impact. 

Restricting dmesg prevents unprivileged users or compromised pods from gathering sensitive kernel information such as memory addresses or driver details, which could aid in exploits. Including this setting strengthens node-level security and aligns with common hardening practices in production clusters.