### PR TITLE
OCPBUGS-77091: Add ts2phc.pin_index 1 to ptpconfigs

### DIFF
--- a/telco-ran/configuration/kube-compare-reference/ptp-operator/configuration/PtpConfigDualCardGmWpc.yaml
+++ b/telco-ran/configuration/kube-compare-reference/ptp-operator/configuration/PtpConfigDualCardGmWpc.yaml
@@ -107,10 +107,12 @@ spec:
       leapfile  /usr/share/zoneinfo/leap-seconds.list
       [(?<iface_timeTx1>[[:alnum:]]+)]
       ts2phc.extts_polarity rising
+      ts2phc.pin_index 1
       ts2phc.extts_correction 0
       [(?<iface_timeTx2>[[:alnum:]]+)]
       ts2phc.master 0
       ts2phc.extts_polarity rising
+      ts2phc.pin_index 1
       #this is a measured value in nanoseconds to compensate for SMA cable delay
       ts2phc.extts_correction -10
     ptp4lConf: |

--- a/telco-ran/configuration/kube-compare-reference/ptp-operator/configuration/PtpConfigDualCardTBCWpc.yaml
+++ b/telco-ran/configuration/kube-compare-reference/ptp-operator/configuration/PtpConfigDualCardTBCWpc.yaml
@@ -156,10 +156,12 @@ spec:
       uds_address /var/run/ptp4l.0.socket
       [(?<iface_FirstPort1>[[:alnum:]]+)]
       ts2phc.extts_polarity rising
+      ts2phc.pin_index 1
       ts2phc.extts_correction -10
       ts2phc.master 0
       [(?<iface_FirstPort2>[[:alnum:]]+)]
       ts2phc.extts_polarity rising
+      ts2phc.pin_index 1
       ts2phc.extts_correction -27
       ts2phc.master 0
     ts2phcOpts: -s generic -a --ts2phc.rh_external_pps 1

--- a/telco-ran/configuration/kube-compare-reference/ptp-operator/configuration/PtpConfigGmWpc.yaml
+++ b/telco-ran/configuration/kube-compare-reference/ptp-operator/configuration/PtpConfigGmWpc.yaml
@@ -77,7 +77,7 @@ spec:
               - "1"
               - "-e"
               - "SURVEYIN,600,50000"
-            reportOutput: true  
+            reportOutput: true
           - args: #ubxtool -P 29.20 -p MON-HW
               - "-P"
               - "29.20"
@@ -105,6 +105,7 @@ spec:
       leapfile  /usr/share/zoneinfo/leap-seconds.list
       [(?<iface_timeTx>[[:alnum:]]+)]
       ts2phc.extts_polarity rising
+      ts2phc.pin_index 1
       ts2phc.extts_correction 0
     ptp4lConf: |
       [(?<iface_timeTx>[[:alnum:]]+)]

--- a/telco-ran/configuration/kube-compare-reference/ptp-operator/configuration/PtpConfigTBCWpc.yaml
+++ b/telco-ran/configuration/kube-compare-reference/ptp-operator/configuration/PtpConfigTBCWpc.yaml
@@ -152,6 +152,7 @@ spec:
       uds_address /var/run/ptp4l.0.socket
       [(?<iface_FirstPort>[[:alnum:]]+)]
       ts2phc.extts_polarity rising
+      ts2phc.pin_index 1
       ts2phc.extts_correction -10
       ts2phc.master 0
     ts2phcOpts: -s generic -a --ts2phc.rh_external_pps 1

--- a/telco-ran/configuration/kube-compare-reference/ptp-operator/configuration/PtpConfigTTSCWpc.yaml
+++ b/telco-ran/configuration/kube-compare-reference/ptp-operator/configuration/PtpConfigTTSCWpc.yaml
@@ -150,6 +150,7 @@ spec:
       uds_address /var/run/ptp4l.0.socket
       [(?<iface_FirstPort>[[:alnum:]]+)]
       ts2phc.extts_polarity rising
+      ts2phc.pin_index 1
       ts2phc.extts_correction -10
       ts2phc.master 0
     ts2phcOpts: -s generic -a --ts2phc.rh_external_pps 1

