### PR TITLE
OCPBUGS-79535: telco-ran: update disableOLMprof compliancetype

### DIFF
--- a/telco-ran/configuration/argocd/example/acmpolicygenerator/acm-group-du-sno-ranGen.yaml
+++ b/telco-ran/configuration/argocd/example/acmpolicygenerator/acm-group-du-sno-ranGen.yaml
@@ -31,6 +31,7 @@ policies:
     ran.openshift.io/ztp-deploy-wave: "10"
   manifests:
     - path: source-crs/cluster-tuning/DisableOLMPprof.yaml
+      complianceType: mustnothave
     - path: source-crs/cluster-logging/ClusterLogForwarder.yaml
       patches:
       - spec:

--- a/telco-ran/configuration/argocd/example/acmpolicygenerator/hub-side-templating/acm-group-du-sno-ranGen-templated.yaml
+++ b/telco-ran/configuration/argocd/example/acmpolicygenerator/hub-side-templating/acm-group-du-sno-ranGen-templated.yaml
@@ -38,6 +38,7 @@ policies:
     ran.openshift.io/ztp-deploy-wave: "10"
   manifests:
     - path: source-crs/cluster-tuning/DisableOLMPprof.yaml
+      complianceType: mustnothave
     - path: source-crs/cluster-logging/ClusterLogForwarder.yaml
       patches:
       - spec:

--- a/telco-ran/configuration/argocd/example/policygentemplates/group-du-sno-ranGen.yaml
+++ b/telco-ran/configuration/argocd/example/policygentemplates/group-du-sno-ranGen.yaml
@@ -14,6 +14,7 @@ spec:
   sourceFiles:
     - fileName: cluster-tuning/DisableOLMPprof.yaml
       policyName: "config-policy"
+      complianceType: mustnothave
     # Set ClusterLogForwarder as example might be better to create another policyTemp-Group
     - fileName: cluster-logging/ClusterLogForwarder.yaml
       policyName: "config-policy"

--- a/telco-ran/configuration/argocd/example/policygentemplates/hub-side-templating/group-du-sno-ranGen-templated.yaml
+++ b/telco-ran/configuration/argocd/example/policygentemplates/hub-side-templating/group-du-sno-ranGen-templated.yaml
@@ -34,6 +34,7 @@ spec:
     ###
     - fileName: cluster-tuning/DisableOLMPprof.yaml # wave 10
       policyName: "gr-du-sno-cfg-pc-templated"
+      complianceType: mustnothave
     ###
     - fileName: ptp-operator/configuration/PtpConfigSlave.yaml
       policyName: "gr-du-sno-cfg-pc-templated"


### PR DESCRIPTION
Updates complianceType for DisableOLMProf policy to MustNotHave