### PR TITLE
telco-core: OCPBUGS-59293: cluster compare to accept logLevel field in nrop

### DIFF
--- a/telco-core/configuration/reference-crs-kube-compare/required/scheduling/nrop.yaml
+++ b/telco-core/configuration/reference-crs-kube-compare/required/scheduling/nrop.yaml
@@ -5,6 +5,9 @@ kind: NUMAResourcesOperator
 metadata:
   name: numaresourcesoperator
 spec:
+{{- if .spec.logLevel }}
+  logLevel: {{ .spec.logLevel }}
+{{- end }}
   nodeGroups:
   {{- if .spec.nodeGroups }}
     {{- range .spec.nodeGroups }}


### PR DESCRIPTION
This PR allows cluster compare tool to accept logLevel field in nrop (if its present) and not show a diff