### PR TITLE
telco-core: migrate PolicyGenerator placement to labelSelector

### DIFF
--- a/telco-core/configuration/core-baseline.yaml
+++ b/telco-core/configuration/core-baseline.yaml
@@ -7,9 +7,10 @@ policyDefaults:
   namespace: ztp-core-policies
   policySets: []
   placement:
-    clusterSelectors:
-      common: "core"
-      version: "4.22"
+    labelSelector:
+      matchLabels:
+        common: "core"
+        version: "4.22"
   remediationAction: "inform"
 policies:
   # Base cluster configuration

--- a/telco-core/configuration/core-finish.yaml
+++ b/telco-core/configuration/core-finish.yaml
@@ -7,9 +7,10 @@ policyDefaults:
   namespace: ztp-core-policies
   policySets: []
   placement:
-    clusterSelectors:
-      common: "core"
-      version: "4.22"
+    labelSelector:
+      matchLabels:
+        common: "core"
+        version: "4.22"
   remediationAction: "inform"
 policies:
   # unpause baseline configuration

--- a/telco-core/configuration/core-overlay.yaml
+++ b/telco-core/configuration/core-overlay.yaml
@@ -7,9 +7,10 @@ policyDefaults:
   namespace: ztp-core-policies
   policySets: []
   placement:
-    clusterSelectors:
-      common: "core"
-      version: "4.22"
+    labelSelector:
+      matchLabels:
+        common: "core"
+        version: "4.22"
   remediationAction: "inform"
 policies:
   # Baseline configuration with custom overlay content

--- a/telco-core/configuration/core-upgrade-finish.yaml
+++ b/telco-core/configuration/core-upgrade-finish.yaml
@@ -7,9 +7,10 @@ policyDefaults:
   namespace: ztp-core-policies
   policySets: []
   placement:
-    clusterSelectors:
-      common: "core"
-      upgrade-finish: ""
+    labelSelector:
+      matchLabels:
+        common: "core"
+        upgrade-finish: ""
   remediationAction: "inform"
 policies:
   - name: core-upgrade-workers-1

--- a/telco-core/configuration/core-upgrade-precache.yaml
+++ b/telco-core/configuration/core-upgrade-precache.yaml
@@ -7,12 +7,13 @@ policyDefaults:
   namespace: ztp-core-policies
   policySets: []
   placement:
-    clusterSelectors:
-      common: "core"
-      # Label clusters with upgrade-precache: "" to activate pre-caching.
-      # This is independent of the upgrade version labels since the PinnedImageSets
-      # contain images for all target releases in the EUS-to-EUS upgrade path.
-      upgrade-precache: ""
+    # Label clusters with upgrade-precache: "" to activate pre-caching.
+    # This is independent of the upgrade version labels since the PinnedImageSets
+    # contain images for all target releases in the EUS-to-EUS upgrade path.
+    labelSelector:
+      matchLabels:
+        common: "core"
+        upgrade-precache: ""
   remediationAction: "inform"
 policies:
   - name: core-upgrade-precache-controlplane-22

--- a/telco-core/configuration/core-upgrade.yaml
+++ b/telco-core/configuration/core-upgrade.yaml
@@ -7,9 +7,10 @@ policyDefaults:
   namespace: ztp-core-policies
   policySets: []
   placement:
-    clusterSelectors:
-      common: "core"
-      upgrade-version-4-22: ""
+    labelSelector:
+      matchLabels:
+        common: "core"
+        upgrade-version-4-22: ""
   remediationAction: "inform"
 policies:
   - name: core-upgrade-prep-22


### PR DESCRIPTION
Replace deprecated `clusterSelectors` with `labelSelector` in all core-* _PolicyGenerator_ files. This generates the current Placement API (`cluster.open-cluster-management.io/v1beta1`) instead of the deprecated PlacementRule API, aligning with RHACM 2.10+ best practices.

Updated: core-baseline, core-overlay, core-finish, core-upgrade, core-upgrade-finish, core-upgrade-precache