### PR TITLE
OCPBUGS-60769: telco-ran: update ptp4lConfig reference to tolerate ordering

### DIFF
--- a/telco-ran/configuration/kube-compare-reference/hack/default_value.yaml
+++ b/telco-ran/configuration/kube-compare-reference/hack/default_value.yaml
@@ -263,22 +263,16 @@ ptp_operator_configuration_PtpConfigDualCardGmWpc:
       priority2: 128
       domainNumber: 24
       masterPorts: |-
-        [(?<iface_timeTx1>[[:alnum:]]+)]
+        # Include one section for each TimeTransmitter port on the WPC cards:
+              [ens1f0]
               masterOnly 1
-              [(?<iface_timeTx1_1>[[:alnum:]]+)]
+              [ens1f1]
               masterOnly 1
-              [(?<iface_timeTx1_2>[[:alnum:]]+)]
+              [ens2f0]
               masterOnly 1
-              [(?<iface_timeTx1_3>[[:alnum:]]+)]
+              [ens2f1]
               masterOnly 1
-              [(?<iface_timeTx2>[[:alnum:]]+)]
-              masterOnly 1
-              [(?<iface_timeTx2_1>[[:alnum:]]+)]
-              masterOnly 1
-              [(?<iface_timeTx2_2>[[:alnum:]]+)]
-              masterOnly 1
-              [(?<iface_timeTx2_3>[[:alnum:]]+)]
-              masterOnly 1
+              # ...
 ptp_operator_configuration_PtpConfigDualFollower:
   - spec:
       profile:

--- a/telco-ran/configuration/kube-compare-reference/hack/default_value.yaml
+++ b/telco-ran/configuration/kube-compare-reference/hack/default_value.yaml
@@ -262,6 +262,23 @@ ptp_operator_configuration_PtpConfigDualCardGmWpc:
     captureGroup_defaults:
       priority2: 128
       domainNumber: 24
+      masterPorts: |-
+        [(?<iface_timeTx1>[[:alnum:]]+)]
+              masterOnly 1
+              [(?<iface_timeTx1_1>[[:alnum:]]+)]
+              masterOnly 1
+              [(?<iface_timeTx1_2>[[:alnum:]]+)]
+              masterOnly 1
+              [(?<iface_timeTx1_3>[[:alnum:]]+)]
+              masterOnly 1
+              [(?<iface_timeTx2>[[:alnum:]]+)]
+              masterOnly 1
+              [(?<iface_timeTx2_1>[[:alnum:]]+)]
+              masterOnly 1
+              [(?<iface_timeTx2_2>[[:alnum:]]+)]
+              masterOnly 1
+              [(?<iface_timeTx2_3>[[:alnum:]]+)]
+              masterOnly 1
 ptp_operator_configuration_PtpConfigDualFollower:
   - spec:
       profile:

--- a/telco-ran/configuration/kube-compare-reference/hack/default_value.yaml
+++ b/telco-ran/configuration/kube-compare-reference/hack/default_value.yaml
@@ -215,6 +215,16 @@ ptp_operator_configuration_PtpConfigBoundary:
     captureGroup_defaults:
       priority2: 128
       domainNumber: 24
+      iface_timeRx: ens1f0
+      masterPorts: |-
+        # Include one section for each TimeTransmitter port:
+              [ens1f1]
+              masterOnly 1
+              [ens1f2]
+              masterOnly 1
+              [ens1f3]
+              masterOnly 1
+              # ...
 ptp_operator_configuration_PtpConfigBoundaryForEvent:
   - spec:
       profile:
@@ -230,6 +240,16 @@ ptp_operator_configuration_PtpConfigBoundaryForEvent:
     captureGroup_defaults:
       priority2: 128
       domainNumber: 24
+      iface_timeRx: ens1f0
+      masterPorts: |-
+        # Include one section for each TimeTransmitter port:
+              [ens1f1]
+              masterOnly 1
+              [ens1f2]
+              masterOnly 1
+              [ens1f3]
+              masterOnly 1
+              # ...
 ptp_operator_configuration_PtpConfigDualCardGmWpc:
   - spec:
       profile:
