### PR TITLE
OCPBUGS-63642: telco-hub: add cluster-logging operator to imageset configuration

### DIFF
--- a/telco-hub/install/mirror-registry/imageset-config.yaml
+++ b/telco-hub/install/mirror-registry/imageset-config.yaml
@@ -37,6 +37,9 @@ mirror:
     - name: local-storage-operator
       channels:
       - name: stable
+    - name: cluster-logging
+      channels:
+      - name: stable-6.2
     - name: odf-operator
       defaultChannel: stable-4.19
       channels:


### PR DESCRIPTION
Add cluster-logging operator (stable-6.2 channel) to mirror registry imageset config.

Signed-off-by: Leonardo Ochoa-Aday <lochoa@redhat.com>