### PR TITLE
Fix: align Network egressIPConfig with default oc get output (CNF-22543

### DIFF
--- a/telco-core/configuration/reference-crs-kube-compare/required/networking/Network.yaml
+++ b/telco-core/configuration/reference-crs-kube-compare/required/networking/Network.yaml
@@ -7,18 +7,10 @@ spec:
     ovnKubernetesConfig:
       gatewayConfig:
         routingViaHost: true
-{{- $ovn := .spec.defaultNetwork.ovnKubernetesConfig }}
-{{- if $ovn }}
-{{- if $ovn.egressIPConfig }}
-{{- if hasKey $ovn.egressIPConfig "reachabilityTotalTimeoutSeconds" }}
+{{- $eip := .spec.defaultNetwork.ovnKubernetesConfig.egressIPConfig }}
+{{- if and $eip $eip.reachabilityTotalTimeoutSeconds }}
       egressIPConfig:
-        reachabilityTotalTimeoutSeconds: {{ index $ovn.egressIPConfig "reachabilityTotalTimeoutSeconds" }}
-{{- else }}
-      egressIPConfig: {}
-{{- end }}
-{{- else }}
-      egressIPConfig: {}
-{{- end }}
+        reachabilityTotalTimeoutSeconds: 1
 {{- else }}
       egressIPConfig: {}
 {{- end }}

--- a/telco-core/configuration/reference-crs-kube-compare/required/networking/Network.yaml
+++ b/telco-core/configuration/reference-crs-kube-compare/required/networking/Network.yaml
@@ -7,8 +7,7 @@ spec:
     ovnKubernetesConfig:
       gatewayConfig:
         routingViaHost: true
-      egressIPConfig:
-        reachabilityTotalTimeoutSeconds: ^(1|)$
+      egressIPConfig: {}
   {{ if hasKey .spec "useMultiNetworkPolicy" }}
   useMultiNetworkPolicy: {{ .spec.useMultiNetworkPolicy }}
   {{ end }}

--- a/telco-core/configuration/reference-crs-kube-compare/required/networking/Network.yaml
+++ b/telco-core/configuration/reference-crs-kube-compare/required/networking/Network.yaml
@@ -8,7 +8,7 @@ spec:
       gatewayConfig:
         routingViaHost: true
       egressIPConfig:
-        reachabilityTotalTimeoutSeconds: 1
+        reachabilityTotalTimeoutSeconds: ^(1|)$
   {{ if hasKey .spec "useMultiNetworkPolicy" }}
   useMultiNetworkPolicy: {{ .spec.useMultiNetworkPolicy }}
   {{ end }}

--- a/telco-core/configuration/reference-crs-kube-compare/required/networking/Network.yaml
+++ b/telco-core/configuration/reference-crs-kube-compare/required/networking/Network.yaml
@@ -7,7 +7,21 @@ spec:
     ovnKubernetesConfig:
       gatewayConfig:
         routingViaHost: true
+{{- $ovn := .spec.defaultNetwork.ovnKubernetesConfig }}
+{{- if $ovn }}
+{{- if $ovn.egressIPConfig }}
+{{- if hasKey $ovn.egressIPConfig "reachabilityTotalTimeoutSeconds" }}
+      egressIPConfig:
+        reachabilityTotalTimeoutSeconds: {{ index $ovn.egressIPConfig "reachabilityTotalTimeoutSeconds" }}
+{{- else }}
       egressIPConfig: {}
+{{- end }}
+{{- else }}
+      egressIPConfig: {}
+{{- end }}
+{{- else }}
+      egressIPConfig: {}
+{{- end }}
   {{ if hasKey .spec "useMultiNetworkPolicy" }}
   useMultiNetworkPolicy: {{ .spec.useMultiNetworkPolicy }}
   {{ end }}

--- a/telco-core/configuration/reference-crs/required/networking/Network.yaml
+++ b/telco-core/configuration/reference-crs/required/networking/Network.yaml
@@ -10,8 +10,9 @@ spec:
     ovnKubernetesConfig:
       gatewayConfig:
         routingViaHost: true
-      # Kube-compare allows {} or explicit reachabilityTotalTimeoutSeconds (default 1).
-      egressIPConfig: {}
+      # Kube-compare template matches either {} or explicit reachabilityTotalTimeoutSeconds: 1 (default).
+      egressIPConfig:
+        reachabilityTotalTimeoutSeconds: 1
   # additional networks are optional and may alternatively be specified using NetworkAttachmentDefinition CRs
   additionalNetworks: [ $additionalNetworks ]
   # eg

--- a/telco-core/configuration/reference-crs/required/networking/Network.yaml
+++ b/telco-core/configuration/reference-crs/required/networking/Network.yaml
@@ -10,6 +10,7 @@ spec:
     ovnKubernetesConfig:
       gatewayConfig:
         routingViaHost: true
+      # Kube-compare allows {} or explicit reachabilityTotalTimeoutSeconds (default 1).
       egressIPConfig: {}
   # additional networks are optional and may alternatively be specified using NetworkAttachmentDefinition CRs
   additionalNetworks: [ $additionalNetworks ]

--- a/telco-core/configuration/reference-crs/required/networking/Network.yaml
+++ b/telco-core/configuration/reference-crs/required/networking/Network.yaml
@@ -10,8 +10,7 @@ spec:
     ovnKubernetesConfig:
       gatewayConfig:
         routingViaHost: true
-      egressIPConfig:
-        reachabilityTotalTimeoutSeconds: ^(1|)$
+      egressIPConfig: {}
   # additional networks are optional and may alternatively be specified using NetworkAttachmentDefinition CRs
   additionalNetworks: [ $additionalNetworks ]
   # eg

--- a/telco-core/configuration/reference-crs/required/networking/Network.yaml
+++ b/telco-core/configuration/reference-crs/required/networking/Network.yaml
@@ -11,7 +11,7 @@ spec:
       gatewayConfig:
         routingViaHost: true
       egressIPConfig:
-        reachabilityTotalTimeoutSeconds: 1
+        reachabilityTotalTimeoutSeconds: ^(1|)$
   # additional networks are optional and may alternatively be specified using NetworkAttachmentDefinition CRs
   additionalNetworks: [ $additionalNetworks ]
   # eg


### PR DESCRIPTION
This updates the telco-core Network kube-compare template so egressIPConfig matches what clusters actually show: either an empty object or an explicit default reachabilityTotalTimeoutSeconds (1), which avoids false diffs in cluster-compare when only the serialization differs. The static reference CR keeps the default empty form, with a short comment that both shapes are valid for compare.