### PR TITLE
CNF-21196: RAN Hardening (Sysctl) - High Severity

### DIFF
--- a/telco-ran/configuration/machineconfigs/sysctl/75-sysctl-high.yaml
+++ b/telco-ran/configuration/machineconfigs/sysctl/75-sysctl-high.yaml
@@ -1,0 +1,29 @@
+apiVersion: machineconfiguration.openshift.io/v1
+kind: MachineConfig
+spec:
+  config:
+    ignition:
+      version: 3.5.0
+    storage:
+      files:
+        - contents:
+            # Top Priority Kernel Sysctl Security Settings (E8/CIS):
+            # 1. Restrict kernel log access - prevents unprivileged users from reading dmesg
+            #    which can leak sensitive system information
+            # kernel.dmesg_restrict=1
+            # 2. Enable full ASLR - randomizes memory layout to prevent exploitation attacks
+            # kernel.randomize_va_space=2
+            # 3. Disable unprivileged BPF - prevents privilege escalation via BPF programs
+            # kernel.unprivileged_bpf_disabled=1
+            # 4. Restrict ptrace to parent-child - prevents process injection and credential theft
+            # kernel.yama.ptrace_scope=1
+            # 5. Harden BPF JIT compiler - prevents JIT spraying attacks
+            # net.core.bpf_jit_harden=2
+            source: data:,kernel.dmesg_restrict%3D1%0Akernel.randomize_va_space%3D2%0Akernel.unprivileged_bpf_disabled%3D1%0Akernel.yama.ptrace_scope%3D1%0Anet.core.bpf_jit_harden%3D2%0A
+          mode: 420
+          overwrite: true
+          path: /etc/sysctl.d/75-sysctl-high.conf
+metadata:
+  name: 75-sysctl-high
+  labels:
+    machineconfiguration.openshift.io/role: worker


### PR DESCRIPTION
## Summary

We'll have a single `MachineConfig` per path, per severity. Future **high** level severity flags will be added to this file and rebuilt with new comment and `source` key/values.

**Kernel hardening via sysctl:**

* Added `75-sysctl-high.yaml` to apply top 5 kernel hardening sysctl flags for worker nodes

## Sysctl Settings Applied

| Setting | Value | Description |
|---------|-------|-------------|
| `kernel.dmesg_restrict` | 1 | Restrict kernel log access to privileged users |
| `kernel.randomize_va_space` | 2 | Full ASLR - randomizes memory layout to prevent exploitation |
| `kernel.unprivileged_bpf_disabled` | 1 | Prevent BPF-based privilege escalation |
| `kernel.yama.ptrace_scope` | 1 | Restrict ptrace to parent-child processes |
| `net.core.bpf_jit_harden` | 2 | Harden BPF JIT against spraying attacks |

## Test Plan

- [ ] Apply MachineConfig to test cluster
- [ ] Verify nodes reboot successfully
- [ ] Check `sysctl -a | grep -E 'dmesg_restrict|randomize_va_space|unprivileged_bpf|ptrace_scope|bpf_jit'` shows expected values
- [ ] Monitor for any boot failures or performance issues

## Related

- Jira: https://issues.redhat.com/browse/CNF-21196
- Similar to SSHD hardening: #466