### PR TITLE
telco-hub: cluster-compare: ignore several annotations/labels and CR names

### DIFF
--- a/telco-hub/configuration/reference-crs-kube-compare/metadata.yaml
+++ b/telco-hub/configuration/reference-crs-kube-compare/metadata.yaml
@@ -161,6 +161,7 @@ fieldsToOmit:
       - pathToKey: metadata.labels."operators.coreos.com/local-storage-operator.openshift-local-storage"
       - pathToKey: metadata.labels."operators.coreos.com/odf-operator.openshift-storage"
       - pathToKey: metadata.labels."operators.coreos.com/topology-aware-lifecycle-manager.openshift-operators"
+      - pathToKey: metadata.labels."operators.coreos.com/cluster-logging.openshift-logging"
       - pathToKey: metadata.labels."operators.coreos.com/advanced-cluster-management.open-cluster-management"
       - pathToKey: metadata.labels."operators.coreos.com/openshift-gitops-operator.openshift-gitops-operator"
       - pathToKey: metadata.labels."agent-install.openshift.io/watch"
@@ -174,6 +175,10 @@ fieldsToOmit:
       - pathToKey: metadata.labels."installer.name"
       - pathToKey: metadata.labels."installer.namespace"
       - pathToKey: metadata.labels."multiclusterhubs.operator.open-cluster-management.io/managed-by"
+      - pathToKey: metadata.annotations."include.release.openshift.io/ibm-cloud-managed"
+      - pathToKey: metadata.annotations."include.release.openshift.io/self-managed-high-availability"
+      - pathToKey: metadata.annotations."release.openshift.io/create-only"
+      - pathToKey: metadata.annotations."ran.openshift.io/ztp-deploy-wave"
       - pathToKey: metadata.creationTimestamp
       - pathToKey: metadata.finalizers
       - pathToKey: metadata.generation

--- a/telco-hub/configuration/reference-crs-kube-compare/optional/logging/clusterLogOperGroup.yaml
+++ b/telco-hub/configuration/reference-crs-kube-compare/optional/logging/clusterLogOperGroup.yaml
@@ -4,7 +4,7 @@ kind: OperatorGroup
 metadata:
   annotations:
     argocd.argoproj.io/sync-wave: "-40"
-  name: cluster-logging
+  name: {{ .metadata.name }}
   namespace: openshift-logging
 spec:
   targetNamespaces:

--- a/telco-hub/configuration/reference-crs-kube-compare/optional/logging/clusterLogSubscription.yaml
+++ b/telco-hub/configuration/reference-crs-kube-compare/optional/logging/clusterLogSubscription.yaml
@@ -4,7 +4,7 @@ kind: Subscription
 metadata:
   annotations:
     argocd.argoproj.io/sync-wave: "-40"
-  name: cluster-logging
+  name: {{ .metadata.name }}
   namespace: openshift-logging
 spec:
   channel: "stable-6.2"

--- a/telco-hub/configuration/reference-crs-kube-compare/optional/lso/lsoOperatorGroup.yaml
+++ b/telco-hub/configuration/reference-crs-kube-compare/optional/lso/lsoOperatorGroup.yaml
@@ -4,7 +4,7 @@ kind: OperatorGroup
 metadata:
   annotations:
     argocd.argoproj.io/sync-wave: "-40"
-  name: local-operator-group
+  name: {{ .metadata.name }}
   namespace: openshift-local-storage
 spec:
   targetNamespaces:

--- a/telco-hub/configuration/reference-crs-kube-compare/optional/lso/lsoSubscription.yaml
+++ b/telco-hub/configuration/reference-crs-kube-compare/optional/lso/lsoSubscription.yaml
@@ -4,7 +4,7 @@ kind: Subscription
 metadata:
   annotations:
     argocd.argoproj.io/sync-wave: "-40"
-  name: local-storage-operator
+  name: {{ .metadata.name }}
   namespace: openshift-local-storage
 spec:
   channel: stable

