### PR TITLE
OCPBUGS-66074: telco-hub: remove workload partitioning annotations

### DIFF
--- a/telco-hub/configuration/reference-crs-kube-compare/default_value.yaml
+++ b/telco-hub/configuration/reference-crs-kube-compare/default_value.yaml
@@ -87,7 +87,6 @@ optional_odf_internal_odfNS:
 - metadata:
     annotations:
       argocd.argoproj.io/sync-wave: "-5"
-      workload.openshift.io/allowed: management
 
 optional_odf_internal_odfOperatorGroup:
 - metadata:
@@ -283,7 +282,7 @@ required_talm_talmSubscription:
 optional_logging_clusterLogNS:
 - metadata:
     annotations:
-      workload.openshift.io/allowed: management
+      argocd.argoproj.io/sync-wave: "-45"
 
 optional_logging_clusterLogSubscription:
 - spec:

--- a/telco-hub/configuration/reference-crs-kube-compare/optional/logging/clusterLogNS.yaml
+++ b/telco-hub/configuration/reference-crs-kube-compare/optional/logging/clusterLogNS.yaml
@@ -3,10 +3,6 @@ apiVersion: v1
 kind: Namespace
 metadata:
   name: openshift-logging
-{{- if .metadata.annotations }}
   annotations:
     argocd.argoproj.io/sync-wave: "-45"
-{{- range $key, $value := .metadata.annotations }}
-    {{ $key }}: {{ $value }}
-{{- end }}
-{{- end }}
+

--- a/telco-hub/configuration/reference-crs-kube-compare/optional/odf-internal/odfNS.yaml
+++ b/telco-hub/configuration/reference-crs-kube-compare/optional/odf-internal/odfNS.yaml
@@ -5,6 +5,5 @@ metadata:
   name: openshift-storage
   annotations:
     argocd.argoproj.io/sync-wave: "-45"
-    workload.openshift.io/allowed: management
   labels:
     openshift.io/cluster-monitoring: "true"

--- a/telco-hub/configuration/reference-crs-kube-compare/required/registry/catalog-source.yaml
+++ b/telco-hub/configuration/reference-crs-kube-compare/required/registry/catalog-source.yaml
@@ -4,7 +4,6 @@ kind: CatalogSource
 metadata:
   annotations:
     argocd.argoproj.io/sync-wave: "-50"
-    target.workload.openshift.io/management: '{"effect": "PreferredDuringScheduling"}'
   name: redhat-operators-disconnected
   namespace: openshift-marketplace
 spec:

--- a/telco-hub/configuration/reference-crs-kube-compare/required/registry/idms-operator.yaml
+++ b/telco-hub/configuration/reference-crs-kube-compare/required/registry/idms-operator.yaml
@@ -8,7 +8,6 @@ kind: ImageDigestMirrorSet
 metadata:
   annotations:
     argocd.argoproj.io/sync-wave: "-50"
-    target.workload.openshift.io/management: '{"effect": "PreferredDuringScheduling"}'
   name: idms-operator-0
 spec:
   imageDigestMirrors: {{- if .spec.imageDigestMirrors }}

--- a/telco-hub/configuration/reference-crs-kube-compare/required/registry/idms-release.yaml
+++ b/telco-hub/configuration/reference-crs-kube-compare/required/registry/idms-release.yaml
@@ -8,7 +8,6 @@ kind: ImageDigestMirrorSet
 metadata:
   annotations:
     argocd.argoproj.io/sync-wave: "-50"
-    target.workload.openshift.io/management: '{"effect": "PreferredDuringScheduling"}'
   name: idms-release-0
 spec:
   imageDigestMirrors:{{- if .spec.imageDigestMirrors }}

--- a/telco-hub/configuration/reference-crs-kube-compare/required/registry/itms-generic.yaml
+++ b/telco-hub/configuration/reference-crs-kube-compare/required/registry/itms-generic.yaml
@@ -8,7 +8,6 @@ kind: ImageTagMirrorSet
 metadata:
   annotations:
     argocd.argoproj.io/sync-wave: "-50"
