### PR TITLE
OCPBUGS-72511: Explicitly set the name of BSL

### DIFF
--- a/telco-ran/configuration/argocd/example/acmpolicygenerator/acm-example-sno-site.yaml
+++ b/telco-ran/configuration/argocd/example/acmpolicygenerator/acm-example-sno-site.yaml
@@ -83,7 +83,8 @@ policies:
 #     patches:
 #     - spec:
 #         backupLocations:
-#         - velero:
+#         - name: dataprotectionapplication-1
+#           velero:
 #             provider: aws
 #             default: true
 #             credential:
@@ -98,5 +99,4 @@ policies:
 #             objectStorage:
 #               bucket: ibu
 #               prefix: '{{hub .ManagedClusterName hub}}'
-#   - path: source-crs/data-protection/OadpBackupStorageLocationStatus.yaml
 #   --- END of source CRs needed for configuring OADP operator for SNO Image Based Upgrade ---

--- a/telco-ran/configuration/argocd/example/acmpolicygenerator/acm-group-du-sno-validator-ranGen.yaml
+++ b/telco-ran/configuration/argocd/example/acmpolicygenerator/acm-group-du-sno-validator-ranGen.yaml
@@ -40,3 +40,5 @@ policies:
     ran.openshift.io/ztp-deploy-wave: "10000"
   manifests:
     - path: source-crs/validatorCRs/informDuValidatorMaster.yaml
+# source CR needed for configuring OADP operator for SNO Image Based Upgrade
+#   - path: source-crs/data-protection/OadpBackupStorageLocationStatus.yaml

--- a/telco-ran/configuration/argocd/example/acmpolicygenerator/hub-side-templating/acm-group-du-sno-ranGen-templated.yaml
+++ b/telco-ran/configuration/argocd/example/acmpolicygenerator/hub-side-templating/acm-group-du-sno-ranGen-templated.yaml
@@ -268,7 +268,8 @@ policies:
 #       patches:
 #       - spec:
 #           backupLocations:
-#           - velero:
+#           - name: dataprotectionapplication-1
+#             velero:
 #               provider: aws
 #               default: true
 #               credential:
@@ -283,5 +284,4 @@ policies:
 #               objectStorage:
 #                 bucket: ibu
 #                 prefix: '{{hub .ManagedClusterName hub}}'
-#     - path: source-crs/data-protection/OadpBackupStorageLocationStatus.yaml
 #   --- END of source CRs needed for configuring OADP operator for SNO Image Based Upgrade ---

--- a/telco-ran/configuration/argocd/example/policygentemplates/example-sno-site.yaml
+++ b/telco-ran/configuration/argocd/example/policygentemplates/example-sno-site.yaml
@@ -57,7 +57,8 @@ spec:
 #     policyName: "config-policy"
 #     spec:
 #       backupLocations:
-#       - velero:
+#       - name: dataprotectionapplication-1
+#         velero:
 #           provider: aws
 #           default: true
 #           credential:
@@ -72,6 +73,4 @@ spec:
 #           objectStorage:
 #             bucket: ibu
 #             prefix: '{{hub .ManagedClusterName hub}}'
-#   - fileName: data-protection/OadpBackupStorageLocationStatus.yaml
-#     policyName: "config-policy"
 #   --- END of source CRs needed for configuring OADP operator for SNO Image Based Upgrade ---

--- a/telco-ran/configuration/argocd/example/policygentemplates/group-du-sno-validator-ranGen.yaml
+++ b/telco-ran/configuration/argocd/example/policygentemplates/group-du-sno-validator-ranGen.yaml
@@ -26,3 +26,7 @@ spec:
       # using a bindingExcludeRules entry with ztp-done
       evaluationInterval:
         compliant: 5s
+# source CRs needed for configuring OADP operator for SNO Image Based Upgrade
+
+#   - fileName: data-protection/OadpBackupStorageLocationStatus.yaml
+#     policyName: "du-policy"

--- a/telco-ran/configuration/argocd/example/policygentemplates/hub-side-templating/group-du-sno-ranGen-templated.yaml
+++ b/telco-ran/configuration/argocd/example/policygentemplates/hub-side-templating/group-du-sno-ranGen-templated.yaml
@@ -245,7 +245,8 @@ spec:
 #      policyName: "oadp-config-policy"
 #      spec:
 #        backupLocations:
-#        - velero:
+#        - name: dataprotectionapplication-1
+#          velero:
 #            provider: aws
 #            default: true
 #            credential:
@@ -260,6 +261,4 @@ spec:
 #            objectStorage:
 #              bucket: ibu
 #              prefix: '{{hub .ManagedClusterName hub}}'
-#    - fileName: data-protection/OadpBackupStorageLocationStatus.yaml  # wave 100
-#      policyName: "oadp-config-policy"
 #    --- END of source CRs needed for configuring OADP operator for SNO Image Based Upgrade ---

--- a/telco-ran/configuration/source-crs/data-protection/OadpBackupStorageLocationStatus.yaml
+++ b/telco-ran/configuration/source-crs/data-protection/OadpBackupStorageLocationStatus.yaml
@@ -12,6 +12,6 @@ metadata:
   name: dataprotectionapplication-1
   namespace: openshift-adp
   annotations:
-    ran.openshift.io/ztp-deploy-wave: "100"
+    ran.openshift.io/ztp-deploy-wave: "10000"
 status:
   phase: Available

--- a/telco-ran/configuration/source-crs/data-protection/OadpDataProtectionApplication.yaml
+++ b/telco-ran/configuration/source-crs/data-protection/OadpDataProtectionApplication.yaml
@@ -19,7 +19,8 @@ spec:
       resourceTimeout: 10m
 # User needs to configure the following backupLocations through PGT overlay
 # backupLocations:
-# - velero:
+# - name: dataprotectionapplication-1
+#   velero:
 #     provider: aws
 #     default: true
 #     credential:


### PR DESCRIPTION
This commit explicitly sets the BackupStorageLocation name in the DataProtectionApplication rather than relying on the default behavior. Additionally, BackupStorageLocation status policy is added to valdiator policy. This change is necessary because the status policy creates an empty BackupStorageLocation, and recent OADP updates no longer allow setting a default value for a BackupStorageLocation after it has already been created.