@@ -328,17 +348,35 @@ ptp_operator_configuration_PtpConfigThreeCardGmWpc:
       priority2: 128
       domainNumber: 24
       iface_timeTx1: $iface_timeTx1
-      iface_timeTx1_1: $iface_timeTx1_1
-      iface_timeTx1_2: $iface_timeTx1_2
-      iface_timeTx1_3: $iface_timeTx1_3
       iface_timeTx2: $iface_timeTx2
-      iface_timeTx2_1: $iface_timeTx2_1
-      iface_timeTx2_2: $iface_timeTx2_2
-      iface_timeTx2_3: $iface_timeTx2_3
       iface_timeTx3: $iface_timeTx3
-      iface_timeTx3_1: $iface_timeTx3_1
-      iface_timeTx3_2: $iface_timeTx3_2
-      iface_timeTx3_3: $iface_timeTx3_3
+      masterPorts: |-
+        # Include one section for each TimeTransmitter port on the WPC cards:
+              [ens1f0]
+              masterOnly 1
+              [ens1f1]
+              masterOnly 1
+              [ens1f2]
+              masterOnly 1
+              [ens1f3]
+              masterOnly 1
+              [ens2f0]
+              masterOnly 1
+              [ens2f1]
+              masterOnly 1
+              [ens2f2]
+              masterOnly 1
+              [ens2f3]
+              masterOnly 1
+              [ens3f0]
+              masterOnly 1
+              [ens3f1]
+              masterOnly 1
+              [ens3f2]
+              masterOnly 1
+              [ens3f3]
+              masterOnly 1
+              # ...
 ptp_operator_configuration_PtpConfigForHA:
   - spec:
       profile:
@@ -431,6 +469,17 @@ ptp_operator_configuration_PtpConfigGmWpc:
     captureGroup_defaults:
       priority2: 128
       domainNumber: 24
+      masterPorts: |-
+        # Include one section for each TimeTransmitter port on the WPC card:
+              [ens1f0]
+              masterOnly 1
+              [ens1f1]
+              masterOnly 1
+              [ens1f2]
+              masterOnly 1
+              [ens1f3]
+              masterOnly 1
+              # ...
 ptp_operator_configuration_PtpConfigSlaveForEvent:
   - spec:
       profile:
@@ -492,9 +541,15 @@ ptp_operator_configuration_PtpConfigTBCWpc:
       pi_integral_const: "0.0003"
       iface_timeRx: $iface_timeRx
       iface_FirstPort: $iface_FirstPort
-      iface_timeTx_0: $iface_timeTx_0
-      iface_timeTx_1: $iface_timeTx_1
-      iface_timeTx_2: $iface_timeTx_2
+      masterPorts: |-
+        # Include one section for each TimeTransmitter port on the WPC card:
+              [ens1f0]
+              masterOnly 1
+              [ens1f1]
+              masterOnly 1
+              [ens1f2]
+              masterOnly 1
+              # ...
 ptp_operator_configuration_PtpConfigDualCardTBCWpc:
   - spec:
       profile:
@@ -550,13 +605,23 @@ ptp_operator_configuration_PtpConfigDualCardTBCWpc:
       iface_timeRx: $iface_timeRx
       iface_FirstPort1: $iface_FirstPort1
       iface_FirstPort2: $iface_FirstPort2
-      iface_timeTx1_0: $iface_timeTx1_0
-      iface_timeTx1_1: $iface_timeTx1_1
-      iface_timeTx1_2: $iface_timeTx1_2
-      iface_timeTx2_0: $iface_timeTx2_0
-      iface_timeTx2_1: $iface_timeTx2_1
-      iface_timeTx2_2: $iface_timeTx2_2
-      iface_timeTx2_3: $iface_timeTx2_3
+      masterPorts: |-
+        # Include one section for each TimeTransmitter port on the WPC cards:
+              [ens1f0]
+              masterOnly 1
+              [ens1f1]
+              masterOnly 1
+              [ens1f2]
+              masterOnly 1
+              [ens2f0]
+              masterOnly 1
+              [ens2f1]
+              masterOnly 1
+              [ens2f2]
+              masterOnly 1
+              [ens2f3]
+              masterOnly 1
+              # ...
 ptp_operator_configuration_PtpConfigThreeCardTBCWpc:
   - spec:
       profile:
