### PR TITLE
OCPBUGS-77228: Add missing rbac permissions

### DIFF
--- a/telco-hub/configuration/reference-crs-kube-compare/required/gitops/clusterrole.yaml
+++ b/telco-hub/configuration/reference-crs-kube-compare/required/gitops/clusterrole.yaml
@@ -85,3 +85,15 @@ rules:
   verbs:
   - 'patch'
   - 'get'
+- apiGroups:
+  - ""
+  resources:
+  - serviceaccounts
+  verbs:
+  - '*'
+- apiGroups:
+  - observability.openshift.io
+  resources:
+  - clusterlogforwarders
+  verbs:
+  - '*'

--- a/telco-hub/configuration/reference-crs/required/gitops/clusterrole.yaml
+++ b/telco-hub/configuration/reference-crs/required/gitops/clusterrole.yaml
@@ -85,3 +85,15 @@ rules:
   verbs:
   - 'patch'
   - 'get'
+- apiGroups:
+  - ""
+  resources:
+  - serviceaccounts
+  verbs:
+  - '*'
+- apiGroups:
+  - observability.openshift.io
+  resources:
+  - clusterlogforwarders
+  verbs:
+  - '*'


### PR DESCRIPTION
Adding the ClusterLogging operator configuration via gitops requires permissions for ClusterLogForwarder and creation of service account.

Leaving serviceaccount out of RBAC permissions for now as gitops best practice is under review.