### PR TITLE
Cluster Logging version 6.4 is required for 4.21

### DIFF
--- a/telco-hub/configuration/reference-crs-kube-compare/optional/logging/clusterLogSubscription.yaml
+++ b/telco-hub/configuration/reference-crs-kube-compare/optional/logging/clusterLogSubscription.yaml
@@ -7,7 +7,7 @@ metadata:
   name: cluster-logging
   namespace: openshift-logging
 spec:
-  channel: "stable-6.2"
+  channel: "stable-6.4"
   name: cluster-logging
   source: {{ .spec.source }}
   sourceNamespace: openshift-marketplace

--- a/telco-hub/configuration/reference-crs/optional/logging/clusterLogSubscription.yaml
+++ b/telco-hub/configuration/reference-crs/optional/logging/clusterLogSubscription.yaml
@@ -7,7 +7,7 @@ metadata:
   name: cluster-logging
   namespace: openshift-logging
 spec:
-  channel: "stable-6.2"
+  channel: "stable-6.4"
   name: cluster-logging
   source: redhat-operators-disconnected
   sourceNamespace: openshift-marketplace

--- a/telco-hub/install/mirror-registry/imageset-config.yaml
+++ b/telco-hub/install/mirror-registry/imageset-config.yaml
@@ -39,7 +39,6 @@ mirror:
       - name: stable
     - name: cluster-logging
       channels:
-      - name: stable-6.2
       - name: stable-6.4
     - name: odf-operator
       defaultChannel: stable-4.20


### PR DESCRIPTION
Update CLO to 6.4 as required to upgrade 4.21