-    target.workload.openshift.io/management: '{"effect": "PreferredDuringScheduling"}'
   name: itms-generic-0
 spec:
   imageTagMirrors:{{- if .spec.imageTagMirrors }}

--- a/telco-hub/configuration/reference-crs-kube-compare/required/registry/itms-release.yaml
+++ b/telco-hub/configuration/reference-crs-kube-compare/required/registry/itms-release.yaml
@@ -8,7 +8,6 @@ kind: ImageTagMirrorSet
 metadata:
   annotations:
     argocd.argoproj.io/sync-wave: "-50"
-    target.workload.openshift.io/management: '{"effect": "PreferredDuringScheduling"}'
   name: itms-release-0
 spec:
   imageTagMirrors:{{- if .spec.imageTagMirrors }}

--- a/telco-hub/configuration/reference-crs/optional/logging/clusterLogNS.yaml
+++ b/telco-hub/configuration/reference-crs/optional/logging/clusterLogNS.yaml
@@ -5,4 +5,3 @@ metadata:
   name: openshift-logging
   annotations:
     argocd.argoproj.io/sync-wave: "-45"
-    workload.openshift.io/allowed: management

--- a/telco-hub/configuration/reference-crs/optional/odf-internal/odfNS.yaml
+++ b/telco-hub/configuration/reference-crs/optional/odf-internal/odfNS.yaml
@@ -5,6 +5,5 @@ metadata:
   name: openshift-storage
   annotations:
     argocd.argoproj.io/sync-wave: "-45"
-    workload.openshift.io/allowed: management
   labels:
     openshift.io/cluster-monitoring: "true"

--- a/telco-hub/configuration/reference-crs/required/registry/catalog-source.yaml
+++ b/telco-hub/configuration/reference-crs/required/registry/catalog-source.yaml
@@ -4,7 +4,6 @@ kind: CatalogSource
 metadata:
   annotations:
     argocd.argoproj.io/sync-wave: "-50"
-    target.workload.openshift.io/management: '{"effect": "PreferredDuringScheduling"}'
   name: redhat-operators-disconnected
   namespace: openshift-marketplace
 spec:

--- a/telco-hub/configuration/reference-crs/required/registry/idms-operator.yaml
+++ b/telco-hub/configuration/reference-crs/required/registry/idms-operator.yaml
@@ -8,7 +8,6 @@ kind: ImageDigestMirrorSet
 metadata:
   annotations:
     argocd.argoproj.io/sync-wave: "-50"
-    target.workload.openshift.io/management: '{"effect": "PreferredDuringScheduling"}'
   name: idms-operator-0
 spec:
   imageDigestMirrors:

--- a/telco-hub/configuration/reference-crs/required/registry/idms-release.yaml
+++ b/telco-hub/configuration/reference-crs/required/registry/idms-release.yaml
@@ -8,7 +8,6 @@ kind: ImageDigestMirrorSet
 metadata:
   annotations:
     argocd.argoproj.io/sync-wave: "-50"
-    target.workload.openshift.io/management: '{"effect": "PreferredDuringScheduling"}'
   name: idms-release-0
 spec:
   imageDigestMirrors:

--- a/telco-hub/configuration/reference-crs/required/registry/itms-generic.yaml
+++ b/telco-hub/configuration/reference-crs/required/registry/itms-generic.yaml
@@ -8,7 +8,6 @@ kind: ImageTagMirrorSet
 metadata:
   annotations:
     argocd.argoproj.io/sync-wave: "-50"
-    target.workload.openshift.io/management: '{"effect": "PreferredDuringScheduling"}'
   name: itms-generic-0
 spec:
   imageTagMirrors:

--- a/telco-hub/configuration/reference-crs/required/registry/itms-release.yaml
+++ b/telco-hub/configuration/reference-crs/required/registry/itms-release.yaml
@@ -8,7 +8,6 @@ kind: ImageTagMirrorSet
 metadata:
   annotations:
     argocd.argoproj.io/sync-wave: "-50"
-    target.workload.openshift.io/management: '{"effect": "PreferredDuringScheduling"}'
   name: itms-release-0
 spec:
   imageTagMirrors:


### PR DESCRIPTION
This PR removes workload partitioning annotations in hub reference CRs