### PR TITLE
[telco-core] Missing maxUnavailable: 100% in policy for upgrading all workers in a mcp

### DIFF
--- a/telco-core/configuration/core-upgrade-finish.yaml
+++ b/telco-core/configuration/core-upgrade-finish.yaml
@@ -21,6 +21,12 @@ policies:
       - path: reference-crs/custom-manifests/mcp-worker-1.yaml
         patches:
         - spec:
+            # Using 100% maxUnavailable for the MCP requires the cluster and workload to be designed for
+            # multiple nodes to be offline simultaneously. This includes sufficient spare capacity, labeling for
+            # zones to spread replicas, and workload dimensioning to ensure service availability is retained.
+            # See https://github.com/openshift-kni/telco-reference/tree/main/telco-core/configuration#worker-node-upgrade
+            # for more details.
+            maxUnavailable: 100%
             paused: false
           status:
             conditions:
@@ -37,6 +43,7 @@ policies:
       - path: reference-crs/custom-manifests/mcp-worker-2.yaml
         patches:
         - spec:
+            maxUnavailable: 100%
             paused: false
           status:
             conditions:
@@ -53,6 +60,7 @@ policies:
       - path: reference-crs/custom-manifests/mcp-worker-3.yaml
         patches:
         - spec:
+            maxUnavailable: 100%
             paused: false
           status:
             conditions:

--- a/telco-core/install/example-standard-clusterinstance.yaml
+++ b/telco-core/install/example-standard-clusterinstance.yaml
@@ -233,6 +233,7 @@ spec:
         deviceName: "/dev/disk/by-path/pci-0000:18:00.0-scsi-0:2:1:0"
       nodeLabels:
         node-role.kubernetes.io/worker-1: ""
+        topology.kubernetes.io/zone: kfd1
       # Example partitioning on secondary disk
       ignitionConfigOverride: '{"ignition":{"version":"3.2.0"},"storage":{"disks":[{"device":"/dev/disk/by-path/pci-0000:18:00.0-scsi-0:2:2:0","wipeTable":true,"partitions":[{"number":1,"sizeMiB":409600,"wipePartitionEntry":true},{"number":2,"label":"containers","sizeMiB":102400,"wipePartitionEntry":true},{"number":3,"sizeMiB":10240,"wipePartitionEntry":true}]}],"filesystems":[{"device":"/dev/disk/by-partlabel/containers","format":"xfs","path":"/var/lib/containers","wipeFilesystem":true}]},"systemd":{"units":[{"contents":"#GeneratedbyButane\n[Unit]\nRequires=systemd-fsck@dev-disk-by\\x2dpartlabel-containers.service\nAfter=systemd-fsck@dev-disk-by\\x2dpartlabel-containers.service\n\n[Mount]\nWhere=/var/lib/containers\nWhat=/dev/disk/by-partlabel/containers\nType=xfs\n\n[Install]\nRequiredBy=local-fs.target","enabled":true,"name":"var-lib-containers.mount"}]}}'
       nodeNetwork:
@@ -293,6 +294,7 @@ spec:
         deviceName: "/dev/disk/by-path/pci-0000:18:00.0-scsi-0:2:1:0"
       nodeLabels:
         node-role.kubernetes.io/worker-1: ""
+        topology.kubernetes.io/zone: kfd1
       # Example partitioning on secondary disk
       ignitionConfigOverride: '{"ignition":{"version":"3.2.0"},"storage":{"disks":[{"device":"/dev/disk/by-path/pci-0000:18:00.0-scsi-0:2:2:0","wipeTable":true,"partitions":[{"number":1,"sizeMiB":409600,"wipePartitionEntry":true},{"number":2,"label":"containers","sizeMiB":102400,"wipePartitionEntry":true},{"number":3,"sizeMiB":10240,"wipePartitionEntry":true}]}],"filesystems":[{"device":"/dev/disk/by-partlabel/containers","format":"xfs","path":"/var/lib/containers","wipeFilesystem":true}]},"systemd":{"units":[{"contents":"#GeneratedbyButane\n[Unit]\nRequires=systemd-fsck@dev-disk-by\\x2dpartlabel-containers.service\nAfter=systemd-fsck@dev-disk-by\\x2dpartlabel-containers.service\n\n[Mount]\nWhere=/var/lib/containers\nWhat=/dev/disk/by-partlabel/containers\nType=xfs\n\n[Install]\nRequiredBy=local-fs.target","enabled":true,"name":"var-lib-containers.mount"}]}}'
       nodeNetwork:
@@ -353,6 +355,7 @@ spec:
         deviceName: "/dev/disk/by-path/pci-0000:08:00.0"
       nodeLabels:
         node-role.kubernetes.io/worker-2: ""
+        topology.kubernetes.io/zone: kfd2
       nodeNetwork:
         interfaces:
         - macAddress: 00:11:22:33:44:5B
@@ -400,6 +403,7 @@ spec:
         deviceName: "/dev/disk/by-path/pci-0000:08:00.0"
       nodeLabels:
         node-role.kubernetes.io/worker-2: ""
+        topology.kubernetes.io/zone: kfd2
       nodeNetwork:
         interfaces:
         - macAddress: 00:11:22:33:44:5C


### PR DESCRIPTION
We are missing the configuration to upgrade all workers of an MCP at the same time. I can confirm that by default it is upgrading one by one since the reference-cr/custom-manifests as it is stored in the repo is set to the default value of maxUnavailable: 1. [Here](https://github.com/openshift-kni/telco-reference/blob/main/telco-core/configuration/reference-crs/custom-manifests/mcp-worker-1.yaml#L15)

cc/ @imiller0
