### PR TITLE
Additional fixes for 4.20 reference

### DIFF
--- a/telco-hub/configuration/reference-crs/required/gitops/clusterrole.yaml
+++ b/telco-hub/configuration/reference-crs/required/gitops/clusterrole.yaml
@@ -85,3 +85,15 @@ rules:
   verbs:
   - 'patch'
   - 'get'
+- apiGroups:
+  - observability.openshift.io
+  resources:
+  - clusterlogforwarders
+  verbs:
+  - '*'
+#- apiGroups:
+#  - ""
+#  resources:
+#  - serviceaccounts
+#  verbs:
+#  - '*'

--- a/telco-hub/install/mirror-registry/imageset-config.yaml
+++ b/telco-hub/install/mirror-registry/imageset-config.yaml
@@ -17,11 +17,11 @@ mirror:
     targetCatalog: openshift-marketplace/redhat-operators-disconnected
     packages:
     - name: advanced-cluster-management
-      defaultChannel: release-2.14
+      defaultChannel: release-2.15
       channels:
-      - name: release-2.14
+      - name: release-2.15
     - name: multicluster-engine
-      defaultChannel: stable-2.9
+      defaultChannel: stable-2.10
       channels:
       - name: stable-2.9
     - name: openshift-gitops-operator


### PR DESCRIPTION
Update the image mirroring to match 2.15 ACM version for 4.20.

Add optional logging CRs to the custom ClusterRole for argocd sync.