### PR TITLE
Add note on mirrored content

### DIFF
--- a/telco-hub/install/mirror-registry/imageset-config.yaml
+++ b/telco-hub/install/mirror-registry/imageset-config.yaml
@@ -6,6 +6,10 @@ mirror:
     channels:
     - name: stable-4.19
       type: ocp
+      # Adjust minVersion and maxVersion according to your required releases. This allows you to
+      # minimize the mirrored content to only what is needed for your deployment. Note that only
+      # versions which are mirrored to the disconnected registry can be installed, so only versions
+      # listed here should be referenced in installation CRs (eg ClusterImageSet / imageSetRef).
       minVersion: 4.19.0
       maxVersion: 4.19.2
   operators:


### PR DESCRIPTION
Add note for users on mirroring their desired content and ensuring this aligns with what ClusterImageSet they use in deploying their clusters.

Manual backport of PR #390