--- a/telco-hub/configuration/reference-crs-kube-compare/optional/odf-internal/odfOperatorGroup.yaml
+++ b/telco-hub/configuration/reference-crs-kube-compare/optional/odf-internal/odfOperatorGroup.yaml
@@ -4,7 +4,7 @@ kind: OperatorGroup
 metadata:
   annotations:
     argocd.argoproj.io/sync-wave: "-40"
-  name: openshift-storage-operatorgroup
+  name: {{ .metadata.name }}
   namespace: openshift-storage
 spec:
   targetNamespaces:

--- a/telco-hub/configuration/reference-crs-kube-compare/optional/odf-internal/odfSubscription.yaml
+++ b/telco-hub/configuration/reference-crs-kube-compare/optional/odf-internal/odfSubscription.yaml
@@ -4,7 +4,7 @@ kind: Subscription
 metadata:
   annotations:
     argocd.argoproj.io/sync-wave: "-40"
-  name: odf-operator
+  name: {{ .metadata.name }}
   namespace: openshift-storage
 spec:
   channel: "stable-4.18"

--- a/telco-hub/configuration/reference-crs-kube-compare/required/acm/acmOperGroup.yaml
+++ b/telco-hub/configuration/reference-crs-kube-compare/required/acm/acmOperGroup.yaml
@@ -4,7 +4,7 @@ kind: OperatorGroup
 metadata:
   annotations:
     argocd.argoproj.io/sync-wave: "-40"
-  name: open-cluster-management-group
+  name: {{ .metadata.name }}
   namespace: open-cluster-management
 spec:
   targetNamespaces:

--- a/telco-hub/configuration/reference-crs-kube-compare/required/acm/acmSubscription.yaml
+++ b/telco-hub/configuration/reference-crs-kube-compare/required/acm/acmSubscription.yaml
@@ -4,7 +4,7 @@ kind: Subscription
 metadata:
   annotations:
     argocd.argoproj.io/sync-wave: "-40"
-  name: open-cluster-management-subscription
+  name: {{ .metadata.name }}
   namespace: open-cluster-management
 spec:
   channel: release-2.13

--- a/telco-hub/configuration/reference-crs-kube-compare/required/gitops/gitopsOperatorGroup.yaml
+++ b/telco-hub/configuration/reference-crs-kube-compare/required/gitops/gitopsOperatorGroup.yaml
@@ -4,7 +4,7 @@ kind: OperatorGroup
 metadata:
   annotations:
     argocd.argoproj.io/sync-wave: "-40"
-  name: openshift-gitops-operator
+  name: {{ .metadata.name }}
   namespace: openshift-gitops-operator
 spec:
   {{- if .spec.upgradeStrategy }}

--- a/telco-hub/configuration/reference-crs-kube-compare/required/gitops/gitopsSubscription.yaml
+++ b/telco-hub/configuration/reference-crs-kube-compare/required/gitops/gitopsSubscription.yaml
@@ -4,7 +4,7 @@ kind: Subscription
 metadata:
   annotations:
     argocd.argoproj.io/sync-wave: "-40"
-  name: openshift-gitops-operator
+  name: {{ .metadata.name }}
   namespace: openshift-gitops-operator
 spec:
   channel: gitops-1.16

--- a/telco-hub/configuration/reference-crs-kube-compare/required/talm/talmSubscription.yaml
+++ b/telco-hub/configuration/reference-crs-kube-compare/required/talm/talmSubscription.yaml
@@ -4,7 +4,7 @@ kind: Subscription
 metadata:
   annotations:
     argocd.argoproj.io/sync-wave: "-40"
-  name: openshift-topology-aware-lifecycle-manager-subscription
+  name: {{ .metadata.name }}
   namespace: openshift-operators
 spec:
   channel: stable


### PR DESCRIPTION
In telco-hub cluster compare tool, ignore several annotations and labels, also don't compare the CR names for operatorgroup and subscription. 