### PR TITLE
Add by2waysprojects to konflux OWNERS_ALIASES (release-4.20)

### DIFF
--- a/OWNERS_ALIASES
+++ b/OWNERS_ALIASES
@@ -22,8 +22,10 @@ aliases:
     - shajmakh
     - fontivan
     - rauhersu
+    - by2waysprojects
   konflux-reviewers:
     - yanirq
     - shajmakh
     - fontivan
     - rauhersu
+    - by2waysprojects


### PR DESCRIPTION
## Summary
- Add `by2waysprojects` to `konflux-approvers` and `konflux-reviewers` aliases in `OWNERS_ALIASES` to align with main branch.


Made with [Cursor](https://cursor.com)