### PR TITLE
Fixed syntax issue in the registry-ca and registry-ca-patch files

### DIFF
--- a/telco-hub/configuration/example-overlays-config/registry/registry-ca-patch.yaml
+++ b/telco-hub/configuration/example-overlays-config/registry/registry-ca-patch.yaml
@@ -2,7 +2,7 @@
 - op: replace
   path: "/data"
   value:
-    "registry.example.com..8443": |
+    registry.example.com..8443: |
       -----BEGIN CERTIFICATE-----
       MIIGcjCCBFqgAwIBAgIFICIE...
       -----END CERTIFICATE-----

--- a/telco-hub/configuration/reference-crs/required/registry/registry-ca.yaml
+++ b/telco-hub/configuration/reference-crs/required/registry/registry-ca.yaml
@@ -8,7 +8,7 @@ metadata:
   namespace: openshift-config
 data:
   # important: keep the format "url..port"
-  "<registry.example.com..8443>": |
+  <registry.example.com..8443>: |
     -----BEGIN CERTIFICATE-----
     MIIGcjCCBFqgAwIBAgIFICIE...
     -----END CERTIFICATE-----


### PR DESCRIPTION
This fixes #370 by fixing the syntax errors in the value fields of the reference-ca* files under hub-configuration.