### PR TITLE
CNF-22621: RAN Hardening (5.0) - Audit SELinux (M4)

### DIFF
--- a/telco-ran/configuration/kube-compare-reference/informational/hardening/75-audit-selinux-master.yaml
+++ b/telco-ran/configuration/kube-compare-reference/informational/hardening/75-audit-selinux-master.yaml
@@ -1,0 +1,23 @@
+apiVersion: machineconfiguration.openshift.io/v1
+kind: MachineConfig
+metadata:
+  name: 75-audit-selinux-master
+  labels:
+    machineconfiguration.openshift.io/role: master
+spec:
+  config:
+    ignition:
+      version: 3.5.0
+    storage:
+      files:
+      - path: /etc/audit/rules.d/75-selinux-audit.rules
+        mode: 420
+        overwrite: true
+        contents:
+          # -a always,exit -F path=/usr/bin/chcon -F auid>=1000 -F auid!=unset -F key=privileged
+          # -a always,exit -F path=/usr/sbin/restorecon -F auid>=1000 -F auid!=unset -F key=privileged
+          # -a always,exit -F path=/usr/sbin/semanage -F auid>=1000 -F auid!=unset -F key=privileged
+          # -a always,exit -F path=/usr/sbin/setfiles -F auid>=1000 -F auid!=unset -F key=privileged
+          # -a always,exit -F path=/usr/sbin/setsebool -F auid>=1000 -F auid!=unset -F key=privileged
+          # -a always,exit -F path=/usr/sbin/seunshare -F auid>=1000 -F auid!=unset -F key=privileged
+          source: data:text/plain,%23%20M4%3A%20Audit%20SELinux%20Commands%20%28E8%20Compliance%29%0A%0A-a%20always%2Cexit%20-F%20path%3D%2Fusr%2Fbin%2Fchcon%20-F%20auid%3E%3D1000%20-F%20auid%21%3Dunset%20-F%20key%3Dprivileged%0A-a%20always%2Cexit%20-F%20path%3D%2Fusr%2Fsbin%2Frestorecon%20-F%20auid%3E%3D1000%20-F%20auid%21%3Dunset%20-F%20key%3Dprivileged%0A-a%20always%2Cexit%20-F%20path%3D%2Fusr%2Fsbin%2Fsemanage%20-F%20auid%3E%3D1000%20-F%20auid%21%3Dunset%20-F%20key%3Dprivileged%0A-a%20always%2Cexit%20-F%20path%3D%2Fusr%2Fsbin%2Fsetfiles%20-F%20auid%3E%3D1000%20-F%20auid%21%3Dunset%20-F%20key%3Dprivileged%0A-a%20always%2Cexit%20-F%20path%3D%2Fusr%2Fsbin%2Fsetsebool%20-F%20auid%3E%3D1000%20-F%20auid%21%3Dunset%20-F%20key%3Dprivileged%0A-a%20always%2Cexit%20-F%20path%3D%2Fusr%2Fsbin%2Fseunshare%20-F%20auid%3E%3D1000%20-F%20auid%21%3Dunset%20-F%20key%3Dprivileged%0A

--- a/telco-ran/configuration/kube-compare-reference/informational/hardening/75-audit-selinux-worker.yaml
+++ b/telco-ran/configuration/kube-compare-reference/informational/hardening/75-audit-selinux-worker.yaml
@@ -1,0 +1,23 @@
+apiVersion: machineconfiguration.openshift.io/v1
+kind: MachineConfig
+metadata:
+  name: 75-audit-selinux-worker
+  labels:
+    machineconfiguration.openshift.io/role: worker
+spec:
+  config:
+    ignition:
+      version: 3.5.0
+    storage:
+      files:
+      - path: /etc/audit/rules.d/75-selinux-audit.rules
+        mode: 420
+        overwrite: true
+        contents:
+          # -a always,exit -F path=/usr/bin/chcon -F auid>=1000 -F auid!=unset -F key=privileged
+          # -a always,exit -F path=/usr/sbin/restorecon -F auid>=1000 -F auid!=unset -F key=privileged
+          # -a always,exit -F path=/usr/sbin/semanage -F auid>=1000 -F auid!=unset -F key=privileged
+          # -a always,exit -F path=/usr/sbin/setfiles -F auid>=1000 -F auid!=unset -F key=privileged
+          # -a always,exit -F path=/usr/sbin/setsebool -F auid>=1000 -F auid!=unset -F key=privileged
+          # -a always,exit -F path=/usr/sbin/seunshare -F auid>=1000 -F auid!=unset -F key=privileged
+          source: data:text/plain,%23%20M4%3A%20Audit%20SELinux%20Commands%20%28E8%20Compliance%29%0A%0A-a%20always%2Cexit%20-F%20path%3D%2Fusr%2Fbin%2Fchcon%20-F%20auid%3E%3D1000%20-F%20auid%21%3Dunset%20-F%20key%3Dprivileged%0A-a%20always%2Cexit%20-F%20path%3D%2Fusr%2Fsbin%2Frestorecon%20-F%20auid%3E%3D1000%20-F%20auid%21%3Dunset%20-F%20key%3Dprivileged%0A-a%20always%2Cexit%20-F%20path%3D%2Fusr%2Fsbin%2Fsemanage%20-F%20auid%3E%3D1000%20-F%20auid%21%3Dunset%20-F%20key%3Dprivileged%0A-a%20always%2Cexit%20-F%20path%3D%2Fusr%2Fsbin%2Fsetfiles%20-F%20auid%3E%3D1000%20-F%20auid%21%3Dunset%20-F%20key%3Dprivileged%0A-a%20always%2Cexit%20-F%20path%3D%2Fusr%2Fsbin%2Fsetsebool%20-F%20auid%3E%3D1000%20-F%20auid%21%3Dunset%20-F%20key%3Dprivileged%0A-a%20always%2Cexit%20-F%20path%3D%2Fusr%2Fsbin%2Fseunshare%20-F%20auid%3E%3D1000%20-F%20auid%21%3Dunset%20-F%20key%3Dprivileged%0A


### PR DESCRIPTION
## Summary
- MEDIUM severity SELinux audit rules (6 rules) for chcon, restorecon, semanage, setfiles, setsebool, seunshare
- Verified on OCP 4.22 (cnfdt16) — all 6 rules active via `auditctl -l`

## Remediation Group
- [M4: Audit SELinux](https://sebrandon1.github.io/compliance-scripts/versions/4.22/groups/M4.html)

## Jira
- [CNF-22621](https://redhat.atlassian.net/browse/CNF-22621)
- Epic: [CNF-22573](https://redhat.atlassian.net/browse/CNF-22573) — RAN Hardening for 5.0

## Test plan
- [x] Applied MachineConfig to OCP 4.22 cluster
- [x] Verified all 6 SELinux audit rules active via `auditctl -l`
- [x] MCP rollout completed without errors