### PR TITLE
telco-core: skip secret lookup if acm observability is disabled

### DIFF
--- a/telco-core/configuration/reference-crs/optional/other/monitoring-config-cm.yaml
+++ b/telco-core/configuration/reference-crs/optional/other/monitoring-config-cm.yaml
@@ -27,7 +27,7 @@ data:
           name: observability-alertmanager-accessor
         scheme: https
         staticConfigs:
-        - {{ (regexFind "alertmanager-endpoint(.*)" ((fromSecret "open-cluster-management-addon-observability" "hub-info-secret" "hub-info.yaml") | base64dec)) | replace "alertmanager-endpoint: https://" "" }}
+        - {{ if (lookup "v1" "Namespace" "" "open-cluster-management-addon-observability") }}{{ (regexFind "alertmanager-endpoint(.*)" ((fromSecret "open-cluster-management-addon-observability" "hub-info-secret" "hub-info.yaml") | base64dec)) | replace "alertmanager-endpoint: https://" "" }}{{ end }}
         tlsConfig:
           ca:
             key: service-ca.crt


### PR DESCRIPTION
This PR wraps the fromSecret lookup for ACM observability so that it does not fail when it is disabled (and hub-info-secret is not present) for core