### PR TITLE
Align sctp_module_mc.yaml within extra-manifests folder

### DIFF
--- a/telco-core/install/extra-manifests/sctp_module_mc.yaml
+++ b/telco-core/install/extra-manifests/sctp_module_mc.yaml
@@ -4,23 +4,22 @@
 apiVersion: machineconfiguration.openshift.io/v1
 kind: MachineConfig
 metadata:
+  name: load-sctp-module
   labels:
     machineconfiguration.openshift.io/role: worker
-  name: load-sctp-module
 spec:
   config:
     ignition:
-      version: 2.2.0
+      version: 3.2.0
     storage:
       files:
-        - contents:
+        - path: /etc/modprobe.d/sctp-blacklist.conf
+          mode: 420
+          overwrite: true
+          contents:
             source: data:,
-            verification: {}
-          filesystem: root
+        - path: /etc/modules-load.d/sctp-load.conf
           mode: 420
-          path: /etc/modprobe.d/sctp-blacklist.conf
-        - contents:
-            source: data:text/plain;charset=utf-8;base64,c2N0cA==
-          filesystem: root
-          mode: 420
-          path: /etc/modules-load.d/sctp-load.conf
+          overwrite: true
+          contents:
+            source: data:,sctp


### PR DESCRIPTION
Addresses discrepancy between `telco-core/configuration/reference-crs/optional/other/sctp_module_mc.yaml` and `telco-core/install/extra-manifests/sctp_module_mc.yaml`