### PR TITLE
telco-ran: Fix PerformanceProfile architecture detection for MNO

### DIFF
--- a/telco-ran/configuration/kube-compare-reference/node-tuning-operator/PerformanceProfile.yaml
+++ b/telco-ran/configuration/kube-compare-reference/node-tuning-operator/PerformanceProfile.yaml
@@ -5,10 +5,14 @@
 {{- $nodes := lookupCRs "v1" "Node" "" "" }}
 {{- range $node := $nodes }}
   {{- /* Skip any nodes that do not match our nodeSelector criteria */ -}}
+  {{- $found := false }}
   {{- range $selector := $profileSelectors }}
-    {{- if not (hasKey ($node.metadata.labels | default dict) $selector) }}
-      {{- continue }}
+    {{- if hasKey ($node.metadata.labels | default dict) $selector }}
+      {{ $found = true }}
     {{- end }}
+  {{- end }}
+  {{- if not $found }}
+    {{- continue }}
   {{- end }}
   {{- /* Found the first matching node; record its architecture */ -}}
   {{- $arch = index $node.metadata.labels "kubernetes.io/arch" }}


### PR DESCRIPTION
The 'continue' was escaping from the wrong scope; Setting a temporary
variable and escaping from the correct loop ensures detection works in
an MNO setting.

Signed-off-by: Jim Ramsay <jramsay@redhat.com>
