### PR TITLE
OCPBUGS-60799: telco-core: Tolerate vrf field in BGPPeer CR

### DIFF
--- a/telco-core/configuration/reference-crs-kube-compare/required/networking/metallb/bgp-peer.yaml
+++ b/telco-core/configuration/reference-crs-kube-compare/required/networking/metallb/bgp-peer.yaml
@@ -12,3 +12,6 @@ spec:
   passwordSecret: {{ .spec.passwordSecret | toJson }}
   disableMP: {{ .spec.disableMP }}
   peerPort: {{ .spec.peerPort }}
+  {{- if .spec.vrf }}
+  vrf: {{ .spec.vrf }}
+  {{- end }}


### PR DESCRIPTION
The cluster-compare tool was incorrectly flagging the `vrf` field in the `BGPPeer` custom resource as a deviation. This fix updates the reference template to optionally include the `vrf` field, preventing false-positive deviations.

Signed-off-by: Jim Ramsay <jramsay@redhat.com>
