### PR TITLE
telco-core: remove conflicting wave annotation from ClusterLogOperatorStatus

### DIFF
--- a/telco-core/configuration/reference-crs/optional/logging/ClusterLogOperatorStatus.yaml
+++ b/telco-core/configuration/reference-crs/optional/logging/ClusterLogOperatorStatus.yaml
@@ -6,8 +6,6 @@ apiVersion: operators.coreos.com/v1
 kind: Operator
 metadata:
   name: cluster-logging.openshift-logging
-  annotations:
-    ran.openshift.io/ztp-deploy-wave: "2"
 status:
 #  components:
 #    refs:

--- a/telco-core/configuration/reference-crs/optional/other/ClusterVersion.yaml
+++ b/telco-core/configuration/reference-crs/optional/other/ClusterVersion.yaml
@@ -4,8 +4,6 @@ apiVersion: config.openshift.io/v1
 kind: ClusterVersion
 metadata:
   name: version
-  annotations:
-    ran.openshift.io/ztp-deploy-wave: "100"
 spec:
   channel: stable-4.22
   upstream: https://api.openshift.com/api/upgrades_info/v1/graph  # default upstream.


### PR DESCRIPTION
Remove wave annotations from ClusterLogOperatorStatus.yaml and ClusterVersion.yaml
to resolve conflicts with policy-level wave annotations in core-baseline.yaml.

For ClusterLogOperatorStatus.yaml, the file-level wave "2" conflicts with the
policy-level wave "5" annotation. For ClusterVersion.yaml, the file-level wave "100"
annotation is unnecessary as this resource is managed through upgrade workflows.

Policy-level annotations take precedence during ACM/ZTP deployment, making
file-level annotations misleading. This change aligns with the pattern used by
other logging operator files in the repository.

Co-Authored-By: Claude Sonnet 4.5 <noreply@anthropic.com>