--- a/telco-ran/configuration/kube-compare-reference/ptp-operator/configuration/PtpConfigThreeCardGmWpc.yaml
+++ b/telco-ran/configuration/kube-compare-reference/ptp-operator/configuration/PtpConfigThreeCardGmWpc.yaml
@@ -106,15 +106,18 @@ spec:
       leapfile /usr/share/zoneinfo/leap-seconds.list
       [(?<iface_timeTx1>[[:alnum:]]+)]
       ts2phc.extts_polarity rising
+      ts2phc.pin_index 1
       ts2phc.extts_correction 0
       [(?<iface_timeTx2>[[:alnum:]]+)]
       ts2phc.master 0
       ts2phc.extts_polarity rising
+      ts2phc.pin_index 1
       #this is a measured value in nanoseconds to compensate for SMA cable delay
       ts2phc.extts_correction -10
       [(?<iface_timeTx3>[[:alnum:]]+)]
       ts2phc.master 0
       ts2phc.extts_polarity rising
+      ts2phc.pin_index 1
       #this is a measured value in nanoseconds to compensate for SMA cable delay
       ts2phc.extts_correction -10
     ptp4lConf: |

--- a/telco-ran/configuration/kube-compare-reference/ptp-operator/configuration/PtpConfigThreeCardTBCWpc.yaml
+++ b/telco-ran/configuration/kube-compare-reference/ptp-operator/configuration/PtpConfigThreeCardTBCWpc.yaml
@@ -156,14 +156,17 @@ spec:
       uds_address /var/run/ptp4l.0.socket
       [(?<iface_FirstPort1>[[:alnum:]]+)]
       ts2phc.extts_polarity rising
+      ts2phc.pin_index 1
       ts2phc.extts_correction -10
       ts2phc.master 0
       [(?<iface_FirstPort2>[[:alnum:]]+)]
       ts2phc.extts_polarity rising
+      ts2phc.pin_index 1
       ts2phc.extts_correction -27
       ts2phc.master 0
       [(?<iface_FirstPort3>[[:alnum:]]+)]
       ts2phc.extts_polarity rising
+      ts2phc.pin_index 1
       ts2phc.extts_correction -27
       ts2phc.master 0
     ts2phcOpts: -s generic -a --ts2phc.rh_external_pps 1

--- a/telco-ran/configuration/source-crs/ptp-operator/configuration/PtpConfigDualCardGmWpc.yaml
+++ b/telco-ran/configuration/source-crs/ptp-operator/configuration/PtpConfigDualCardGmWpc.yaml
@@ -117,10 +117,12 @@ spec:
       leapfile  /usr/share/zoneinfo/leap-seconds.list
       [(?<iface_timeTx1>[[:alnum:]]+)]
       ts2phc.extts_polarity rising
+      ts2phc.pin_index 1
       ts2phc.extts_correction 0
       [(?<iface_timeTx2>[[:alnum:]]+)]
       ts2phc.master 0
       ts2phc.extts_polarity rising
+      ts2phc.pin_index 1
       #this is a measured value in nanoseconds to compensate for SMA cable delay
       ts2phc.extts_correction -10
     ptp4lConf: |

--- a/telco-ran/configuration/source-crs/ptp-operator/configuration/PtpConfigDualCardTBCWpc.yaml
+++ b/telco-ran/configuration/source-crs/ptp-operator/configuration/PtpConfigDualCardTBCWpc.yaml
@@ -174,10 +174,12 @@ spec:
       uds_address /var/run/ptp4l.0.socket
       [$iface_FirstPort1]
       ts2phc.extts_polarity rising
+      ts2phc.pin_index 1
       ts2phc.extts_correction -10
       ts2phc.master 0
       [$iface_FirstPort2]
       ts2phc.extts_polarity rising
+      ts2phc.pin_index 1
       ts2phc.extts_correction -27
       ts2phc.master 0
     ts2phcOpts: -s generic -a --ts2phc.rh_external_pps 1

