### PR TITLE
CNFCERT-1258: Add kustomize validation check

### DIFF
--- a/.github/workflows/kustomize-validation.yml
+++ b/.github/workflows/kustomize-validation.yml
@@ -1,0 +1,26 @@
+---
+name: Kustomize Validation
+
+on:
+  pull_request:
+    branches:
+      - main
+
+permissions:
+  contents: read
+
+jobs:
+  kustomize-validation:
+    name: Validate Kustomization Files
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Install Kustomize
+        run: |
+          curl -s "https://raw.githubusercontent.com/kubernetes-sigs/kustomize/kustomize/v5.8.1/hack/install_kustomize.sh" | bash -s 5.8.1
+          sudo mv kustomize /usr/local/bin/
+
+      - name: Validate Kustomization Files
+        run: make test-kustomize

--- a/Makefile
+++ b/Makefile
@@ -113,6 +113,9 @@ ocp-doc-check:  ## Download and run ocp-doc-checker against markdown files
 	rm -f ./$$BINARY_NAME; \
 	echo "ocp-doc-check completed"
 
+test-kustomize:  ## Validate all kustomization.yaml files can build
+	./hack/test-kustomize.sh
+
 ci-validate: lintCheck check-reference-core check-reference-ran check-reference-hub
 
 .PHONY: check-reference-core

--- a/hack/test-kustomize.sh
+++ b/hack/test-kustomize.sh
@@ -1,0 +1,92 @@
+#!/bin/bash
+
+set -e
+
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+YELLOW='\033[1;33m'
+BLUE='\033[0;34m'
+NC='\033[0m' # No Color
+
+# Excluded: these use ZTP kustomize plugins only available in OpenShift ArgoCD with ACM/MCE.
+EXCLUDED_DIRS=(
+    "./telco-core/configuration"
+    "./telco-ran/configuration/argocd/example/acmpolicygenerator"
+    "./telco-ran/configuration/argocd/example/clusterinstance"
+    "./telco-ran/configuration/argocd/example/image-based-upgrades"
+    "./telco-ran/configuration/argocd/example/policygentemplates"
+    "./telco-ran/configuration/argocd/example/siteconfig"
+)
+
+if ! command -v kustomize &> /dev/null; then
+    echo -e "${RED}ERROR: kustomize is not installed${NC}"
+    echo ""
+    echo "Please install kustomize to run this check:"
+    echo "  - macOS: brew install kustomize"
+    echo "  - go install: go install sigs.k8s.io/kustomize/kustomize/v5@v5.8.1"
+    echo "  - Manual: https://kubectl.docs.kubernetes.io/installation/kustomize/"
+    echo ""
+    exit 1
+fi
+
+echo "Checking all kustomization.yaml files can build successfully..."
+echo ""
+
+ERRORS=0
+CHECKED=0
+SKIPPED=0
+
+is_excluded() {
+    local dir="$1"
+    for excluded in "${EXCLUDED_DIRS[@]}"; do
+        if [ "$dir" = "$excluded" ]; then
+            return 0
+        fi
+    done
+    return 1
+}
+
+kustomize_files=()
+while IFS= read -r file; do
+    kustomize_files+=("$file")
+done < <(find . -name 'kustomization.yaml' -not -path '*/venv/*' -not -path '*/.git/*' | sort)
+
+if [ ${#kustomize_files[@]} -eq 0 ]; then
+    echo -e "${YELLOW}WARNING: No kustomization.yaml files found${NC}"
+    exit 0
+fi
+
+for kustomize_file in "${kustomize_files[@]}"; do
+    dir=$(dirname "$kustomize_file")
+    echo -n "  $dir: "
+    
+    if is_excluded "$dir"; then
+        echo -e "${BLUE}SKIPPED${NC} (requires external plugins)"
+        SKIPPED=$((SKIPPED + 1))
+        continue
+    fi
+
+    CHECKED=$((CHECKED + 1))
+    output=$(kustomize build "$dir" 2>&1)
+    if [ $? -eq 0 ]; then
+        echo -e "${GREEN}OK${NC}"
+    else
+        echo -e "${RED}FAILED${NC}"
+        echo -e "${YELLOW}    Error details:${NC}"
+        echo "$output" | sed 's/^/    /'
+        echo ""
+        ERRORS=$((ERRORS + 1))
+    fi
+done
+
+echo ""
+echo "Summary: Checked $CHECKED kustomization.yaml files, skipped $SKIPPED (require external plugins)"
+
+if [[ $ERRORS -eq 0 ]]; then
+    echo -e "${GREEN}All kustomization files validated successfully!${NC}"
+    exit 0
+else
+    echo -e "${RED}$ERRORS kustomization file(s) failed validation${NC}"
+    exit 1
+fi
+


### PR DESCRIPTION
Changes:
- Adds a quick PR check that attempts to `kustomize build` appropriate files.  Only runs against `main`.
- Adds a make path for `make test-kustomize` which runs the script.  Users can run this locally as well as there are safeguards to ensure `kustomize` exists first.
- Skips YAMLs that might require external plugins.  See `EXCLUDED_DIRS`.

Example of a successful run:
```
$ make test-kustomize 
./hack/test-kustomize.sh
Checking all kustomization.yaml files can build successfully...

  ./telco-core/configuration: SKIPPED (requires external plugins)
  ./telco-hub/configuration/example-overlays-config/acm: OK
  ./telco-hub/configuration/example-overlays-config/gitops: OK
  ./telco-hub/configuration/example-overlays-config/logging: OK
  ./telco-hub/configuration/example-overlays-config/lso: OK
  ./telco-hub/configuration/example-overlays-config/odf: OK
  ./telco-hub/configuration/example-overlays-config/registry: OK
  ./telco-hub/configuration: OK
  ./telco-hub/configuration/reference-crs: OK
  ./telco-hub/configuration/reference-crs/optional/logging: OK
  ./telco-hub/configuration/reference-crs/optional/lso: OK
  ./telco-hub/configuration/reference-crs/optional/odf-internal: OK
  ./telco-hub/configuration/reference-crs/required/acm: OK
  ./telco-hub/configuration/reference-crs/required/gitops: OK
  ./telco-hub/configuration/reference-crs/required/gitops/ztp-installation: OK
  ./telco-hub/configuration/reference-crs/required/registry: OK
  ./telco-hub/configuration/reference-crs/required/talm: OK
  ./telco-ran/configuration/argocd/deployment: OK
  ./telco-ran/configuration/argocd/example/acmpolicygenerator: SKIPPED (requires external plugins)
  ./telco-ran/configuration/argocd/example/clusterinstance: SKIPPED (requires external plugins)
  ./telco-ran/configuration/argocd/example/image-based-upgrades: SKIPPED (requires external plugins)
  ./telco-ran/configuration/argocd/example/policygentemplates: SKIPPED (requires external plugins)
  ./telco-ran/configuration/argocd/example/siteconfig: SKIPPED (requires external plugins)

Summary: Checked 17 kustomization.yaml files, skipped 6 (require external plugins)
All kustomization files validated successfully!
```
