### PR TITLE
OCPBUGS-63357: core RDS: Ignore k8s.v1.cni.cncf.io/resourceName annotation

### DIFF
--- a/telco-core/configuration/reference-crs-kube-compare/metadata.yaml
+++ b/telco-core/configuration/reference-crs-kube-compare/metadata.yaml
@@ -215,6 +215,7 @@ fieldsToOmit:
       - pathToKey: metadata.annotations."operator.sriovnetwork.openshift.io/last-network-namespace"
       - pathToKey: metadata.annotations."workload.openshift.io/allowed"
       - pathToKey: spec.installPlanApproval
+      - pathToKey: metadata.annotations."k8s.v1.cni.cncf.io/resourceName"
     allowStatusCheck:
       - include: defaults
     all:


### PR DESCRIPTION
Signed-off-by: Jim Ramsay <jramsay@redhat.com>
