### PR TITLE
OCPBUGS-61396: Replace chrony-wait instead of adding a new service for inital chrony…

### DIFF
--- a/telco-ran/configuration/extra-manifests-builder/99-sync-time-once/build.sh
+++ b/telco-ran/configuration/extra-manifests-builder/99-sync-time-once/build.sh
@@ -24,10 +24,9 @@ spec:
             [Service]
             Type=oneshot
             TimeoutStartSec=${SYNC_ATTEMPT_TIMEOUT_SEC}
-            ExecCondition=/bin/bash -c 'systemctl is-enabled chronyd.service --quiet && exit 1 || exit 0'
             ExecStart=/usr/sbin/chronyd -n -f /etc/chrony.conf -q
             RemainAfterExit=yes
             [Install]
             WantedBy=multi-user.target
           enabled: true
-          name: sync-time-once.service"
+          name: chrony-wait.service"

--- a/telco-ran/configuration/kube-compare-reference/machine-config/one-shot-time-sync/99-sync-time-once-master.yaml
+++ b/telco-ran/configuration/kube-compare-reference/machine-config/one-shot-time-sync/99-sync-time-once-master.yaml
@@ -20,10 +20,9 @@ spec:
             [Service]
             Type=oneshot
             TimeoutStartSec=300
-            ExecCondition=/bin/bash -c 'systemctl is-enabled chronyd.service --quiet && exit 1 || exit 0'
             ExecStart=/usr/sbin/chronyd -n -f /etc/chrony.conf -q
             RemainAfterExit=yes
             [Install]
             WantedBy=multi-user.target
           enabled: true
-          name: sync-time-once.service
+          name: chrony-wait.service

--- a/telco-ran/configuration/kube-compare-reference/machine-config/one-shot-time-sync/99-sync-time-once-worker.yaml
+++ b/telco-ran/configuration/kube-compare-reference/machine-config/one-shot-time-sync/99-sync-time-once-worker.yaml
@@ -20,10 +20,9 @@ spec:
             [Service]
             Type=oneshot
             TimeoutStartSec=300
-            ExecCondition=/bin/bash -c 'systemctl is-enabled chronyd.service --quiet && exit 1 || exit 0'
             ExecStart=/usr/sbin/chronyd -n -f /etc/chrony.conf -q
             RemainAfterExit=yes
             [Install]
             WantedBy=multi-user.target
           enabled: true
-          name: sync-time-once.service
+          name: chrony-wait.service

--- a/telco-ran/configuration/source-crs/extra-manifest/99-sync-time-once-master.yaml
+++ b/telco-ran/configuration/source-crs/extra-manifest/99-sync-time-once-master.yaml
@@ -20,10 +20,9 @@ spec:
             [Service]
             Type=oneshot
             TimeoutStartSec=300
-            ExecCondition=/bin/bash -c 'systemctl is-enabled chronyd.service --quiet && exit 1 || exit 0'
             ExecStart=/usr/sbin/chronyd -n -f /etc/chrony.conf -q
             RemainAfterExit=yes
             [Install]
             WantedBy=multi-user.target
           enabled: true
-          name: sync-time-once.service
+          name: chrony-wait.service

--- a/telco-ran/configuration/source-crs/extra-manifest/99-sync-time-once-worker.yaml
+++ b/telco-ran/configuration/source-crs/extra-manifest/99-sync-time-once-worker.yaml
@@ -20,10 +20,9 @@ spec:
             [Service]
             Type=oneshot
             TimeoutStartSec=300
-            ExecCondition=/bin/bash -c 'systemctl is-enabled chronyd.service --quiet && exit 1 || exit 0'
             ExecStart=/usr/sbin/chronyd -n -f /etc/chrony.conf -q
             RemainAfterExit=yes
             [Install]
             WantedBy=multi-user.target
           enabled: true
-          name: sync-time-once.service
+          name: chrony-wait.service


### PR DESCRIPTION
…d sync

This is because chrony-wait was causing chronyd to start then the one time sync was also triggering a chronyd request time, this can sensitive NTP servers to respond with a KOD packet.