@@ -623,17 +688,31 @@ ptp_operator_configuration_PtpConfigThreeCardTBCWpc:
       iface_FirstPort1: $iface_FirstPort1
       iface_FirstPort2: $iface_FirstPort2
       iface_FirstPort3: $iface_FirstPort3
-      iface_timeTx1_0: $iface_timeTx1_0
-      iface_timeTx1_1: $iface_timeTx1_1
-      iface_timeTx1_2: $iface_timeTx1_2
-      iface_timeTx2_0: $iface_timeTx2_0
-      iface_timeTx2_1: $iface_timeTx2_1
-      iface_timeTx2_2: $iface_timeTx2_2
-      iface_timeTx2_3: $iface_timeTx2_3
-      iface_timeTx3_0: $iface_timeTx3_0
-      iface_timeTx3_1: $iface_timeTx3_1
-      iface_timeTx3_2: $iface_timeTx3_2
-      iface_timeTx3_3: $iface_timeTx3_3
+      masterPorts: |-
+        # Include one section for each TimeTransmitter port on the WPC cards:
+              [ens1f0]
+              masterOnly 1
+              [ens1f1]
+              masterOnly 1
+              [ens1f2]
+              masterOnly 1
+              [ens2f0]
+              masterOnly 1
+              [ens2f1]
+              masterOnly 1
+              [ens2f2]
+              masterOnly 1
+              [ens2f3]
+              masterOnly 1
+              [ens3f0]
+              masterOnly 1
+              [ens3f1]
+              masterOnly 1
+              [ens3f2]
+              masterOnly 1
+              [ens3f3]
+              masterOnly 1
+              # ...
 ptp_operator_configuration_PtpConfigTTSCWpc:
   - spec:
       profile:

--- a/telco-ran/configuration/kube-compare-reference/hack/default_value.yaml
+++ b/telco-ran/configuration/kube-compare-reference/hack/default_value.yaml
@@ -215,7 +215,7 @@ ptp_operator_configuration_PtpConfigBoundary:
     captureGroup_defaults:
       priority2: 128
       domainNumber: 24
-      iface_timeRx: ens1f0
+      iface_timeRx: $iface_timeRx
       masterPorts: |-
         # Include one section for each TimeTransmitter port:
               [ens1f1]
@@ -240,7 +240,7 @@ ptp_operator_configuration_PtpConfigBoundaryForEvent:
     captureGroup_defaults:
       priority2: 128
       domainNumber: 24
-      iface_timeRx: ens1f0
+      iface_timeRx: $iface_timeRx
       masterPorts: |-
         # Include one section for each TimeTransmitter port:
               [ens1f1]

--- a/telco-ran/configuration/kube-compare-reference/ptp-operator/configuration/PtpConfigBoundary.yaml
+++ b/telco-ran/configuration/kube-compare-reference/ptp-operator/configuration/PtpConfigBoundary.yaml
@@ -19,12 +19,8 @@ spec:
       # The interface name is hardware-specific
       [(?<iface_timeRx>[[:alnum:]]+)]
       masterOnly 0
