### PR TITLE
CNF-19322: telco-ran: Move all required kernel arguments from PerformanceProfile to TunedPerformancePatch

### DIFF
--- a/telco-ran/configuration/kube-compare-reference/hack/arch/aarch64.yaml
+++ b/telco-ran/configuration/kube-compare-reference/hack/arch/aarch64.yaml
@@ -1,8 +1,6 @@
 node_tuning_operator_PerformanceProfile:
   - spec:
       additionalKernelArgs:
-        - "rcupdate.rcu_normal_after_boot=0"
-        - "efi=runtime"
         - acpi_power_meter.force_cap_on=y
         - console=ttyAMA0,115200n8
         - earlycon

--- a/telco-ran/configuration/kube-compare-reference/hack/arch/x86_64.yaml
+++ b/telco-ran/configuration/kube-compare-reference/hack/arch/x86_64.yaml
@@ -1,11 +1,8 @@
 node_tuning_operator_PerformanceProfile:
   - spec:
       additionalKernelArgs:
-        - "rcupdate.rcu_normal_after_boot=0"
-        - "efi=runtime"
         - "vfio_pci.enable_sriov=1"
         - "vfio_pci.disable_idle_d3=1"
-        - "module_blacklist=irdma"
       cpu:
         isolated: $isolated
         reserved: $reserved

--- a/telco-ran/configuration/kube-compare-reference/node-tuning-operator/PerformanceProfile.yaml
+++ b/telco-ran/configuration/kube-compare-reference/node-tuning-operator/PerformanceProfile.yaml
@@ -76,19 +76,16 @@ spec:
   #   To enable acpi_idle CPUIdle driver
   #     - intel_idle.max_cstate=0
   {{- end }}
+  {{- if .spec.additionalKernelArgs }}
   additionalKernelArgs:
-    {{- $requiredArgs := list
-      "efi=runtime"
-      "rcupdate.rcu_normal_after_boot=0"
-    }}
     {{- $optionalArgs := list
       "console=.*"
       "earlycon"
+      "efi=runtime"
+      "rcupdate.rcu_normal_after_boot=0"
+      "module_blacklist=.*"
     }}
     {{- if eq $arch "x86_64" }}
