### PR TITLE
telco-hub: kube-compare MCO: add default for instanceSize

### DIFF
--- a/telco-hub/configuration/reference-crs-kube-compare/required/acm/observabilityMCO.yaml
+++ b/telco-hub/configuration/reference-crs-kube-compare/required/acm/observabilityMCO.yaml
@@ -32,7 +32,7 @@ spec:
       retentionResolution5m: {{ .spec.advanced.retentionConfig.retentionResolutionRaw | default "15d"}}
       retentionResolution1h: {{ .spec.advanced.retentionConfig.retentionResolutionRaw | default "15d"}}
   enableDownsampling: true
-  instanceSize: {{ .spec.storageConfig.instanceSize }}
+  instanceSize: {{ .spec.storageConfig.instanceSize | default "default" }}
   observabilityAddonSpec:
     enableMetrics: true
     interval: 300


### PR DESCRIPTION
Add default value for instanceSize in MultiClusterObservability kube-compare reference to avoid validation conflicts in telco-hub pattern when no size is provided. The change was initially included in PR #362.

```diff
Cluster CR: observability.open-cluster-management.io/v1beta2_MultiClusterObservability_observability
Reference File: required/acm/observabilityMCO.yaml
Description:
  https://docs.redhat.com/en/documentation/openshift_container_platform/4.20/html/scalability_and_performance/telco-hub-ref-design-specs#telco-hub-red-hat-advanced-cluster-management-rhacm_telco-hub
Diff Output: diff -u -N /tmp/MERGED-3398219948/observability-open-cluster-management-io-v1beta2_multiclusterobservability_observability /tmp/LIVE-444693855/observability-open-cluster-management-io-v1beta2_multiclusterobservability_observability
--- /tmp/MERGED-3398219948/observability-open-cluster-management-io-v1beta2_multiclusterobservability_observability     2025-10-20 10:59:45.020874546 +0200
+++ /tmp/LIVE-444693855/observability-open-cluster-management-io-v1beta2_multiclusterobservability_observability        2025-10-20 10:59:45.020874546 +0200
@@ -14,6 +14,7 @@
       retentionResolution5m: 15d
       retentionResolutionRaw: 15d
   enableDownsampling: true
+  instanceSize: default
   observabilityAddonSpec:
     enableMetrics: true
     interval: 300
```

Signed-off-by: Leonardo Ochoa-Aday lochoa@redhat.com