### PR TITLE
[release-4.19] telco-hub: remove workload annotation from reference

### DIFF
--- a/telco-hub/configuration/reference-crs/optional/logging/clusterLogNS.yaml
+++ b/telco-hub/configuration/reference-crs/optional/logging/clusterLogNS.yaml
@@ -3,5 +3,3 @@ apiVersion: v1
 kind: Namespace
 metadata:
   name: openshift-logging
-  annotations:
-    workload.openshift.io/allowed: management

--- a/telco-hub/configuration/reference-crs/optional/odf-internal/odfNS.yaml
+++ b/telco-hub/configuration/reference-crs/optional/odf-internal/odfNS.yaml
@@ -5,6 +5,5 @@ metadata:
   name: openshift-storage
   annotations:
     argocd.argoproj.io/sync-wave: "-5"
-    workload.openshift.io/allowed: management
   labels:
     openshift.io/cluster-monitoring: "true"

--- a/telco-hub/configuration/reference-crs/required/registry/catalog-source.yaml
+++ b/telco-hub/configuration/reference-crs/required/registry/catalog-source.yaml
@@ -4,7 +4,6 @@ kind: CatalogSource
 metadata:
   annotations:
     argocd.argoproj.io/sync-wave: "-10"
-    target.workload.openshift.io/management: '{"effect": "PreferredDuringScheduling"}'
   name: redhat-operators-disconnected
   namespace: openshift-marketplace
 spec:

--- a/telco-hub/configuration/reference-crs/required/registry/idms-operator.yaml
+++ b/telco-hub/configuration/reference-crs/required/registry/idms-operator.yaml
@@ -8,7 +8,6 @@ kind: ImageDigestMirrorSet
 metadata:
   annotations:
     argocd.argoproj.io/sync-wave: "-10"
-    target.workload.openshift.io/management: '{"effect": "PreferredDuringScheduling"}'
   name: idms-operator-0
 spec:
   imageDigestMirrors:

--- a/telco-hub/configuration/reference-crs/required/registry/idms-release.yaml
+++ b/telco-hub/configuration/reference-crs/required/registry/idms-release.yaml
@@ -8,7 +8,6 @@ kind: ImageDigestMirrorSet
 metadata:
   annotations:
     argocd.argoproj.io/sync-wave: "-10"
-    target.workload.openshift.io/management: '{"effect": "PreferredDuringScheduling"}'
   name: idms-release-0
 spec:
   imageDigestMirrors:

--- a/telco-hub/configuration/reference-crs/required/registry/itms-generic.yaml
+++ b/telco-hub/configuration/reference-crs/required/registry/itms-generic.yaml
@@ -8,7 +8,6 @@ kind: ImageTagMirrorSet
 metadata:
   annotations:
     argocd.argoproj.io/sync-wave: "-10"
-    target.workload.openshift.io/management: '{"effect": "PreferredDuringScheduling"}'
   name: itms-generic-0
 spec:
   imageTagMirrors:

--- a/telco-hub/configuration/reference-crs/required/registry/itms-release.yaml
+++ b/telco-hub/configuration/reference-crs/required/registry/itms-release.yaml
@@ -8,7 +8,6 @@ kind: ImageTagMirrorSet
 metadata:
   annotations:
     argocd.argoproj.io/sync-wave: "-10"
-    target.workload.openshift.io/management: '{"effect": "PreferredDuringScheduling"}'
   name: itms-release-0
 spec:
   imageTagMirrors:


### PR DESCRIPTION
This PR removes workload annotations from the hub reference
manual backport of https://github.com/openshift-kni/telco-reference/pull/534 
This manual backport is needed because the 4.19 hub reference does not have a kube-compare-reference directory and this fix needed to be backported for just the reference CRs