### PR TITLE
OCPBUGS-81698: Exclude local-cluster from gitops

### DIFF
--- a/telco-hub/configuration/reference-crs-kube-compare/required/gitops/app-project.yaml
+++ b/telco-hub/configuration/reference-crs-kube-compare/required/gitops/app-project.yaml
@@ -6,6 +6,13 @@ metadata:
   namespace: openshift-gitops
 spec:
   destinations:
+    # Hub policies are copied by ACM to the local-cluster namespace. This causes
+    # ArgoCD/GitOps to see those policies and flag them for pruning due to argocd
+    # annotations which remain on the copies. Prevent this confusion by restricting
+    # GitOps from managing resources in the local-cluster namespace where the
+    # copies are being created.
+    - namespace: '!local-cluster'
+      server: '*'
     - namespace: '*'
       server: '*'
   sourceRepos:

--- a/telco-hub/configuration/reference-crs/required/gitops/app-project.yaml
+++ b/telco-hub/configuration/reference-crs/required/gitops/app-project.yaml
@@ -8,6 +8,13 @@ metadata:
   namespace: openshift-gitops
 spec:
   destinations:
+    # Hub policies are copied by ACM to the local-cluster namespace. This causes
+    # ArgoCD/GitOps to see those policies and flag them for pruning due to argocd
+    # annotations which remain on the copies. Prevent this confusion by restricting
+    # GitOps from managing resources in the local-cluster namespace where the
+    # copies are being created.
+    - namespace: '!local-cluster'
+      server: '*'
     - namespace: '*'
       server: '*'
   sourceRepos:


### PR DESCRIPTION
The hub reference does not explicitly add any resources to the local-cluster namespace, however policy propagation will copy any ACM Policies bound to the hub cluster to that namespace. These policy copies include the argocd annotations which identify the CRs as belonging to the application which triggers a degraded status and flag that argocd wants to prune them.

This fix removes the local-cluster namespace from monitoring by the ArgoCD AppProject to eliminate the confusion and avoid false pruning of the resources.