-      {{- $requiredArgs = concat $requiredArgs ( list
-        "module_blacklist=irdma"
-      ) }}
       {{- $optionalArgs = concat $optionalArgs ( list 
         "vfio_pci.disable_idle_d3=1"
         "vfio_pci.enable_sriov=1"
@@ -110,7 +107,8 @@ spec:
     {{- if .spec.workloadHints.perPodPowerManagement }}
       {{- $optionalArgs = append $optionalArgs "cpufreq.default_governor=.*" }}
     {{- end }}
-    {{- template "kernelArgList" (list .spec.additionalKernelArgs $requiredArgs $optionalArgs) }}
+    {{- template "kernelArgList" (list .spec.additionalKernelArgs ( list ) $optionalArgs) }}
+  {{- end }}
   cpu:
     isolated: {{ .spec.cpu.isolated }}
     reserved: {{ .spec.cpu.reserved }}

--- a/telco-ran/configuration/kube-compare-reference/node-tuning-operator/TunedPerformancePatch.yaml
+++ b/telco-ran/configuration/kube-compare-reference/node-tuning-operator/TunedPerformancePatch.yaml
@@ -23,6 +23,9 @@ spec:
         [service]
         service.chronyd=stop,disable
         service.stalld=start,enable
+        [bootloader]
+        cmdline_add=rcupdate.rcu_normal_after_boot=0
+        cmdline_add=efi=runtime
     - name: performance-patch-arm-aarch64
       data: |
         [main]
@@ -35,6 +38,8 @@ spec:
         group.ice-ptp=0:f:10:*:ice-ptp.*
         group.ice-gnss=0:f:10:*:ice-gnss.*
         group.ice-dplls=0:f:10:*:ice-dplls.*
+        [bootloader]
+        cmdline_add=module_blacklist=irdma
     - name: performance-patch-amd-x86
       data: |
         [main]
@@ -43,6 +48,8 @@ spec:
         group.ice-ptp=0:f:10:*:ice-ptp.*
         group.ice-gnss=0:f:10:*:ice-gnss.*
         group.ice-dplls=0:f:10:*:ice-dplls.*
+        [bootloader]
+        cmdline_add=module_blacklist=irdma
   recommend:
   {{- range .spec.recommend }}
     - machineConfigLabels:

--- a/telco-ran/configuration/source-crs/node-tuning-operator/TunedPerformancePatch.yaml
+++ b/telco-ran/configuration/source-crs/node-tuning-operator/TunedPerformancePatch.yaml
@@ -23,6 +23,9 @@ spec:
         [service]
         service.chronyd=stop,disable
         service.stalld=start,enable
+        [bootloader]
+        cmdline_add=rcupdate.rcu_normal_after_boot=0
+        cmdline_add=efi=runtime
     - name: performance-patch-arm-aarch64
       data: |
         [main]
@@ -35,6 +38,8 @@ spec:
         group.ice-ptp=0:f:10:*:ice-ptp.*
         group.ice-gnss=0:f:10:*:ice-gnss.*
         group.ice-dplls=0:f:10:*:ice-dplls.*
+        [bootloader]
+        cmdline_add=module_blacklist=irdma
     - name: performance-patch-amd-x86
       data: |
         [main]
@@ -43,6 +48,8 @@ spec:
         group.ice-ptp=0:f:10:*:ice-ptp.*
         group.ice-gnss=0:f:10:*:ice-gnss.*
         group.ice-dplls=0:f:10:*:ice-dplls.*
+        [bootloader]
+        cmdline_add=module_blacklist=irdma
   recommend:
     - machineConfigLabels:
         machineconfiguration.openshift.io/role: $mcp

--- a/telco-ran/configuration/source-crs/node-tuning-operator/aarch64/PerformanceProfile-SetSelector.yaml
+++ b/telco-ran/configuration/source-crs/node-tuning-operator/aarch64/PerformanceProfile-SetSelector.yaml
@@ -14,8 +14,6 @@ spec:
   #       - pci=realloc=on (default is off)
   #       - iommu.passthrough=1
   additionalKernelArgs:
-    - rcupdate.rcu_normal_after_boot=0
-    - efi=runtime
     - acpi_power_meter.force_cap_on=y
     - console=ttyAMA0,115200n8
     - earlycon

--- a/telco-ran/configuration/source-crs/node-tuning-operator/aarch64/PerformanceProfile.yaml
+++ b/telco-ran/configuration/source-crs/node-tuning-operator/aarch64/PerformanceProfile.yaml
@@ -14,8 +14,6 @@ spec:
   #       - pci=realloc=on (default is off)
   #       - iommu.passthrough=1
   additionalKernelArgs:
-    - rcupdate.rcu_normal_after_boot=0
-    - efi=runtime
     - acpi_power_meter.force_cap_on=y
     - console=ttyAMA0,115200n8
     - earlycon

--- a/telco-ran/configuration/source-crs/node-tuning-operator/x86_64/PerformanceProfile-SetSelector.yaml
+++ b/telco-ran/configuration/source-crs/node-tuning-operator/x86_64/PerformanceProfile-SetSelector.yaml
@@ -14,11 +14,8 @@ spec:
   #   To enable acpi_idle CPUIdle driver
   #     - intel_idle.max_cstate=0
   additionalKernelArgs:
-    - rcupdate.rcu_normal_after_boot=0
-    - efi=runtime
     - vfio_pci.enable_sriov=1
     - vfio_pci.disable_idle_d3=1
-    - module_blacklist=irdma
   cpu:
   #    isolated: $isolated
   #    reserved: $reserved

--- a/telco-ran/configuration/source-crs/node-tuning-operator/x86_64/PerformanceProfile.yaml
+++ b/telco-ran/configuration/source-crs/node-tuning-operator/x86_64/PerformanceProfile.yaml
@@ -14,11 +14,8 @@ spec:
   #   To enable acpi_idle CPUIdle driver
   #     - intel_idle.max_cstate=0
   additionalKernelArgs:
-    - rcupdate.rcu_normal_after_boot=0
-    - efi=runtime
     - vfio_pci.enable_sriov=1
     - vfio_pci.disable_idle_d3=1
-    - module_blacklist=irdma
   cpu:
     isolated: $isolated
     reserved: $reserved


### PR DESCRIPTION
Rather than requiring customers to keep required arguments in the
PerformanceProfile object, it is easier to enforce them in the
TunedPerformancePatch which is properly architecture-aware.

Signed-off-by: Jim Ramsay <jramsay@redhat.com>
