### PR TITLE
telco-ran: OCPBUGS-62245: skip secret lookup if acm observability is disabled

### DIFF
--- a/telco-ran/configuration/kube-compare-reference/hack/default_value.yaml
+++ b/telco-ran/configuration/kube-compare-reference/hack/default_value.yaml
@@ -307,7 +307,7 @@ cluster_tuning_monitoring_configuration_ReduceMonitoringFootprint:
   - metadata:
       name: cluster-monitoring-config
     captureGroup_defaults:
-      alertmanager_endpoint: '{{ `{{ (regexFind "alertmanager-endpoint(.*)" ((fromSecret "open-cluster-management-addon-observability" "hub-info-secret" "hub-info.yaml") | base64dec)) | replace "alertmanager-endpoint: https://" "" }}` }}'
+      alertmanager_endpoint: '{{ `{{ if (lookup "v1" "Namespace" "" "open-cluster-management-addon-observability") }}{{ (regexFind "alertmanager-endpoint(.*)" ((fromSecret "open-cluster-management-addon-observability" "hub-info-secret" "hub-info.yaml") | base64dec)) | replace "alertmanager-endpoint: https://" "" }}{{ else }}[]{{ end }}` }}'
       managed_cluster: '{{ `{{ fromClusterClaim "id.openshift.io" }}` }}'
 lca_LcaSubscription:
   - spec:

--- a/telco-ran/configuration/kube-compare-reference/hack/default_value.yaml
+++ b/telco-ran/configuration/kube-compare-reference/hack/default_value.yaml
@@ -307,7 +307,7 @@ cluster_tuning_monitoring_configuration_ReduceMonitoringFootprint:
   - metadata:
       name: cluster-monitoring-config
     captureGroup_defaults:
-      alertmanager_endpoint: '{{ `{{ if (lookup "v1" "Namespace" "" "open-cluster-management-addon-observability") }}{{ (regexFind "alertmanager-endpoint(.*)" ((fromSecret "open-cluster-management-addon-observability" "hub-info-secret" "hub-info.yaml") | base64dec)) | replace "alertmanager-endpoint: https://" "" }}{{ else }}[]{{ end }}` }}'
+      alertmanager_endpoint: '{{ `{{ if (lookup "v1" "Namespace" "" "open-cluster-management-addon-observability") }}{{ (regexFind "alertmanager-endpoint(.*)" ((fromSecret "open-cluster-management-addon-observability" "hub-info-secret" "hub-info.yaml") | base64dec)) | replace "alertmanager-endpoint: https://" "" }}{{ end }}` }}'
       managed_cluster: '{{ `{{ fromClusterClaim "id.openshift.io" }}` }}'
 lca_LcaSubscription:
   - spec:

--- a/telco-ran/configuration/source-crs/cluster-tuning/monitoring-configuration/ReduceMonitoringFootprint.yaml
+++ b/telco-ran/configuration/source-crs/cluster-tuning/monitoring-configuration/ReduceMonitoringFootprint.yaml
@@ -30,7 +30,7 @@ data:
           name: observability-alertmanager-accessor
         scheme: https
         staticConfigs:
-        - {{ (regexFind "alertmanager-endpoint(.*)" ((fromSecret "open-cluster-management-addon-observability" "hub-info-secret" "hub-info.yaml") | base64dec)) | replace "alertmanager-endpoint: https://" "" }}
+        - {{ if (lookup "v1" "Namespace" "" "open-cluster-management-addon-observability") }}{{ (regexFind "alertmanager-endpoint(.*)" ((fromSecret "open-cluster-management-addon-observability" "hub-info-secret" "hub-info.yaml") | base64dec)) | replace "alertmanager-endpoint: https://" "" }}{{ else }}[]{{ end }}
         tlsConfig:
           ca:
             key: service-ca.crt

--- a/telco-ran/configuration/source-crs/cluster-tuning/monitoring-configuration/ReduceMonitoringFootprint.yaml
+++ b/telco-ran/configuration/source-crs/cluster-tuning/monitoring-configuration/ReduceMonitoringFootprint.yaml
@@ -30,7 +30,7 @@ data:
           name: observability-alertmanager-accessor
         scheme: https
         staticConfigs:
-        - {{ if (lookup "v1" "Namespace" "" "open-cluster-management-addon-observability") }}{{ (regexFind "alertmanager-endpoint(.*)" ((fromSecret "open-cluster-management-addon-observability" "hub-info-secret" "hub-info.yaml") | base64dec)) | replace "alertmanager-endpoint: https://" "" }}{{ else }}[]{{ end }}
+        - {{ if (lookup "v1" "Namespace" "" "open-cluster-management-addon-observability") }}{{ (regexFind "alertmanager-endpoint(.*)" ((fromSecret "open-cluster-management-addon-observability" "hub-info-secret" "hub-info.yaml") | base64dec)) | replace "alertmanager-endpoint: https://" "" }}{{ end }}
         tlsConfig:
           ca:
             key: service-ca.crt


### PR DESCRIPTION
This PR wraps the fromSecret lookup for ACM observability so that it does not fail when it is disabled (and hub-info-secret is not present)