### PR TITLE
OCPBUGS-60798: telco-core: Tolerate disableMP field in BGPPeer CR

### DIFF
--- a/telco-core/configuration/reference-crs-kube-compare/required/networking/metallb/bgp-peer.yaml
+++ b/telco-core/configuration/reference-crs-kube-compare/required/networking/metallb/bgp-peer.yaml
@@ -10,5 +10,7 @@ spec:
   routerID: {{ .spec.routerID }}
   bfdProfile: {{ .spec.bfdProfile }}
   passwordSecret: {{ .spec.passwordSecret | toJson }}
+  {{- if .spec.disableMP }}
   disableMP: {{ .spec.disableMP }}
+  {{- end }}
   peerPort: {{ .spec.peerPort }}


### PR DESCRIPTION
The cluster-compare tool was incorrectly flagging the `disableMP` field in the `BGPPeer` custom resource as a deviation. This fix updates the reference template to optionally include the `disableMP` field, preventing false-positive deviations.

Signed-off-by: Jim Ramsay <jramsay@redhat.com>
