### PR TITLE
adding right version to release 4.21 hub rds

### DIFF
--- a/telco-hub/configuration/reference-crs-kube-compare/required/acm/acmSubscription.yaml
+++ b/telco-hub/configuration/reference-crs-kube-compare/required/acm/acmSubscription.yaml
@@ -7,7 +7,7 @@ metadata:
   name: open-cluster-management-subscription
   namespace: open-cluster-management
 spec:
-  channel: release-2.14
+  channel: release-2.15
   installPlanApproval: Automatic
   name: advanced-cluster-management
   source: {{ .spec.source }}

--- a/telco-hub/configuration/reference-crs-kube-compare/required/gitops/gitopsSubscription.yaml
+++ b/telco-hub/configuration/reference-crs-kube-compare/required/gitops/gitopsSubscription.yaml
@@ -7,7 +7,7 @@ metadata:
   name: openshift-gitops-operator
   namespace: openshift-gitops-operator
 spec:
-  channel: gitops-1.16
+  channel: gitops-1.19
   installPlanApproval: Automatic
   name: openshift-gitops-operator
   source: {{ .spec.source }}

--- a/telco-hub/configuration/reference-crs/required/acm/acmSubscription.yaml
+++ b/telco-hub/configuration/reference-crs/required/acm/acmSubscription.yaml
@@ -7,7 +7,7 @@ metadata:
   name: open-cluster-management-subscription
   namespace: open-cluster-management
 spec:
-  channel: release-2.14
+  channel: release-2.15
   installPlanApproval: Automatic
   name: advanced-cluster-management
   source: redhat-operators-disconnected

--- a/telco-hub/configuration/reference-crs/required/gitops/addPluginsPolicy.yaml
+++ b/telco-hub/configuration/reference-crs/required/gitops/addPluginsPolicy.yaml
@@ -67,7 +67,7 @@ spec:
                         terminationMessagePath: "/dev/termination-log"
                         image: "registry.redhat.io/openshift4/ztp-site-generate-rhel8:v4.20"
                       - name: "policy-generator-install"
-                        image: "registry.redhat.io/rhacm2/multicluster-operators-subscription-rhel9:v2.13"
+                        image: "registry.redhat.io/rhacm2/multicluster-operators-subscription-rhel9:v2.15"
                         imagePullPolicy: "Always"
                         volumeMounts:
                           - name: "kustomize"

--- a/telco-hub/configuration/reference-crs/required/gitops/gitopsSubscription.yaml
+++ b/telco-hub/configuration/reference-crs/required/gitops/gitopsSubscription.yaml
@@ -7,7 +7,7 @@ metadata:
   name: openshift-gitops-operator
   namespace: openshift-gitops-operator
 spec:
-  channel: gitops-1.16
+  channel: gitops-1.19
   installPlanApproval: Automatic
   name: openshift-gitops-operator
   source: redhat-operators-disconnected

--- a/telco-hub/install/mirror-registry/imageset-config.yaml
+++ b/telco-hub/install/mirror-registry/imageset-config.yaml
@@ -10,24 +10,24 @@ mirror:
       # minimize the mirrored content to only what is needed for your deployment. Note that only
       # versions which are mirrored to the disconnected registry can be installed, so only versions
       # listed here should be referenced in installation CRs (eg ClusterImageSet / imageSetRef).
-      minVersion: 4.20.0
-      maxVersion: 4.20.2
+      minVersion: 4.21.0
+      maxVersion: 4.21.2
   operators:
   - catalog: registry.redhat.io/redhat/redhat-operator-index:v4.20
     targetCatalog: openshift-marketplace/redhat-operators-disconnected
     packages:
     - name: advanced-cluster-management
-      defaultChannel: release-2.14
+      defaultChannel: release-2.15
       channels:
-      - name: release-2.14
+      - name: release-2.15
     - name: multicluster-engine
-      defaultChannel: stable-2.9
+      defaultChannel: stable-2.10
       channels:
-      - name: stable-2.9
+      - name: stable-2.10
     - name: openshift-gitops-operator
-      defaultChannel: gitops-1.16
+      defaultChannel: gitops-1.19
       channels:
-      - name: gitops-1.16
+      - name: gitops-1.19
     - name: redhat-oadp-operator
       channels:
       - name: stable
@@ -39,7 +39,7 @@ mirror:
       - name: stable
     - name: cluster-logging
       channels:
-      - name: stable-6.2
+      - name: stable-6.4
     - name: odf-operator
       defaultChannel: stable-4.20
       channels:
@@ -100,5 +100,5 @@ mirror:
   - name: registry.redhat.io/ubi8/ubi:latest
   - name: registry.redhat.io/openshift4/ztp-site-generate-rhel8:v4.20
   - name: registry.redhat.io/rhel8/support-tools:latest
-  - name: registry.redhat.io/rhacm2/multicluster-operators-subscription-rhel9:2.14.0-1
+  - name: registry.redhat.io/rhacm2/multicluster-operators-subscription-rhel9:v2.15.0-1
   helm: {}


### PR DESCRIPTION
Adding the right version to the imageset-config to get the right Image into the registry
Adjusting the Operator version to match release version
keeping version 4.20 for ODR