### PR TITLE
OCPBUGS-60169: telco-core: Ignore security.openshift.io/MinimallySufficientPodSecurityStandard annotation

### DIFF
--- a/telco-core/configuration/reference-crs-kube-compare/metadata.yaml
+++ b/telco-core/configuration/reference-crs-kube-compare/metadata.yaml
@@ -229,6 +229,7 @@ fieldsToOmit:
       - pathToKey: metadata.annotations."nmstate.io/webhook-mutating-timestamp"
       - pathToKey: metadata.annotations."operator.sriovnetwork.openshift.io/last-network-namespace"
       - pathToKey: metadata.annotations."k8s.v1.cni.cncf.io/resourceName"
+      - pathToKey: metadata.annotations."security.openshift.io/MinimallySufficientPodSecurityStandard"
     allowStatusCheck:
       - include: defaults
     all:


### PR DESCRIPTION
Signed-off-by: Jim Ramsay <jramsay@redhat.com>
