### PR TITLE
Update doc links to current versions

### DIFF
--- a/telco-hub/README.md
+++ b/telco-hub/README.md
@@ -1,7 +1,7 @@
 # Telco Hub Cluster Setup
 
 The goal of this document is to provide a step-by-step guide on how to install and configure a Hub cluster that follows the
-specifications and recommendations of the [Telco Hub Cluster RDS](https://docs.redhat.com/en/documentation/openshift_container_platform/4.18/html/scalability_and_performance/telco-hub-ref-design-specs). Starting from a basic OpenShift cluster,
+specifications and recommendations of the [Telco Hub Cluster RDS](https://docs.redhat.com/en/documentation/openshift_container_platform/4.19/html/scalability_and_performance/telco-hub-ref-design-specs). Starting from a basic OpenShift cluster,
 the different operators that make up a Hub cluster will be installed, all in a disconnected environment.
 
 The Yaml manifests used to install the OpenShift cluster and the required mirror registry can be found in the [install](install) folder
@@ -25,7 +25,7 @@ is acceptable as long as they reach the same end result. The instructions below 
 The instructions that follow consider a partially-disconnected environment. In this kind of environment there is a host that has
 Internet connectivity but the OCP nodes of the Hub cluster are disconnected. This scenario has the advantage that it allows to create and
 populate the mirror registry directly using the public repositories while proceeding with the Hub cluster installation as if it was fully-disconnected.
-For a fully disconnected environment a few additional step are required (see [Mirroring an image set in a fully disconnected environment](https://docs.redhat.com/en/documentation/openshift_container_platform/4.17/html-single/disconnected_environments/index#mirroring-image-set-full)).
+For a fully disconnected environment a few additional step are required (see [Mirroring an image set in a fully disconnected environment](https://docs.redhat.com/en/documentation/openshift_container_platform/4.19/html-single/disconnected_environments/index#mirroring-image-set-full)).
 
 [Mirror registry setup](install/mirror-registry/README.md)
 

--- a/telco-hub/install/mirror-registry/README.md
+++ b/telco-hub/install/mirror-registry/README.md
@@ -6,12 +6,12 @@ In order to create a mirror registry follow the steps below:
 2. [Generate the SSL/TLS certificates](https://docs.redhat.com/en/documentation/red_hat_quay/3/html/proof_of_concept_-_deploying_red_hat_quay/advanced-quay-poc-deployment).
 3. Create the mirror registry with the following command:
    `./mirror-registry install --quayHostname <registry.example.com> --sslCert ssl.cert --sslKey ssl.key`.
-4. [Install the oc-mirror plugin](https://docs.redhat.com/en/documentation/openshift_container_platform/4.17/html-single/disconnected_environments/index#installation-oc-mirror-installing-plugin_about-installing-oc-mirror-v2).
-5. [Configure the pull-secret to contain the mirror registry credentials](https://docs.redhat.com/en/documentation/openshift_container_platform/4.17/html-single/disconnected_environments/index#installation-adding-registry-pull-secret_about-installing-oc-mirror-v2).
+4. [Install the oc-mirror plugin](https://docs.redhat.com/en/documentation/openshift_container_platform/4.19/html-single/disconnected_environments/index#installation-oc-mirror-installing-plugin_about-installing-oc-mirror-v2).
+5. [Configure the pull-secret to contain the mirror registry credentials](https://docs.redhat.com/en/documentation/openshift_container_platform/4.19/html-single/disconnected_environments/index#installation-adding-registry-pull-secret_about-installing-oc-mirror-v2).
 6. Create the `imageset-config.yaml` file to mirror the OCP release as well as the required operators images.
 7. Mirror the images required for a disconnected installation: `oc mirror -c imageset-config.yaml --workspace file://oc-mirror-workspace docker://<registry.example.com:8443> --v2`.
 8. Check the mirror registry’s local website (`<registry.example.com:8443>`) to verify that the repositories have been created and that the images have been pushed (see Usage Logs).
 
-For more information see [Disconnected environments](https://docs.redhat.com/en/documentation/openshift_container_platform/4.17/html-single/disconnected_environments/index).
+For more information see [Disconnected environments](https://docs.redhat.com/en/documentation/openshift_container_platform/4.19/html-single/disconnected_environments/index).
 
 Back to [Hub Cluster Setup](../../README.md).


### PR DESCRIPTION
I've been experimenting with a new tool I wrote that will traverse markdown files in search of "old" OCP doc links:

https://github.com/sebrandon1/ocp-doc-checker

It can also be installed as a Github Action and will lint docs live.  