-      [(?<iface_timeTx_1>[[:alnum:]]+)]
-      masterOnly 1
-      [(?<iface_timeTx_2>[[:alnum:]]+)]
-      masterOnly 1
-      [(?<iface_timeTx_3>[[:alnum:]]+)]
-      masterOnly 1
+      (?<masterPorts>((\[[[:alnum:]]+\]
+      masterOnly 1| *#.*| *)(\n|$))+)
       [global]
       #
       # Default Data Set

--- a/telco-ran/configuration/kube-compare-reference/ptp-operator/configuration/PtpConfigBoundaryForEvent.yaml
+++ b/telco-ran/configuration/kube-compare-reference/ptp-operator/configuration/PtpConfigBoundaryForEvent.yaml
@@ -19,12 +19,8 @@ spec:
       # The interface name is hardware-specific
       [(?<iface_timeRx>[[:alnum:]]+)]
       masterOnly 0
-      [(?<iface_timeTx_1>[[:alnum:]]+)]
-      masterOnly 1
-      [(?<iface_timeTx_2>[[:alnum:]]+)]
-      masterOnly 1
-      [(?<iface_timeTx_3>[[:alnum:]]+)]
-      masterOnly 1
+      (?<masterPorts>((\[[[:alnum:]]+\]
+      masterOnly 1| *#.*| *)(\n|$))+)
       [global]
       #
       # Default Data Set

--- a/telco-ran/configuration/kube-compare-reference/ptp-operator/configuration/PtpConfigDualCardGmWpc.yaml
+++ b/telco-ran/configuration/kube-compare-reference/ptp-operator/configuration/PtpConfigDualCardGmWpc.yaml
@@ -114,22 +114,8 @@ spec:
       #this is a measured value in nanoseconds to compensate for SMA cable delay
       ts2phc.extts_correction -10
     ptp4lConf: |
-      [(?<iface_timeTx1>[[:alnum:]]+)]
-      masterOnly 1
-      [(?<iface_timeTx1_1>[[:alnum:]]+)]
-      masterOnly 1
-      [(?<iface_timeTx1_2>[[:alnum:]]+)]
-      masterOnly 1
-      [(?<iface_timeTx1_3>[[:alnum:]]+)]
-      masterOnly 1
-      [(?<iface_timeTx2>[[:alnum:]]+)]
-      masterOnly 1
-      [(?<iface_timeTx2_1>[[:alnum:]]+)]
-      masterOnly 1
-      [(?<iface_timeTx2_2>[[:alnum:]]+)]
-      masterOnly 1
-      [(?<iface_timeTx2_3>[[:alnum:]]+)]
-      masterOnly 1
+      (?<masterPorts>((\[[[:alnum:]]+\]
+      masterOnly 1| *#.*| *)(\n|$))+)
       [global]
       #
       # Default Data Set

--- a/telco-ran/configuration/kube-compare-reference/ptp-operator/configuration/PtpConfigDualCardTBCWpc.yaml
+++ b/telco-ran/configuration/kube-compare-reference/ptp-operator/configuration/PtpConfigDualCardTBCWpc.yaml
@@ -167,20 +167,8 @@ spec:
   {{- if eq .name "tbc-dual-card-tt" }}
   - name: tbc-dual-card-tt
     ptp4lConf: |
-      [(?<iface_timeTx1_0>[[:alnum:]]+)]
-      masterOnly 1
-      [(?<iface_timeTx1_1>[[:alnum:]]+)]
-      masterOnly 1
-      [(?<iface_timeTx1_2>[[:alnum:]]+)]
-      masterOnly 1
-      [(?<iface_timeTx2_0>[[:alnum:]]+)]
-      masterOnly 1
-      [(?<iface_timeTx2_1>[[:alnum:]]+)]
-      masterOnly 1
-      [(?<iface_timeTx2_2>[[:alnum:]]+)]
-      masterOnly 1
-      [(?<iface_timeTx2_3>[[:alnum:]]+)]
-      masterOnly 1
+      (?<masterPorts>((\[[[:alnum:]]+\]
+      masterOnly 1| *#.*| *)(\n|$))+)
       [global]
       #
       # Default Data Set

--- a/telco-ran/configuration/kube-compare-reference/ptp-operator/configuration/PtpConfigGmWpc.yaml
+++ b/telco-ran/configuration/kube-compare-reference/ptp-operator/configuration/PtpConfigGmWpc.yaml
@@ -107,14 +107,8 @@ spec:
       ts2phc.extts_polarity rising
       ts2phc.extts_correction 0
     ptp4lConf: |
-      [(?<iface_timeTx>[[:alnum:]]+)]
-      masterOnly 1
-      [(?<iface_timeTx_1>[[:alnum:]]+)]
-      masterOnly 1
-      [(?<iface_timeTx_2>[[:alnum:]]+)]
-      masterOnly 1
-      [(?<iface_timeTx_3>[[:alnum:]]+)]
-      masterOnly 1
+      (?<masterPorts>((\[[[:alnum:]]+\]
+      masterOnly 1| *#.*| *)(\n|$))+)
       [global]
       #
       # Default Data Set

--- a/telco-ran/configuration/kube-compare-reference/ptp-operator/configuration/PtpConfigTBCWpc.yaml
+++ b/telco-ran/configuration/kube-compare-reference/ptp-operator/configuration/PtpConfigTBCWpc.yaml
@@ -159,12 +159,8 @@ spec:
   {{- if eq .name "tbc-tt" }}
   - name: tbc-tt
     ptp4lConf: |
-      [(?<iface_timeTx_0>[[:alnum:]]+)]
-      masterOnly 1
-      [(?<iface_timeTx_1>[[:alnum:]]+)]
-      masterOnly 1
-      [(?<iface_timeTx_2>[[:alnum:]]+)]
-      masterOnly 1
+      (?<masterPorts>((\[[[:alnum:]]+\]
+      masterOnly 1| *#.*| *)(\n|$))+)
       [global]
       #
       # Default Data Set

--- a/telco-ran/configuration/kube-compare-reference/ptp-operator/configuration/PtpConfigThreeCardGmWpc.yaml
+++ b/telco-ran/configuration/kube-compare-reference/ptp-operator/configuration/PtpConfigThreeCardGmWpc.yaml
@@ -118,30 +118,8 @@ spec:
       #this is a measured value in nanoseconds to compensate for SMA cable delay
       ts2phc.extts_correction -10
     ptp4lConf: |
-      [(?<iface_timeTx1>[[:alnum:]]+)]
-      masterOnly 1
-      [(?<iface_timeTx1_1>[[:alnum:]]+)]
-      masterOnly 1
-      [(?<iface_timeTx1_2>[[:alnum:]]+)]
-      masterOnly 1
-      [(?<iface_timeTx1_3>[[:alnum:]]+)]
-      masterOnly 1
-      [(?<iface_timeTx2>[[:alnum:]]+)]
-      masterOnly 1
-      [(?<iface_timeTx2_1>[[:alnum:]]+)]
-      masterOnly 1
-      [(?<iface_timeTx2_2>[[:alnum:]]+)]
-      masterOnly 1
-      [(?<iface_timeTx2_3>[[:alnum:]]+)]
-      masterOnly 1
-      [(?<iface_timeTx3>[[:alnum:]]+)]
-      masterOnly 1
-      [(?<iface_timeTx3_1>[[:alnum:]]+)]
-      masterOnly 1
-      [(?<iface_timeTx3_2>[[:alnum:]]+)]
-      masterOnly 1
-      [(?<iface_timeTx3_3>[[:alnum:]]+)]
-      masterOnly 1
+      (?<masterPorts>((\[[[:alnum:]]+\]
+      masterOnly 1| *#.*| *)(\n|$))+)
       [global]
       #
       # Default Data Set

--- a/telco-ran/configuration/kube-compare-reference/ptp-operator/configuration/PtpConfigThreeCardTBCWpc.yaml
+++ b/telco-ran/configuration/kube-compare-reference/ptp-operator/configuration/PtpConfigThreeCardTBCWpc.yaml
@@ -171,28 +171,8 @@ spec:
   {{- if eq .name "tbc-3-card-tt" }}
   - name: tbc-3-card-tt
     ptp4lConf: |
-      [(?<iface_timeTx1_0>[[:alnum:]]+)]
-      masterOnly 1
-      [(?<iface_timeTx1_1>[[:alnum:]]+)]
-      masterOnly 1
-      [(?<iface_timeTx1_2>[[:alnum:]]+)]
-      masterOnly 1
-      [(?<iface_timeTx2_0>[[:alnum:]]+)]
-      masterOnly 1
-      [(?<iface_timeTx2_1>[[:alnum:]]+)]
-      masterOnly 1
-      [(?<iface_timeTx2_2>[[:alnum:]]+)]
-      masterOnly 1
-      [(?<iface_timeTx2_3>[[:alnum:]]+)]
-      masterOnly 1
-      [(?<iface_timeTx3_0>[[:alnum:]]+)]
-      masterOnly 1
-      [(?<iface_timeTx3_1>[[:alnum:]]+)]
-      masterOnly 1
-      [(?<iface_timeTx3_2>[[:alnum:]]+)]
-      masterOnly 1
-      [(?<iface_timeTx3_3>[[:alnum:]]+)]
-      masterOnly 1
+      (?<masterPorts>((\[[[:alnum:]]+\]
+      masterOnly 1| *#.*| *)(\n|$))+)
       [global]
       #
       # Default Data Set

--- a/telco-ran/configuration/source-crs/ptp-operator/configuration/PtpConfigBoundary.yaml
+++ b/telco-ran/configuration/source-crs/ptp-operator/configuration/PtpConfigBoundary.yaml
@@ -16,14 +16,16 @@ spec:
       logReduce: "true"
     ptp4lConf: |
       # The interface name is hardware-specific
-      [(?<iface_timeRx>[[:alnum:]]+)]
+      [ens1f0]
       masterOnly 0
-      [(?<iface_timeTx_1>[[:alnum:]]+)]
+      # Include one section for each TimeTransmitter port:
+      [ens1f1]
       masterOnly 1
-      [(?<iface_timeTx_2>[[:alnum:]]+)]
+      [ens1f2]
       masterOnly 1
-      [(?<iface_timeTx_3>[[:alnum:]]+)]
+      [ens1f3]
       masterOnly 1
+      # ...
       [global]
       #
       # Default Data Set

--- a/telco-ran/configuration/source-crs/ptp-operator/configuration/PtpConfigBoundary.yaml
+++ b/telco-ran/configuration/source-crs/ptp-operator/configuration/PtpConfigBoundary.yaml
@@ -16,7 +16,7 @@ spec:
       logReduce: "true"
     ptp4lConf: |
       # The interface name is hardware-specific
-      [ens1f0]
+      [$iface_timeRx]
       masterOnly 0
       # Include one section for each TimeTransmitter port:
       [ens1f1]

--- a/telco-ran/configuration/source-crs/ptp-operator/configuration/PtpConfigBoundaryForEvent.yaml
+++ b/telco-ran/configuration/source-crs/ptp-operator/configuration/PtpConfigBoundaryForEvent.yaml
@@ -16,14 +16,16 @@ spec:
       logReduce: "true"
     ptp4lConf: |
       # The interface name is hardware-specific
-      [(?<iface_timeRx>[[:alnum:]]+)]
+      [ens1f0]
       masterOnly 0
-      [(?<iface_timeTx_1>[[:alnum:]]+)]
+      # Include one section for each TimeTransmitter port:
+      [ens1f1]
       masterOnly 1
-      [(?<iface_timeTx_2>[[:alnum:]]+)]
+      [ens1f2]
       masterOnly 1
-      [(?<iface_timeTx_3>[[:alnum:]]+)]
+      [ens1f3]
       masterOnly 1
+      # ...
       [global]
       #
       # Default Data Set

--- a/telco-ran/configuration/source-crs/ptp-operator/configuration/PtpConfigBoundaryForEvent.yaml
+++ b/telco-ran/configuration/source-crs/ptp-operator/configuration/PtpConfigBoundaryForEvent.yaml
@@ -16,7 +16,7 @@ spec:
       logReduce: "true"
     ptp4lConf: |
       # The interface name is hardware-specific
-      [ens1f0]
+      [$iface_timeRx]
       masterOnly 0
       # Include one section for each TimeTransmitter port:
       [ens1f1]

--- a/telco-ran/configuration/source-crs/ptp-operator/configuration/PtpConfigDualCardGmWpc.yaml
+++ b/telco-ran/configuration/source-crs/ptp-operator/configuration/PtpConfigDualCardGmWpc.yaml
@@ -124,22 +124,16 @@ spec:
       #this is a measured value in nanoseconds to compensate for SMA cable delay
       ts2phc.extts_correction -10
     ptp4lConf: |
-      [(?<iface_timeTx1>[[:alnum:]]+)]
+      # Include one section for each TimeTransmitter port on the WPC cards:
+      [ens1f0]
       masterOnly 1
-      [(?<iface_timeTx1_1>[[:alnum:]]+)]
+      [ens1f1]
       masterOnly 1
-      [(?<iface_timeTx1_2>[[:alnum:]]+)]
+      [ens2f0]
       masterOnly 1
-      [(?<iface_timeTx1_3>[[:alnum:]]+)]
+      [ens2f1]
       masterOnly 1
-      [(?<iface_timeTx2>[[:alnum:]]+)]
-      masterOnly 1
-      [(?<iface_timeTx2_1>[[:alnum:]]+)]
-      masterOnly 1
-      [(?<iface_timeTx2_2>[[:alnum:]]+)]
-      masterOnly 1
-      [(?<iface_timeTx2_3>[[:alnum:]]+)]
-      masterOnly 1
+      # ...
       [global]
       #
       # Default Data Set

--- a/telco-ran/configuration/source-crs/ptp-operator/configuration/PtpConfigDualCardTBCWpc.yaml
+++ b/telco-ran/configuration/source-crs/ptp-operator/configuration/PtpConfigDualCardTBCWpc.yaml
@@ -183,20 +183,22 @@ spec:
     ts2phcOpts: -s generic -a --ts2phc.rh_external_pps 1
   - name: tbc-dual-card-tt
     ptp4lConf: |
-      [$iface_timeTx1_0]
+      # Include one section for each TimeTransmitter port on the WPC cards:
+      [ens1f0]
       masterOnly 1
-      [$iface_timeTx1_1]
+      [ens1f1]
       masterOnly 1
-      [$iface_timeTx1_2]
+      [ens1f2]
       masterOnly 1
-      [$iface_timeTx2_0]
+      [ens2f0]
       masterOnly 1
-      [$iface_timeTx2_1]
+      [ens2f1]
       masterOnly 1
-      [$iface_timeTx2_2]
+      [ens2f2]
       masterOnly 1
-      [$iface_timeTx2_3]
+      [ens2f3]
       masterOnly 1
+      # ...
       [global]
       #
       # Default Data Set

--- a/telco-ran/configuration/source-crs/ptp-operator/configuration/PtpConfigGmWpc.yaml
+++ b/telco-ran/configuration/source-crs/ptp-operator/configuration/PtpConfigGmWpc.yaml
@@ -112,14 +112,16 @@ spec:
       ts2phc.extts_polarity rising
       ts2phc.extts_correction 0
     ptp4lConf: |
-      [(?<iface_timeTx>[[:alnum:]]+)]
+      # Include one section for each TimeTransmitter port on the WPC card:
+      [ens1f0]
       masterOnly 1
-      [(?<iface_timeTx_1>[[:alnum:]]+)]
+      [ens1f1]
       masterOnly 1
-      [(?<iface_timeTx_2>[[:alnum:]]+)]
+      [ens1f2]
       masterOnly 1
-      [(?<iface_timeTx_3>[[:alnum:]]+)]
+      [ens1f3]
       masterOnly 1
+      # ...
       [global]
       #
       # Default Data Set

--- a/telco-ran/configuration/source-crs/ptp-operator/configuration/PtpConfigTBCWpc.yaml
+++ b/telco-ran/configuration/source-crs/ptp-operator/configuration/PtpConfigTBCWpc.yaml
@@ -168,12 +168,14 @@ spec:
     ts2phcOpts: -s generic -a --ts2phc.rh_external_pps 1
   - name: tbc-tt
     ptp4lConf: |
-      [$iface_timeTx_0]
+      # Include one section for each TimeTransmitter port on the WPC card:
+      [ens1f0]
       masterOnly 1
-      [$iface_timeTx_1]
+      [ens1f1]
       masterOnly 1
-      [$iface_timeTx_2]
+      [ens1f2]
       masterOnly 1
+      # ...
       [global]
       #
       # Default Data Set

--- a/telco-ran/configuration/source-crs/ptp-operator/configuration/PtpConfigThreeCardGmWpc.yaml
+++ b/telco-ran/configuration/source-crs/ptp-operator/configuration/PtpConfigThreeCardGmWpc.yaml
@@ -133,30 +133,32 @@ spec:
       #this is a measured value in nanoseconds to compensate for SMA cable delay
       ts2phc.extts_correction -10
     ptp4lConf: |
-      [$iface_timeTx1]
+      # Include one section for each TimeTransmitter port on the WPC cards:
+      [ens1f0]
       masterOnly 1
-      [$iface_timeTx1_1]
+      [ens1f1]
       masterOnly 1
-      [$iface_timeTx1_2]
+      [ens1f2]
       masterOnly 1
-      [$iface_timeTx1_3]
+      [ens1f3]
       masterOnly 1
-      [$iface_timeTx2]
+      [ens2f0]
       masterOnly 1
-      [$iface_timeTx2_1]
+      [ens2f1]
       masterOnly 1
-      [$iface_timeTx2_2]
+      [ens2f2]
       masterOnly 1
-      [$iface_timeTx2_3]
+      [ens2f3]
       masterOnly 1
-      [$iface_timeTx3]
+      [ens3f0]
       masterOnly 1
-      [$iface_timeTx3_1]
+      [ens3f1]
       masterOnly 1
-      [$iface_timeTx3_2]
+      [ens3f2]
       masterOnly 1
-      [$iface_timeTx3_3]
+      [ens3f3]
       masterOnly 1
+      # ...
       [global]
       #
       # Default Data Set

--- a/telco-ran/configuration/source-crs/ptp-operator/configuration/PtpConfigThreeCardTBCWpc.yaml
+++ b/telco-ran/configuration/source-crs/ptp-operator/configuration/PtpConfigThreeCardTBCWpc.yaml
@@ -199,28 +199,30 @@ spec:
     ts2phcOpts: -s generic -a --ts2phc.rh_external_pps 1
   - name: tbc-3-card-tt
     ptp4lConf: |
-      [$iface_timeTx1_0]
+      # Include one section for each TimeTransmitter port on the WPC cards:
+      [ens1f0]
       masterOnly 1
-      [$iface_timeTx1_1]
+      [ens1f1]
       masterOnly 1
-      [$iface_timeTx1_2]
+      [ens1f2]
       masterOnly 1
-      [$iface_timeTx2_0]
+      [ens2f0]
       masterOnly 1
-      [$iface_timeTx2_1]
+      [ens2f1]
       masterOnly 1
-      [$iface_timeTx2_2]
+      [ens2f2]
       masterOnly 1
-      [$iface_timeTx2_3]
+      [ens2f3]
       masterOnly 1
-      [$iface_timeTx3_0]
+      [ens3f0]
       masterOnly 1
-      [$iface_timeTx3_1]
+      [ens3f1]
       masterOnly 1
-      [$iface_timeTx3_2]
+      [ens3f2]
       masterOnly 1
-      [$iface_timeTx3_3]
+      [ens3f3]
       masterOnly 1
+      # ...
       [global]
       #
       # Default Data Set


### PR DESCRIPTION
This PR updates the PtpConfigDualCardGmWpc reference CR to tolerate different ordering in ptp4lConf