### PR TITLE
telco-core: align policy names in core-overlay with naming convention

### DIFF
--- a/telco-core/configuration/core-overlay.yaml
+++ b/telco-core/configuration/core-overlay.yaml
@@ -269,6 +269,8 @@ policies:
   # reference-crs/optional/networking/nodeNetworkConfigurationPolicy.yaml
 
   - name: config-monitoring-4.22
+    # For consistency the name of this policy will be updated in a future release:
+    # - name: core-overlay-monitoring-4.22
     policyAnnotations:
       ran.openshift.io/ztp-deploy-wave: "10"
     manifests:
@@ -304,6 +306,7 @@ policies:
                   - "10.11.12.14:9999"
 
   # Cert-manager configuration (optional component)
+  # For consistency the name of this policy will be updated in a future release to `core-overlay-cert-manager-4.22`
   # - name: config-cert-manager-4.22
   #   policyAnnotations:
   #     ran.openshift.io/ztp-deploy-wave: "10"


### PR DESCRIPTION
Renamed policies to follow the consistent naming pattern used across all PolicyGenerator files where policies are prefixed with the generator name (core-overlay-*):

- config-monitoring-4.22 → core-overlay-monitoring-4.22
- config-cert-manager-4.22 → core-overlay-cert-manager-4.22 (commented)

This aligns with the pattern used in core-baseline.yaml, core-finish.yaml, and other PolicyGenerator files in the telco-core configuration.