### PR TITLE
OCPBUGS-63085: telco-ran ARM: Remove redundant pci=realloc=off kernel arg

### DIFF
--- a/telco-ran/configuration/kube-compare-reference/hack/arch/aarch64.yaml
+++ b/telco-ran/configuration/kube-compare-reference/hack/arch/aarch64.yaml
@@ -7,7 +7,6 @@ node_tuning_operator_PerformanceProfile:
         - console=ttyAMA0,115200n8
         - earlycon
         - module_blacklist=nouveau
-        - pci=realloc=off
         - pci=pcie_bus_safe
       cpu:
         isolated: 4-$lastcpu

--- a/telco-ran/configuration/kube-compare-reference/node-tuning-operator/PerformanceProfile.yaml
+++ b/telco-ran/configuration/kube-compare-reference/node-tuning-operator/PerformanceProfile.yaml
@@ -69,7 +69,7 @@ metadata:
 spec:
   {{- if eq $arch "aarch64" }}
   # Note: The defaults here are for Grace Hopper systems. Other systems may alternative PCI or iommu settings such as:
-  #       - pci=realloc (instead of pci=realloc-off)
+  #       - pci=realloc=on (default is off)
   #       - iommu.passthrough=1
   {{- end }}
   additionalKernelArgs:
@@ -98,7 +98,6 @@ spec:
       {{- $ghKernelArgs := list
         "acpi_power_meter.force_cap_on=y"
         "module_blacklist=nouveau"
-        "pci=realloc=off"
         "pci=pcie_bus_safe"
       }}
       {{- $optionalArgs = concat $optionalArgs $nonghKernelArgs $ghKernelArgs }}

--- a/telco-ran/configuration/source-crs/node-tuning-operator/aarch64/PerformanceProfile-SetSelector.yaml
+++ b/telco-ran/configuration/source-crs/node-tuning-operator/aarch64/PerformanceProfile-SetSelector.yaml
@@ -11,7 +11,7 @@ metadata:
     ran.openshift.io/reference-configuration: "ran-du.redhat.com"
 spec:
   # Note: The defaults here are for Grace Hopper systems. Other systems may alternative PCI or iommu settings such as:
-  #       - pci=realloc (instead of pci=realloc-off)
+  #       - pci=realloc=on (default is off)
   #       - iommu.passthrough=1
   additionalKernelArgs:
     - rcupdate.rcu_normal_after_boot=0
@@ -20,7 +20,6 @@ spec:
     - console=ttyAMA0,115200n8
     - earlycon
     - module_blacklist=nouveau
-    - pci=realloc=off
     - pci=pcie_bus_safe
   cpu:
   #  isolated: 4-$lastcpu

--- a/telco-ran/configuration/source-crs/node-tuning-operator/aarch64/PerformanceProfile.yaml
+++ b/telco-ran/configuration/source-crs/node-tuning-operator/aarch64/PerformanceProfile.yaml
@@ -11,7 +11,7 @@ metadata:
     ran.openshift.io/reference-configuration: "ran-du.redhat.com"
 spec:
   # Note: The defaults here are for Grace Hopper systems. Other systems may alternative PCI or iommu settings such as:
-  #       - pci=realloc (instead of pci=realloc-off)
+  #       - pci=realloc=on (default is off)
   #       - iommu.passthrough=1
   additionalKernelArgs:
     - rcupdate.rcu_normal_after_boot=0
@@ -20,7 +20,6 @@ spec:
     - console=ttyAMA0,115200n8
     - earlycon
     - module_blacklist=nouveau
-    - pci=realloc=off
     - pci=pcie_bus_safe
   cpu:
     isolated: 4-$lastcpu


### PR DESCRIPTION
The default kernel behavior is pci=realloc=off, so there is no need to
specify it.

Signed-off-by: Jim Ramsay <jramsay@redhat.com>
