### PR TITLE
telco-core: OCPBUGS-59296: add defaults for bgppeer

### DIFF
--- a/telco-core/configuration/reference-crs-kube-compare/required/networking/metallb/bgp-peer.yaml
+++ b/telco-core/configuration/reference-crs-kube-compare/required/networking/metallb/bgp-peer.yaml
@@ -10,3 +10,5 @@ spec:
   routerID: {{ .spec.routerID }}
   bfdProfile: {{ .spec.bfdProfile }}
   passwordSecret: {{ .spec.passwordSecret | toJson }}
+  disableMP: {{ .spec.disableMP }}
+  peerPort: {{ .spec.peerPort }}

--- a/telco-core/configuration/reference-crs/required/networking/metallb/bgp-peer.yaml
+++ b/telco-core/configuration/reference-crs/required/networking/metallb/bgp-peer.yaml
@@ -13,3 +13,5 @@ spec:
   routerID: $id  # eg 10.10.10.10
   bfdProfile: $bfdprofile  # e.g. bfdprofile
   passwordSecret: {}
+  disableMP: $disableMP # e.g. false
+  peerPort: $peerPort # e.g. 179


### PR DESCRIPTION
Added accepted defaults for bgppeer in kube-compare-reference