### PR TITLE
OCPBUGS-67196: cluster network mtu setting at deployment time 

### DIFF
--- a/telco-core/install/extra-manifests/Network.yaml
+++ b/telco-core/install/extra-manifests/Network.yaml
@@ -7,4 +7,4 @@ metadata:
 spec:
   defaultNetwork:
     ovnKubernetesConfig:
-      mtu: $clusterNetworkMTU # Explicitly set cluster network MTU at deployment time. Setting the Cluster Network MTU at deployment requires caution. Its value must be lower than the Machine Network MTU by at least 100 bytes to account for OVN overhead. A further reduction (100 bytes) is necessary if IPsec is enabled
+      mtu: 8900 # This is the recommended default value. Setting the Cluster Network MTU at deployment requires caution. Its value must be lower than the Machine Network MTU by at least 100 bytes to account for OVN overhead. A further reduction (100 bytes) is necessary if IPsec is enabled.

--- a/telco-core/install/extra-manifests/Network.yaml
+++ b/telco-core/install/extra-manifests/Network.yaml
@@ -1,0 +1,10 @@
+# optional
+---
+apiVersion: operator.openshift.io/v1
+kind: Network
+metadata:
+  name: cluster
+spec:
+  defaultNetwork:
+    ovnKubernetesConfig:
+      mtu: $clusterNetworkMTU # Explicitly set cluster network MTU at deployment time. Setting the Cluster Network MTU at deployment requires caution. Its value must be lower than the Machine Network MTU by at least 100 bytes to account for OVN overhead. A further reduction (100 bytes) is necessary if IPsec is enabled

--- a/telco-core/install/extra-manifests/Network.yaml
+++ b/telco-core/install/extra-manifests/Network.yaml
@@ -8,3 +8,4 @@ spec:
   defaultNetwork:
     ovnKubernetesConfig:
       mtu: 8900 # This is the recommended default value. Setting the Cluster Network MTU at deployment requires caution. Its value must be lower than the Machine Network MTU by at least 100 bytes to account for OVN overhead. A further reduction (100 bytes) is necessary if IPsec is enabled.
+      

--- a/telco-core/install/extra-manifests/Network.yaml
+++ b/telco-core/install/extra-manifests/Network.yaml
@@ -7,5 +7,4 @@ metadata:
 spec:
   defaultNetwork:
     ovnKubernetesConfig:
-      mtu: 8900 # This is the recommended default value. Setting the Cluster Network MTU at deployment requires caution. Its value must be lower than the Machine Network MTU by at least 100 bytes to account for OVN overhead. A further reduction (100 bytes) is necessary if IPsec is enabled.
-      
+      mtu: 8900 # The cluster MTU must be set lower than machine network MTU. Optional features like encryption may require further lowering the MTU. See the documentation for details: https://docs.redhat.com/en/documentation/openshift_container_platform/latest/html/advanced_networking/changing-cluster-network-mtu


### PR DESCRIPTION
This PR is for setting cluster network MTU at deployment time for Spoke cluster. This is needed for uses case where partner would avoid MTU migration in day2 (minimum 2 reboot) and prefer to set the recommended default cluster network mtu or to set a buffer for MTU for future needs.