### PR TITLE
CNF-21326: RAN Hardening (4.22) - SSHD (H3: PermitEmptyPasswords)

### DIFF
--- a/telco-ran/configuration/kube-compare-reference/informational/hardening/75-sshd-permit-empty-passwords-master.yaml
+++ b/telco-ran/configuration/kube-compare-reference/informational/hardening/75-sshd-permit-empty-passwords-master.yaml
@@ -1,0 +1,17 @@
+apiVersion: machineconfiguration.openshift.io/v1
+kind: MachineConfig
+metadata:
+  name: 75-sshd-permit-empty-passwords-master
+  labels:
+    machineconfiguration.openshift.io/role: master
+spec:
+  config:
+    ignition:
+      version: 3.5.0
+    storage:
+      files:
+        - path: /etc/ssh/sshd_config.d/01-permit-empty-passwords.conf
+          mode: 0600
+          overwrite: true
+          contents:
+            source: "data:,PermitEmptyPasswords%20no%0A"

--- a/telco-ran/configuration/kube-compare-reference/informational/hardening/75-sshd-permit-empty-passwords-worker.yaml
+++ b/telco-ran/configuration/kube-compare-reference/informational/hardening/75-sshd-permit-empty-passwords-worker.yaml
@@ -1,0 +1,17 @@
+apiVersion: machineconfiguration.openshift.io/v1
+kind: MachineConfig
+metadata:
+  name: 75-sshd-permit-empty-passwords-worker
+  labels:
+    machineconfiguration.openshift.io/role: worker
+spec:
+  config:
+    ignition:
+      version: 3.5.0
+    storage:
+      files:
+        - path: /etc/ssh/sshd_config.d/01-permit-empty-passwords.conf
+          mode: 0600
+          overwrite: true
+          contents:
+            source: "data:,PermitEmptyPasswords%20no%0A"


### PR DESCRIPTION
## Summary
SSHD hardening for HIGH severity compliance remediations only.

## Remediation Group
- [H3: SSHD Empty Passwords](https://sebrandon1.github.io/compliance-scripts/versions/4.21/groups/H3.html) - HIGH severity

## SSHD Setting

| Severity | Setting | Value | Description |
|----------|---------|-------|-------------|
| HIGH | PermitEmptyPasswords | no | Prevent SSH login with empty passwords |

## Implementation
Uses drop-in file at `/etc/ssh/sshd_config.d/75-hardening.conf`

## Scope Note
This PR focuses exclusively on HIGH severity SSHD compliance. MEDIUM and LOW severity SSHD settings (M1, L1) will be addressed in separate PRs.

## Related
- **Jira**: [CNF-21326](https://issues.redhat.com/browse/CNF-21326)
- **Epic**: [CNF-19031](https://issues.redhat.com/browse/CNF-19031) - RAN Hardening (High Severity Compliance)
- [Full Remediation Tracking](https://sebrandon1.github.io/compliance-scripts/versions/4.21/remediations.html)

## Test plan
- [ ] Apply MachineConfig to test cluster
- [ ] Verify: `sshd -T | grep permitemptypasswords`
- [ ] Run Compliance Operator scan to verify check passes

## Compliance Checks
- `rhcos4-e8-worker-sshd-disable-empty-passwords`
- `rhcos4-e8-master-sshd-disable-empty-passwords`

🤖 Generated with [Claude Code](https://claude.com/claude-code)