### PR TITLE
 updating ODF version to match ocp version 4.19

### DIFF
--- a/telco-hub/configuration/reference-crs/optional/odf-internal/odfSubscription.yaml
+++ b/telco-hub/configuration/reference-crs/optional/odf-internal/odfSubscription.yaml
@@ -7,7 +7,7 @@ metadata:
   name: odf-operator
   namespace: openshift-storage
 spec:
-  channel: "stable-4.18"
+  channel: "stable-4.19"
   name: odf-operator
   source: redhat-operators-disconnected
   sourceNamespace: openshift-marketplace


### PR DESCRIPTION
ODF version should match OCP version. updating ODF subscription to match the OCP version of 4.19.