### PR TITLE
 [Release-4.19] modifiying .containerignore file to excluse some directories from the container build

### DIFF
--- a/.containerignore
+++ b/.containerignore
@@ -1,2 +1,4 @@
 telco-core/Dockerfile.telco-core
 telco-hub/Dockerfile.telco-hub
+telco-hub/configuration/reference-crs/optional/cert-manager
+telco-hub/configuration/reference-crs/optional/backup-recovery


### PR DESCRIPTION
Backup-recovery and cert-manager should be excluded.