### PR TITLE
chore(KONFLUX-6210): fix and set name and cpe label for telco-core-rds-4-16

### DIFF
--- a/telco-core/Dockerfile.telco-core
+++ b/telco-core/Dockerfile.telco-core
@@ -12,6 +12,7 @@ ENTRYPOINT ["/bin/bash"]
 CMD ["-c", "tar -cf - --directory /usr/share telco-core-rds | base64 -w0"]
 
 LABEL com.redhat.component="openshift-telco-core-rds-container" \
+    cpe="cpe:/a:redhat:openshift:4.16::el9" \
     name="openshift4/openshift-telco-core-rds-rhel9" \
     summary="Telco Core RDS manifests" \
     io.openshift.expose-services="" \


### PR DESCRIPTION
For https://issues.redhat.com/browse/KONFLUX-6210, clair needs access to a name and cpe label that it can use to look up the image in VEX statements.

See also release-engineering/rhtap-ec-policy#149

Signed-off-by: Ralph Bean <rbean@redhat.com>
Assisted-by: Gemini
