### PR TITLE
CNF-22622: RAN Hardening (5.0) - Audit Time (M6)

### DIFF
--- a/telco-ran/configuration/kube-compare-reference/informational/hardening/75-audit-time-master.yaml
+++ b/telco-ran/configuration/kube-compare-reference/informational/hardening/75-audit-time-master.yaml
@@ -1,0 +1,24 @@
+apiVersion: machineconfiguration.openshift.io/v1
+kind: MachineConfig
+metadata:
+  name: 75-audit-time-master
+  labels:
+    machineconfiguration.openshift.io/role: master
+spec:
+  config:
+    ignition:
+      version: 3.5.0
+    storage:
+      files:
+      - path: /etc/audit/rules.d/75-time-change.rules
+        mode: 420
+        overwrite: true
+        contents:
+          # # Time syscalls
+          # -a always,exit -F arch=b64 -S adjtimex -S settimeofday -k time-change
+          # -a always,exit -F arch=b32 -S adjtimex -S settimeofday -S stime -k time-change
+          # -a always,exit -F arch=b64 -S clock_settime -F a0=0x0 -k time-change
+          # -a always,exit -F arch=b32 -S clock_settime -F a0=0x0 -k time-change
+          # # Localtime file watch
+          # -w /etc/localtime -p wa -k time-change
+          source: data:text/plain,%23%20M6%3A%20Audit%20Time%20Modifications%20%28E8%20Compliance%29%0A%0A%23%20Time%20syscalls%0A-a%20always%2Cexit%20-F%20arch%3Db64%20-S%20adjtimex%20-S%20settimeofday%20-k%20time-change%0A-a%20always%2Cexit%20-F%20arch%3Db32%20-S%20adjtimex%20-S%20settimeofday%20-S%20stime%20-k%20time-change%0A-a%20always%2Cexit%20-F%20arch%3Db64%20-S%20clock_settime%20-F%20a0%3D0x0%20-k%20time-change%0A-a%20always%2Cexit%20-F%20arch%3Db32%20-S%20clock_settime%20-F%20a0%3D0x0%20-k%20time-change%0A%0A%23%20Localtime%20file%20watch%0A-w%20%2Fetc%2Flocaltime%20-p%20wa%20-k%20time-change%0A

--- a/telco-ran/configuration/kube-compare-reference/informational/hardening/75-audit-time-worker.yaml
+++ b/telco-ran/configuration/kube-compare-reference/informational/hardening/75-audit-time-worker.yaml
@@ -1,0 +1,24 @@
+apiVersion: machineconfiguration.openshift.io/v1
+kind: MachineConfig
+metadata:
+  name: 75-audit-time-worker
+  labels:
+    machineconfiguration.openshift.io/role: worker
+spec:
+  config:
+    ignition:
+      version: 3.5.0
+    storage:
+      files:
+      - path: /etc/audit/rules.d/75-time-change.rules
+        mode: 420
+        overwrite: true
+        contents:
+          # # Time syscalls
+          # -a always,exit -F arch=b64 -S adjtimex -S settimeofday -k time-change
+          # -a always,exit -F arch=b32 -S adjtimex -S settimeofday -S stime -k time-change
+          # -a always,exit -F arch=b64 -S clock_settime -F a0=0x0 -k time-change
+          # -a always,exit -F arch=b32 -S clock_settime -F a0=0x0 -k time-change
+          # # Localtime file watch
+          # -w /etc/localtime -p wa -k time-change
+          source: data:text/plain,%23%20M6%3A%20Audit%20Time%20Modifications%20%28E8%20Compliance%29%0A%0A%23%20Time%20syscalls%0A-a%20always%2Cexit%20-F%20arch%3Db64%20-S%20adjtimex%20-S%20settimeofday%20-k%20time-change%0A-a%20always%2Cexit%20-F%20arch%3Db32%20-S%20adjtimex%20-S%20settimeofday%20-S%20stime%20-k%20time-change%0A-a%20always%2Cexit%20-F%20arch%3Db64%20-S%20clock_settime%20-F%20a0%3D0x0%20-k%20time-change%0A-a%20always%2Cexit%20-F%20arch%3Db32%20-S%20clock_settime%20-F%20a0%3D0x0%20-k%20time-change%0A%0A%23%20Localtime%20file%20watch%0A-w%20%2Fetc%2Flocaltime%20-p%20wa%20-k%20time-change%0A


### PR DESCRIPTION
## Summary
- MEDIUM severity time modification audit rules (5 rules) for adjtimex, clock_settime, settimeofday, stime, /etc/localtime
- Includes both 32-bit and 64-bit syscall variants
- Verified on OCP 4.22 (cnfdt16) — all rules active via `auditctl -l`

## Remediation Group
- [M6: Audit Time](https://sebrandon1.github.io/compliance-scripts/versions/4.22/groups/M6.html)

## Jira
- [CNF-22622](https://redhat.atlassian.net/browse/CNF-22622)
- Epic: [CNF-22573](https://redhat.atlassian.net/browse/CNF-22573) — RAN Hardening for 5.0

## Test plan
- [x] Applied MachineConfig to OCP 4.22 cluster
- [x] Verified all time audit rules active via `auditctl -l`
- [x] MCP rollout completed without errors