### PR TITLE
CNF-13731: Add CertificatePolicy CR for monitoring certificate health

### DIFF
--- a/telco-hub/configuration/reference-crs-kube-compare/default_value.yaml
+++ b/telco-hub/configuration/reference-crs-kube-compare/default_value.yaml
@@ -460,6 +460,14 @@ optional_cert_manager_apiServerConfig:
           servingCertificate:
             name: api-server-cert
 
+optional_cert_manager_certManagerCertificatePolicy:
+- spec:
+    minimumDuration: 720h
+    namespaceSelector:
+      include:
+        - openshift-ingress
+        - openshift-config
+
 optional_cert_manager_certManagerSubscription:
 - spec:
     source: redhat-operators-disconnected

--- a/telco-hub/configuration/reference-crs-kube-compare/metadata.yaml
+++ b/telco-hub/configuration/reference-crs-kube-compare/metadata.yaml
@@ -31,6 +31,13 @@ parts:
         allOrNoneOf:
           - path: optional/cert-manager/apiServerCertificate.yaml
           - path: optional/cert-manager/apiServerConfig.yaml
+      - name: cert-manager-monitoring
+        description: |-
+          Certificate monitoring policy for RHACM
+        allOrNoneOf:
+          - path: optional/cert-manager/certManagerCertificatePolicy.yaml
+          - path: optional/cert-manager/certManagerCertificatePolicyPlacement.yaml
+          - path: optional/cert-manager/certManagerCertificatePolicyPlacementBinding.yaml
   - name: optional-storage
     components:
       - name: local-storage-operator
@@ -157,6 +164,7 @@ parts:
 
 templateFunctionFiles:
   - version_match.tmpl
+  - unordered_list.tmpl
 
 fieldsToOmit:
   defaultOmitRef: all

--- a/telco-hub/configuration/reference-crs-kube-compare/optional/cert-manager/certManagerCertificatePolicy.yaml
+++ b/telco-hub/configuration/reference-crs-kube-compare/optional/cert-manager/certManagerCertificatePolicy.yaml
@@ -1,0 +1,25 @@
+---
+apiVersion: policy.open-cluster-management.io/v1
+kind: Policy
+metadata:
+  name: monitor-certificates
+  namespace: default
+  annotations:
+    policy.open-cluster-management.io/categories: SC System and Communications Protection
+    policy.open-cluster-management.io/controls: SC-8 Transmission Confidentiality and Integrity
+    policy.open-cluster-management.io/standards: NIST 800-53
+spec:
+  disabled: false
+  policy-templates:
+    - objectDefinition:
+        apiVersion: policy.open-cluster-management.io/v1
+        kind: CertificatePolicy
+        metadata:
+          name: policy-monitor-certificates
+        spec:
+          minimumDuration: {{ .spec.minimumDuration | default "720h" }}
+          namespaceSelector:
+            include:{{- template "unorderedListAllowExtra" (list .spec.namespaceSelector.include (list "openshift-ingress" "openshift-config") ) }}
+          remediationAction: inform
+          severity: low
+  remediationAction: inform

--- a/telco-hub/configuration/reference-crs-kube-compare/optional/cert-manager/certManagerCertificatePolicyPlacement.yaml
+++ b/telco-hub/configuration/reference-crs-kube-compare/optional/cert-manager/certManagerCertificatePolicyPlacement.yaml
@@ -1,0 +1,13 @@
+---
+apiVersion: cluster.open-cluster-management.io/v1beta1
+kind: Placement
+metadata:
+  name: monitor-certificates-placement
+  namespace: default
+spec:
+  predicates:
+    - requiredClusterSelector:
+        labelSelector:
+          matchExpressions:
+            - key: common
+              operator: Exists

--- a/telco-hub/configuration/reference-crs-kube-compare/optional/cert-manager/certManagerCertificatePolicyPlacementBinding.yaml
+++ b/telco-hub/configuration/reference-crs-kube-compare/optional/cert-manager/certManagerCertificatePolicyPlacementBinding.yaml
@@ -1,0 +1,14 @@
+---
+apiVersion: policy.open-cluster-management.io/v1
+kind: PlacementBinding
+metadata:
+  name: monitor-certificates-placementbinding
+  namespace: default
+placementRef:
+  name: monitor-certificates-placement
+  apiGroup: cluster.open-cluster-management.io
+  kind: Placement
+subjects:
+  - name: monitor-certificates
+    apiGroup: policy.open-cluster-management.io
+    kind: Policy