--- a/telco-ran/configuration/source-crs/ptp-operator/configuration/PtpConfigGmWpc.yaml
+++ b/telco-ran/configuration/source-crs/ptp-operator/configuration/PtpConfigGmWpc.yaml
@@ -82,7 +82,7 @@ spec:
               - "1"
               - "-e"
               - "SURVEYIN,600,50000"
-            reportOutput: true  
+            reportOutput: true
           - args: #ubxtool -P 29.20 -p MON-HW
               - "-P"
               - "29.20"
@@ -110,6 +110,7 @@ spec:
       leapfile  /usr/share/zoneinfo/leap-seconds.list
       [(?<iface_timeTx>[[:alnum:]]+)]
       ts2phc.extts_polarity rising
+      ts2phc.pin_index 1
       ts2phc.extts_correction 0
     ptp4lConf: |
       [(?<iface_timeTx>[[:alnum:]]+)]

--- a/telco-ran/configuration/source-crs/ptp-operator/configuration/PtpConfigTBCWpc.yaml
+++ b/telco-ran/configuration/source-crs/ptp-operator/configuration/PtpConfigTBCWpc.yaml
@@ -163,6 +163,7 @@ spec:
       uds_address /var/run/ptp4l.0.socket
       [$iface_FirstPort]
       ts2phc.extts_polarity rising
+      ts2phc.pin_index 1
       ts2phc.extts_correction -10
       ts2phc.master 0
     ts2phcOpts: -s generic -a --ts2phc.rh_external_pps 1

--- a/telco-ran/configuration/source-crs/ptp-operator/configuration/PtpConfigTTSCWpc.yaml
+++ b/telco-ran/configuration/source-crs/ptp-operator/configuration/PtpConfigTTSCWpc.yaml
@@ -162,6 +162,7 @@ spec:
       uds_address /var/run/ptp4l.0.socket
       [$iface_FirstPort]
       ts2phc.extts_polarity rising
+      ts2phc.pin_index 1
       ts2phc.extts_correction -10
       ts2phc.master 0
     ts2phcOpts: -s generic -a --ts2phc.rh_external_pps 1

--- a/telco-ran/configuration/source-crs/ptp-operator/configuration/PtpConfigThreeCardGmWpc.yaml
+++ b/telco-ran/configuration/source-crs/ptp-operator/configuration/PtpConfigThreeCardGmWpc.yaml
@@ -121,15 +121,18 @@ spec:
       leapfile /usr/share/zoneinfo/leap-seconds.list
       [$iface_timeTx1]
       ts2phc.extts_polarity rising
+      ts2phc.pin_index 1
       ts2phc.extts_correction 0
       [$iface_timeTx2]
       ts2phc.master 0
       ts2phc.extts_polarity rising
+      ts2phc.pin_index 1
       #this is a measured value in nanoseconds to compensate for SMA cable delay
       ts2phc.extts_correction -10
       [$iface_timeTx3]
       ts2phc.master 0
       ts2phc.extts_polarity rising
+      ts2phc.pin_index 1
       #this is a measured value in nanoseconds to compensate for SMA cable delay
       ts2phc.extts_correction -10
     ptp4lConf: |

--- a/telco-ran/configuration/source-crs/ptp-operator/configuration/PtpConfigThreeCardTBCWpc.yaml
+++ b/telco-ran/configuration/source-crs/ptp-operator/configuration/PtpConfigThreeCardTBCWpc.yaml
@@ -186,14 +186,17 @@ spec:
       uds_address /var/run/ptp4l.0.socket
       [$iface_FirstPort1]
       ts2phc.extts_polarity rising
+      ts2phc.pin_index 1
       ts2phc.extts_correction -10
       ts2phc.master 0
       [$iface_FirstPort2]
       ts2phc.extts_polarity rising
+      ts2phc.pin_index 1
       ts2phc.extts_correction -27
       ts2phc.master 0
       [$iface_FirstPort3]
       ts2phc.extts_polarity rising
+      ts2phc.pin_index 1
       ts2phc.extts_correction -27
       ts2phc.master 0
     ts2phcOpts: -s generic -a --ts2phc.rh_external_pps 1


### PR DESCRIPTION
A driver has made it so the default value (0) for the pin_index is no longer valid instead it must be set to 1 for ts2phc to function