### PR TITLE
OCPBUGS-65953: Safety checks for ReducedMonitoringFootprint when observability is disabled

### DIFF
--- a/telco-core/configuration/reference-crs-kube-compare/optional/other/monitoring-config-cm.yaml
+++ b/telco-core/configuration/reference-crs-kube-compare/optional/other/monitoring-config-cm.yaml
@@ -26,8 +26,7 @@ data:
           key: token
           name: observability-alertmanager-accessor
         scheme: https
-        staticConfigs:
-        - (?<alertmanager_endpoint>.*)
+        staticConfigs: (?<alertmanager_endpoint>.*)
         tlsConfig:
           ca:
             key: service-ca.crt

--- a/telco-core/configuration/reference-crs/optional/other/monitoring-config-cm.yaml
+++ b/telco-core/configuration/reference-crs/optional/other/monitoring-config-cm.yaml
@@ -28,8 +28,7 @@ data:
           key: token
           name: observability-alertmanager-accessor
         scheme: https
-        staticConfigs:
-        - {{ if (lookup "v1" "Namespace" "" "open-cluster-management-addon-observability") }}{{hub index (lookup "cluster.open-cluster-management.io/v1" "ManagedCluster" "" .ManagedClusterName).metadata.annotations "acm-alertmanager-route" hub}}{{ end }}
+        staticConfigs: {{ if (lookup "v1" "Namespace" "" "open-cluster-management-addon-observability") }}{{hub $route := index (lookup "cluster.open-cluster-management.io/v1" "ManagedCluster" "" .ManagedClusterName).metadata.annotations "acm-alertmanager-route" hub}}{{hub if $route hub}}[{{hub $route hub}}]{{hub else hub}}[]{{hub end hub}}{{ else }}[]{{ end }}
         tlsConfig:
           ca:
             key: service-ca.crt

--- a/telco-ran/configuration/kube-compare-reference/cluster-tuning/monitoring-configuration/ReduceMonitoringFootprint.yaml
+++ b/telco-ran/configuration/kube-compare-reference/cluster-tuning/monitoring-configuration/ReduceMonitoringFootprint.yaml
@@ -32,8 +32,7 @@ data:
           key: token
           name: observability-alertmanager-accessor
         scheme: https
-        staticConfigs:
-        - (?<alertmanager_endpoint>.*)
+        staticConfigs: (?<alertmanager_endpoint>.*)
         tlsConfig:
           ca:
             key: service-ca.crt

--- a/telco-ran/configuration/kube-compare-reference/hack/default_value.yaml
+++ b/telco-ran/configuration/kube-compare-reference/hack/default_value.yaml
@@ -557,7 +557,7 @@ cluster_tuning_monitoring_configuration_ReduceMonitoringFootprint:
   - metadata:
       name: cluster-monitoring-config
     captureGroup_defaults:
-      alertmanager_endpoint: '{{ `{{ if (lookup "v1" "Namespace" "" "open-cluster-management-addon-observability") }}{{hub index (lookup "cluster.open-cluster-management.io/v1" "ManagedCluster" "" .ManagedClusterName).metadata.annotations "acm-alertmanager-route" hub}}{{ end }}` }}'
+      alertmanager_endpoint: '{{ `{{ if (lookup "v1" "Namespace" "" "open-cluster-management-addon-observability") }}{{hub $route := index (lookup "cluster.open-cluster-management.io/v1" "ManagedCluster" "" .ManagedClusterName).metadata.annotations "acm-alertmanager-route" hub}}{{hub if $route hub}}[{{hub $route hub}}]{{hub else hub}}[]{{hub end hub}}{{ else }}[]{{ end }}` }}'
       managed_cluster: '{{ `{{ fromClusterClaim "id.openshift.io" }}` }}'
 lca_LcaSubscription:
   - spec:

--- a/telco-ran/configuration/source-crs/cluster-tuning/monitoring-configuration/ReduceMonitoringFootprint.yaml
+++ b/telco-ran/configuration/source-crs/cluster-tuning/monitoring-configuration/ReduceMonitoringFootprint.yaml
@@ -32,8 +32,7 @@ data:
           key: token
           name: observability-alertmanager-accessor
         scheme: https
-        staticConfigs:
-        - {{ if (lookup "v1" "Namespace" "" "open-cluster-management-addon-observability") }}{{hub index (lookup "cluster.open-cluster-management.io/v1" "ManagedCluster" "" .ManagedClusterName).metadata.annotations "acm-alertmanager-route" hub}}{{ end }}
+        staticConfigs: {{ if (lookup "v1" "Namespace" "" "open-cluster-management-addon-observability") }}{{hub $route := index (lookup "cluster.open-cluster-management.io/v1" "ManagedCluster" "" .ManagedClusterName).metadata.annotations "acm-alertmanager-route" hub}}{{hub if $route hub}}[{{hub $route hub}}]{{hub else hub}}[]{{hub end hub}}{{ else }}[]{{ end }}
         tlsConfig:
           ca:
             key: service-ca.crt


### PR DESCRIPTION
This PR includes a safety check to ensure the configmap has default values when the alerting URL maybe missing for different cases.
We've added the safety checks for scenarios where,
1. observability is not setup, URL would become: `[]`
2. observability enabled but obs-route-policy is not setup on hub, URL would become: `[]`
3. observability enabled and obs-route-policy is setup: [alerting-url]