### PR TITLE
CNF-22624: RAN Hardening (5.0) - API Encryption (M10)

### DIFF
--- a/telco-ran/configuration/hardening/api-server/75-api-server-encryption.yaml
+++ b/telco-ran/configuration/hardening/api-server/75-api-server-encryption.yaml
@@ -1,0 +1,7 @@
+apiVersion: config.openshift.io/v1
+kind: APIServer
+metadata:
+  name: cluster
+spec:
+  encryption:
+    type: aescbc


### PR DESCRIPTION
## Summary
- MEDIUM severity API server encryption — enables AES-CBC encryption at rest for etcd (Secrets, ConfigMaps, Routes, OAuth tokens)
- APIServer CRD patch (not a MachineConfig, no node reboots)
- Verified on OCP 4.22 (cnfdt16) — `encryption.type: aescbc` confirmed

## Remediation Group
- [M10: API Encryption](https://sebrandon1.github.io/compliance-scripts/versions/4.22/groups/M10.html)

## Jira
- [CNF-22624](https://redhat.atlassian.net/browse/CNF-22624)
- Epic: [CNF-22573](https://redhat.atlassian.net/browse/CNF-22573) — RAN Hardening for 5.0

## Test plan
- [x] Applied APIServer CRD to OCP 4.22 cluster
- [x] Verified `encryption.type: aescbc` set
- [x] Encryption in progress for etcd resources