### PR TITLE
WIP/POC: RAN Hardening (High): Top 5 SSHD

### DIFF
--- a/telco-ran/configuration/machineconfigs/sshd/75-sshd_config-base.yaml
+++ b/telco-ran/configuration/machineconfigs/sshd/75-sshd_config-base.yaml
@@ -1,0 +1,21 @@
+# Base sshd_config that enables the include directory for modular configuration
+apiVersion: machineconfiguration.openshift.io/v1
+kind: MachineConfig
+metadata:
+  name: 75-sshd-config-base
+  labels:
+    machineconfiguration.openshift.io/role: worker
+spec:
+  config:
+    ignition:
+      version: 3.1.0
+    storage:
+      files:
+        - contents:
+            # Plaintext content:
+            # Include /etc/ssh/sshd_config.d/*.conf
+            source: data:,Include%20%2Fetc%2Fssh%2Fsshd_config.d%2F*.conf%0A
+          mode: 0644
+          overwrite: true
+          path: /etc/ssh/sshd_config.d/00-include.conf
+

--- a/telco-ran/configuration/machineconfigs/sshd/76-sshd-disable-root-login.yaml
+++ b/telco-ran/configuration/machineconfigs/sshd/76-sshd-disable-root-login.yaml
@@ -1,0 +1,22 @@
+# Prevents direct root SSH access
+# Remediation: High severity - Force use of privilege escalation for admin tasks
+apiVersion: machineconfiguration.openshift.io/v1
+kind: MachineConfig
+metadata:
+  name: 76-sshd-disable-root-login
+  labels:
+    machineconfiguration.openshift.io/role: worker
+spec:
+  config:
+    ignition:
+      version: 3.1.0
+    storage:
+      files:
+        - contents:
+            # Plaintext content:
+            # PermitRootLogin no
+            source: data:,PermitRootLogin%20no%0A
+          mode: 0644
+          overwrite: true
+          path: /etc/ssh/sshd_config.d/01-disable-root-login.conf
+

--- a/telco-ran/configuration/machineconfigs/sshd/77-sshd-disable-password-auth.yaml
+++ b/telco-ran/configuration/machineconfigs/sshd/77-sshd-disable-password-auth.yaml
@@ -1,0 +1,23 @@
+# Disables password-based authentication entirely
+# Remediation: High severity - Prevents brute-force, password spraying, and credential stuffing
+apiVersion: machineconfiguration.openshift.io/v1
+kind: MachineConfig
+metadata:
+  name: 77-sshd-disable-password-auth
+  labels:
+    machineconfiguration.openshift.io/role: worker
+spec:
+  config:
+    ignition:
+      version: 3.1.0
+    storage:
+      files:
+        - contents:
+            # Plaintext content:
+            # PasswordAuthentication no
+            # PermitEmptyPasswords no
+            source: data:,PasswordAuthentication%20no%0APermitEmptyPasswords%20no%0A
+          mode: 0644
+          overwrite: true
+          path: /etc/ssh/sshd_config.d/02-disable-password-auth.conf
+

--- a/telco-ran/configuration/machineconfigs/sshd/78-sshd-session-timeout.yaml
+++ b/telco-ran/configuration/machineconfigs/sshd/78-sshd-session-timeout.yaml
@@ -1,0 +1,23 @@
+# Implements automatic session timeout after 5 minutes of inactivity
+# Remediation: High severity - Prevents abandoned sessions from being hijacked
+apiVersion: machineconfiguration.openshift.io/v1
+kind: MachineConfig
+metadata:
+  name: 78-sshd-session-timeout
+  labels:
+    machineconfiguration.openshift.io/role: worker
+spec:
+  config:
+    ignition:
+      version: 3.1.0
+    storage:
+      files:
+        - contents:
+            # Plaintext content:
+            # ClientAliveInterval 300
+            # ClientAliveCountMax 0
+            source: data:,ClientAliveInterval%20300%0AClientAliveCountMax%200%0A
+          mode: 0644
+          overwrite: true
+          path: /etc/ssh/sshd_config.d/03-session-timeout.conf
+

--- a/telco-ran/configuration/machineconfigs/sshd/79-sshd-enable-pubkey-auth.yaml
+++ b/telco-ran/configuration/machineconfigs/sshd/79-sshd-enable-pubkey-auth.yaml
@@ -1,0 +1,22 @@
+# Explicitly enables public key authentication
+# Remediation: High severity - Ensures key-based auth works when password auth is disabled
+apiVersion: machineconfiguration.openshift.io/v1
+kind: MachineConfig
+metadata:
+  name: 79-sshd-enable-pubkey-auth
+  labels:
+    machineconfiguration.openshift.io/role: worker
+spec:
+  config:
+    ignition:
+      version: 3.1.0
+    storage:
+      files:
+        - contents:
+            # Plaintext content:
+            # PubkeyAuthentication yes
+            source: data:,PubkeyAuthentication%20yes%0A
+          mode: 0644
+          overwrite: true
+          path: /etc/ssh/sshd_config.d/04-pubkey-auth.conf
+


### PR DESCRIPTION
Based on changes from: #339 

I'm breaking down the `high` level compliance remediation objects into smaller and more manageable and reviewable YAML files.  I asked AI to help me break down the 5 highest priority flags from #339 and put them in their own individual files.

### Files Added

- **`75-sshd_config-base.yaml`** - Enables the `/etc/ssh/sshd_config.d/` include directory for modular SSH configuration management

- **`76-sshd-disable-root-login.yaml`** - Disables direct root SSH access (`PermitRootLogin no`), forcing use of privilege escalation for administrative tasks

- **`77-sshd-disable-password-auth.yaml`** - Disables password-based authentication (`PasswordAuthentication no`, `PermitEmptyPasswords no`) to prevent brute-force attacks, password spraying, and credential stuffing

- **`78-sshd-session-timeout.yaml`** - Implements automatic session timeout after 5 minutes of inactivity (`ClientAliveInterval 300`, `ClientAliveCountMax 0`) to prevent abandoned session hijacking

- **`79-sshd-enable-pubkey-auth.yaml`** - Explicitly enables public key authentication (`PubkeyAuthentication yes`) as the primary authentication method
