### PR TITLE
OCPBUGS-76838: Blacklist mgag200 video driver for RAN profile

### DIFF
--- a/telco-ran/configuration/kube-compare-reference/node-tuning-operator/TunedPerformancePatch.yaml
+++ b/telco-ran/configuration/kube-compare-reference/node-tuning-operator/TunedPerformancePatch.yaml
@@ -42,7 +42,7 @@ spec:
         group.ice-gnss=0:f:10:*:ice-gnss.*
         group.ice-dplls=0:f:10:*:ice-dplls.*
         [bootloader]
-        cmdline_x86_blacklist=module_blacklist=irdma
+        cmdline_x86_blacklist=module_blacklist=irdma,mgag200
         [sysctl]
         kernel.panic_on_unrecovered_nmi=1
   recommend:

--- a/telco-ran/configuration/source-crs/node-tuning-operator/TunedPerformancePatch.yaml
+++ b/telco-ran/configuration/source-crs/node-tuning-operator/TunedPerformancePatch.yaml
@@ -42,7 +42,7 @@ spec:
         group.ice-gnss=0:f:10:*:ice-gnss.*
         group.ice-dplls=0:f:10:*:ice-dplls.*
         [bootloader]
-        cmdline_x86_blacklist=module_blacklist=irdma
+        cmdline_x86_blacklist=module_blacklist=irdma,mgag200
         [sysctl]
         kernel.panic_on_unrecovered_nmi=1
   recommend:


### PR DESCRIPTION
- **OCPBUGS-76838: Repair RAN DU profile tuned commandline argument handling**
- **OCPBUGS-76838: Blacklist mgag200 video driver for RAN profile**