--- a/telco-hub/configuration/reference-crs-kube-compare/unordered_list.tmpl
+++ b/telco-hub/configuration/reference-crs-kube-compare/unordered_list.tmpl
@@ -1,0 +1,13 @@
+{{- define "unorderedListAllowExtra" -}}
+{{- /* unorderedListAllowExtra <listToEval> <requiredValues>: ensures required values present, allows extras */ -}}
+{{- $result := list }}
+{{- $requiredArgs := index . 1 }}
+{{- range $value := (index . 0) }}
+  {{- $result = append $result $value }}
+  {{- $requiredArgs = without $requiredArgs $value }}
+{{- end }}
+{{- range $value := $requiredArgs }}
+  {{- $result = append $result $value }}
+{{- end }}
+{{- $result | toYaml | nindent 14 }}
+{{- end }}

--- a/telco-hub/configuration/reference-crs/optional/cert-manager/certManagerCertificatePolicy.yaml
+++ b/telco-hub/configuration/reference-crs/optional/cert-manager/certManagerCertificatePolicy.yaml
@@ -1,0 +1,27 @@
+---
+apiVersion: policy.open-cluster-management.io/v1
+kind: Policy
+metadata:
+  name: monitor-certificates
+  namespace: default
+  annotations:
+    policy.open-cluster-management.io/categories: SC System and Communications Protection
+    policy.open-cluster-management.io/controls: SC-8 Transmission Confidentiality and Integrity
+    policy.open-cluster-management.io/standards: NIST 800-53
+spec:
+  disabled: false
+  policy-templates:
+    - objectDefinition:
+        apiVersion: policy.open-cluster-management.io/v1
+        kind: CertificatePolicy
+        metadata:
+          name: policy-monitor-certificates
+        spec:
+          minimumDuration: 720h
+          namespaceSelector:
+            include:
+              - openshift-ingress
+              - openshift-config
+          remediationAction: inform
+          severity: low
+  remediationAction: inform

--- a/telco-hub/configuration/reference-crs/optional/cert-manager/certManagerCertificatePolicyPlacement.yaml
+++ b/telco-hub/configuration/reference-crs/optional/cert-manager/certManagerCertificatePolicyPlacement.yaml
@@ -1,0 +1,13 @@
+---
+apiVersion: cluster.open-cluster-management.io/v1beta1
+kind: Placement
+metadata:
+  name: monitor-certificates-placement
+  namespace: default
+spec:
+  predicates:
+    - requiredClusterSelector:
+        labelSelector:
+          matchExpressions:
+            - key: common
+              operator: Exists

--- a/telco-hub/configuration/reference-crs/optional/cert-manager/certManagerCertificatePolicyPlacementBinding.yaml
+++ b/telco-hub/configuration/reference-crs/optional/cert-manager/certManagerCertificatePolicyPlacementBinding.yaml
@@ -1,0 +1,14 @@
+---
+apiVersion: policy.open-cluster-management.io/v1
+kind: PlacementBinding
+metadata:
+  name: monitor-certificates-placementbinding
+  namespace: default
+placementRef:
+  name: monitor-certificates-placement
+  apiGroup: cluster.open-cluster-management.io
+  kind: Placement
+subjects:
+  - name: monitor-certificates
+    apiGroup: policy.open-cluster-management.io
+    kind: Policy

--- a/telco-hub/configuration/reference-crs/optional/cert-manager/kustomization.yaml
+++ b/telco-hub/configuration/reference-crs/optional/cert-manager/kustomization.yaml
@@ -10,3 +10,6 @@ resources:
   - ingressControllerConfig.yaml
   - apiServerCertificate.yaml
   - apiServerConfig.yaml
+  - certManagerCertificatePolicy.yaml
+  - certManagerCertificatePolicyPlacement.yaml
+  - certManagerCertificatePolicyPlacementBinding.yaml


### PR DESCRIPTION
Follow up to: https://github.com/openshift-kni/telco-reference/pull/458

Based on a comment from @imiller0 we had to add a reference link to the RDS for `telco-hub/configuration/reference-crs/optional/cert-manager/certManagerCertificatePolicy.yaml`.

Related to: https://gitlab.cee.redhat.com/reference-configurations/reference-design-specifications/-/merge_requests/147

---
*Recreated from #516 to target `main` branch instead of `release-4.21`.*