### PR TITLE
[release-4.21] Add CertificatePolicy CR for monitoring certificate health

### DIFF
--- a/telco-hub/configuration/reference-crs-kube-compare/metadata.yaml
+++ b/telco-hub/configuration/reference-crs-kube-compare/metadata.yaml
@@ -31,6 +31,11 @@ parts:
         allOrNoneOf:
           - path: optional/cert-manager/apiServerCertificate.yaml
           - path: optional/cert-manager/apiServerConfig.yaml
+      - name: cert-manager-monitoring
+        description: |-
+          Certificate monitoring policy for RHACM
+        allOrNoneOf:
+          - path: optional/cert-manager/certManagerCertificatePolicy.yaml
   - name: optional-storage
     components:
       - name: local-storage-operator

--- a/telco-hub/configuration/reference-crs-kube-compare/optional/cert-manager/certManagerCertificatePolicy.yaml
+++ b/telco-hub/configuration/reference-crs-kube-compare/optional/cert-manager/certManagerCertificatePolicy.yaml
@@ -1,0 +1,27 @@
+---
+apiVersion: policy.open-cluster-management.io/v1
+kind: Policy
+metadata:
+  name: monitor-certificates
+  namespace: default
+  annotations:
+    policy.open-cluster-management.io/categories: SC System and Communications Protection
+    policy.open-cluster-management.io/controls: SC-8 Transmission Confidentiality and Integrity
+    policy.open-cluster-management.io/standards: NIST 800-53
+spec:
+  disabled: false
+  policy-templates:
+    - objectDefinition:
+        apiVersion: policy.open-cluster-management.io/v1
+        kind: CertificatePolicy
+        metadata:
+          name: policy-monitor-certificates
+        spec:
+          minimumDuration: 720h
+          namespaceSelector:
+            include:
+              - openshift-ingress
+              - openshift-config
+          remediationAction: inform
+          severity: low
+  remediationAction: inform

--- a/telco-hub/configuration/reference-crs/optional/cert-manager/certManagerCertificatePolicy.yaml
+++ b/telco-hub/configuration/reference-crs/optional/cert-manager/certManagerCertificatePolicy.yaml
@@ -1,0 +1,27 @@
+---
+apiVersion: policy.open-cluster-management.io/v1
+kind: Policy
+metadata:
+  name: monitor-certificates
+  namespace: default
+  annotations:
+    policy.open-cluster-management.io/categories: SC System and Communications Protection
+    policy.open-cluster-management.io/controls: SC-8 Transmission Confidentiality and Integrity
+    policy.open-cluster-management.io/standards: NIST 800-53
+spec:
+  disabled: false
+  policy-templates:
+    - objectDefinition:
+        apiVersion: policy.open-cluster-management.io/v1
+        kind: CertificatePolicy
+        metadata:
+          name: policy-monitor-certificates
+        spec:
+          minimumDuration: 720h
+          namespaceSelector:
+            include:
+              - openshift-ingress
+              - openshift-config
+          remediationAction: inform
+          severity: low
+  remediationAction: inform

--- a/telco-hub/configuration/reference-crs/optional/cert-manager/kustomization.yaml
+++ b/telco-hub/configuration/reference-crs/optional/cert-manager/kustomization.yaml
@@ -10,3 +10,4 @@ resources:
   - ingressControllerConfig.yaml
   - apiServerCertificate.yaml
   - apiServerConfig.yaml
+  - certManagerCertificatePolicy.yaml


### PR DESCRIPTION
Follow up to: https://github.com/openshift-kni/telco-reference/pull/458

Based on a comment from @imiller0 we had to add a reference link to the RDS for `telco-hub/configuration/reference-crs/optional/cert-manager/certManagerCertificatePolicy.yaml`.

Related to: https://gitlab.cee.redhat.com/reference-configurations/reference-design-specifications/-/merge_requests/147