### PR TITLE
RHEL-90663: Adjust crashkernel size to 676M for all architectures

### DIFF
--- a/telco-ran/configuration/extra-manifests-builder/06-kdump/build.sh
+++ b/telco-ran/configuration/extra-manifests-builder/06-kdump/build.sh
@@ -20,4 +20,4 @@ spec:
       - enabled: true
         name: kdump.service
   kernelArguments:
-    - crashkernel=1024M"
+    - crashkernel=676M"

--- a/telco-ran/configuration/kube-compare-reference/machine-config/kdump/06-kdump-master.yaml
+++ b/telco-ran/configuration/kube-compare-reference/machine-config/kdump/06-kdump-master.yaml
@@ -15,4 +15,4 @@ spec:
       - enabled: true
         name: kdump.service
   kernelArguments:
-    - crashkernel=1024M
+    - crashkernel=676M

--- a/telco-ran/configuration/kube-compare-reference/machine-config/kdump/06-kdump-worker.yaml
+++ b/telco-ran/configuration/kube-compare-reference/machine-config/kdump/06-kdump-worker.yaml
@@ -15,4 +15,4 @@ spec:
       - enabled: true
         name: kdump.service
   kernelArguments:
-    - crashkernel=1024M
+    - crashkernel=676M

--- a/telco-ran/configuration/source-crs/extra-manifest/06-kdump-master.yaml
+++ b/telco-ran/configuration/source-crs/extra-manifest/06-kdump-master.yaml
@@ -15,4 +15,4 @@ spec:
       - enabled: true
         name: kdump.service
   kernelArguments:
-    - crashkernel=1024M
+    - crashkernel=676M

--- a/telco-ran/configuration/source-crs/extra-manifest/06-kdump-worker.yaml
+++ b/telco-ran/configuration/source-crs/extra-manifest/06-kdump-worker.yaml
@@ -15,4 +15,4 @@ spec:
       - enabled: true
         name: kdump.service
   kernelArguments:
-    - crashkernel=1024M
+    - crashkernel=676M


### PR DESCRIPTION
- Adjust crashkernel size for all architectures to 1024M. 
- Minimum definition used as prescribed here: https://docs.redhat.com/en/documentation/red_hat_enterprise_linux/9/html/managing_monitoring_and_updating_the_kernel/supported-kdump-configurations-and-targets_managing-monitoring-and-updating-the-kernel#memory-requirements-for-kdump_supported-kdump-configurations-and-targets