### PR TITLE
OCPBUGS-82516: Update reduce monitoring footprint CR to use hub-side templating

### DIFF
--- a/telco-core/configuration/reference-crs/optional/other/monitoring-config-cm.yaml
+++ b/telco-core/configuration/reference-crs/optional/other/monitoring-config-cm.yaml
@@ -26,16 +26,16 @@ data:
       - apiVersion: v2
         bearerToken:
           key: token
-          name: {{ if (lookup "v1" "Namespace" "" "open-cluster-management-addon-observability") }}{{ $result := (regexFind "hub-cluster-id(.*)" ((fromSecret "open-cluster-management-addon-observability" "hub-info-secret" "hub-info.yaml") | base64dec)) | replace "hub-cluster-id: " "observability-alertmanager-accessor-" }}{{ (empty $result) | ternary "observability-alertmanager-accessor" $result }}{{ else }}observability-alertmanager-accessor{{ end }}
+          name: {{hub $hubID := index (lookup "cluster.open-cluster-management.io/v1" "ManagedCluster" "" .ManagedClusterName).metadata.annotations "acm-hub-cluster-id" hub}}{{hub if $hubID hub}}observability-alertmanager-accessor-{{hub $hubID hub}}{{hub else hub}}observability-alertmanager-accessor{{hub end hub}}
         scheme: https
-        staticConfigs: {{ if (lookup "v1" "Namespace" "" "open-cluster-management-addon-observability") }}{{hub $route := index (lookup "cluster.open-cluster-management.io/v1" "ManagedCluster" "" .ManagedClusterName).metadata.annotations "acm-alertmanager-route" hub}}{{hub if $route hub}}[{{hub $route hub}}]{{hub else hub}}[]{{hub end hub}}{{ else }}[]{{ end }}
+        staticConfigs: {{hub $route := index (lookup "cluster.open-cluster-management.io/v1" "ManagedCluster" "" .ManagedClusterName).metadata.annotations "acm-alertmanager-route" hub}}{{hub if $route hub}}[{{hub $route hub}}]{{hub else hub}}[]{{hub end hub}}
         tlsConfig:
           ca:
             key: service-ca.crt
-            name: {{ if (lookup "v1" "Namespace" "" "open-cluster-management-addon-observability") }}{{ $result := (regexFind "hub-cluster-id(.*)" ((fromSecret "open-cluster-management-addon-observability" "hub-info-secret" "hub-info.yaml") | base64dec)) | replace "hub-cluster-id: " "hub-alertmanager-router-ca-" }}{{ (empty $result) | ternary "hub-alertmanager-router-ca" $result }}{{ else }}hub-alertmanager-router-ca{{ end }}
+            name: {{hub $hubID2 := index (lookup "cluster.open-cluster-management.io/v1" "ManagedCluster" "" .ManagedClusterName).metadata.annotations "acm-hub-cluster-id" hub}}{{hub if $hubID2 hub}}hub-alertmanager-router-ca-{{hub $hubID2 hub}}{{hub else hub}}hub-alertmanager-router-ca{{hub end hub}}
           insecureSkipVerify: false
       externalLabels:
-        managed_cluster: {{ fromClusterClaim "id.openshift.io" }}
+        managed_cluster: {{hub index (lookup "cluster.open-cluster-management.io/v1" "ManagedCluster" "" .ManagedClusterName).metadata.labels "clusterID" hub}}
       retention: 15d
       volumeClaimTemplate:
         spec:

--- a/telco-hub/configuration/reference-crs/required/acm/observabilityRoutePolicy.yaml
+++ b/telco-hub/configuration/reference-crs/required/acm/observabilityRoutePolicy.yaml
@@ -27,6 +27,9 @@ spec:
             include:
               - '*'
           object-templates-raw: |
+            {{- $localCluster := (lookup "cluster.open-cluster-management.io/v1" "ManagedCluster" "" "local-cluster") }}
+            {{- $clusterID := index $localCluster.metadata.labels "clusterID" }}
+            {{- $hubID := $clusterID | replace "-" "" | trunc 19 }}
             {{- range (lookup "cluster.open-cluster-management.io/v1" "ManagedCluster" "" "").items }}
             - metadataComplianceType: musthave
               objectDefinition:
@@ -36,6 +39,7 @@ spec:
                   name: {{ .metadata.name }}
                   annotations:
                     acm-alertmanager-route: '{{ (lookup "route.openshift.io/v1" "Route" "open-cluster-management-observability" "alertmanager").spec.host }}'
+                    acm-hub-cluster-id: '{{ $hubID }}'
             {{- end }}
 ---
 apiVersion: cluster.open-cluster-management.io/v1beta1

--- a/telco-ran/configuration/kube-compare-reference/hack/default_value.yaml
+++ b/telco-ran/configuration/kube-compare-reference/hack/default_value.yaml
@@ -738,10 +738,10 @@ cluster_tuning_monitoring_configuration_ReduceMonitoringFootprint:
   - metadata:
       name: cluster-monitoring-config
     captureGroup_defaults:
-      alertmanager_endpoint: '{{ `{{ if (lookup "v1" "Namespace" "" "open-cluster-management-addon-observability") }}{{hub $route := index (lookup "cluster.open-cluster-management.io/v1" "ManagedCluster" "" .ManagedClusterName).metadata.annotations "acm-alertmanager-route" hub}}{{hub if $route hub}}[{{hub $route hub}}]{{hub else hub}}[]{{hub end hub}}{{ else }}[]{{ end }}` }}'
-      managed_cluster: '{{ `{{ fromClusterClaim "id.openshift.io" }}` }}'
-      observability_alertmanager_accessor: '{{ `{{ if (lookup "v1" "Namespace" "" "open-cluster-management-addon-observability") }}{{ $result := (regexFind "hub-cluster-id(.*)" ((fromSecret "open-cluster-management-addon-observability" "hub-info-secret" "hub-info.yaml") | base64dec)) | replace "hub-cluster-id: " "observability-alertmanager-accessor-" }}{{ (empty $result) | ternary "observability-alertmanager-accessor" $result }}{{ else }}observability-alertmanager-accessor{{ end }}` }}'
-      hub_alertmanager_router_ca: '{{ `{{ if (lookup "v1" "Namespace" "" "open-cluster-management-addon-observability") }}{{ $result := (regexFind "hub-cluster-id(.*)" ((fromSecret "open-cluster-management-addon-observability" "hub-info-secret" "hub-info.yaml") | base64dec)) | replace "hub-cluster-id: " "hub-alertmanager-router-ca-" }}{{ (empty $result) | ternary "hub-alertmanager-router-ca" $result }}{{ else }}hub-alertmanager-router-ca{{ end }}` }}'
+      alertmanager_endpoint: '{{ `{{hub $route := index (lookup "cluster.open-cluster-management.io/v1" "ManagedCluster" "" .ManagedClusterName).metadata.annotations "acm-alertmanager-route" hub}}{{hub if $route hub}}[{{hub $route hub}}]{{hub else hub}}[]{{hub end hub}}` }}'
+      managed_cluster: '{{ `{{hub index (lookup "cluster.open-cluster-management.io/v1" "ManagedCluster" "" .ManagedClusterName).metadata.labels "clusterID" hub}}` }}'
+      observability_alertmanager_accessor: '{{ `{{hub $hubID := index (lookup "cluster.open-cluster-management.io/v1" "ManagedCluster" "" .ManagedClusterName).metadata.annotations "acm-hub-cluster-id" hub}}{{hub if $hubID hub}}observability-alertmanager-accessor-{{hub $hubID hub}}{{hub else hub}}observability-alertmanager-accessor{{hub end hub}}` }}'
+      hub_alertmanager_router_ca: '{{ `{{hub $hubID2 := index (lookup "cluster.open-cluster-management.io/v1" "ManagedCluster" "" .ManagedClusterName).metadata.annotations "acm-hub-cluster-id" hub}}{{hub if $hubID2 hub}}hub-alertmanager-router-ca-{{hub $hubID2 hub}}{{hub else hub}}hub-alertmanager-router-ca{{hub end hub}}` }}'
 lca_LcaSubscription:
   - spec:
       source: redhat-operators-disconnected

--- a/telco-ran/configuration/source-crs/cluster-tuning/monitoring-configuration/ReduceMonitoringFootprint.yaml
+++ b/telco-ran/configuration/source-crs/cluster-tuning/monitoring-configuration/ReduceMonitoringFootprint.yaml
@@ -30,14 +30,14 @@ data:
       - apiVersion: v2
         bearerToken:
           key: token
-          name: {{ if (lookup "v1" "Namespace" "" "open-cluster-management-addon-observability") }}{{ $result := (regexFind "hub-cluster-id(.*)" ((fromSecret "open-cluster-management-addon-observability" "hub-info-secret" "hub-info.yaml") | base64dec)) | replace "hub-cluster-id: " "observability-alertmanager-accessor-" }}{{ (empty $result) | ternary "observability-alertmanager-accessor" $result }}{{ else }}observability-alertmanager-accessor{{ end }}
+          name: {{hub $hubID := index (lookup "cluster.open-cluster-management.io/v1" "ManagedCluster" "" .ManagedClusterName).metadata.annotations "acm-hub-cluster-id" hub}}{{hub if $hubID hub}}observability-alertmanager-accessor-{{hub $hubID hub}}{{hub else hub}}observability-alertmanager-accessor{{hub end hub}}
         scheme: https
-        staticConfigs: {{ if (lookup "v1" "Namespace" "" "open-cluster-management-addon-observability") }}{{hub $route := index (lookup "cluster.open-cluster-management.io/v1" "ManagedCluster" "" .ManagedClusterName).metadata.annotations "acm-alertmanager-route" hub}}{{hub if $route hub}}[{{hub $route hub}}]{{hub else hub}}[]{{hub end hub}}{{ else }}[]{{ end }}
+        staticConfigs: {{hub $route := index (lookup "cluster.open-cluster-management.io/v1" "ManagedCluster" "" .ManagedClusterName).metadata.annotations "acm-alertmanager-route" hub}}{{hub if $route hub}}[{{hub $route hub}}]{{hub else hub}}[]{{hub end hub}}
         tlsConfig:
           ca:
             key: service-ca.crt
-            name: {{ if (lookup "v1" "Namespace" "" "open-cluster-management-addon-observability") }}{{ $result := (regexFind "hub-cluster-id(.*)" ((fromSecret "open-cluster-management-addon-observability" "hub-info-secret" "hub-info.yaml") | base64dec)) | replace "hub-cluster-id: " "hub-alertmanager-router-ca-" }}{{ (empty $result) | ternary "hub-alertmanager-router-ca" $result }}{{ else }}hub-alertmanager-router-ca{{ end }}
+            name: {{hub $hubID2 := index (lookup "cluster.open-cluster-management.io/v1" "ManagedCluster" "" .ManagedClusterName).metadata.annotations "acm-hub-cluster-id" hub}}{{hub if $hubID2 hub}}hub-alertmanager-router-ca-{{hub $hubID2 hub}}{{hub else hub}}hub-alertmanager-router-ca{{hub end hub}}
           insecureSkipVerify: false
       externalLabels:
-        managed_cluster: {{ fromClusterClaim "id.openshift.io" }}
+        managed_cluster: {{hub index (lookup "cluster.open-cluster-management.io/v1" "ManagedCluster" "" .ManagedClusterName).metadata.labels "clusterID" hub}}
       retention: 24h


### PR DESCRIPTION
Replace spoke-side templates for retrieving hub-info-secret with hub-side templating that reads the hub cluster ID from ManagedCluster annotations. 
The observabilityRoutePolicy now computes the hub ID from local-cluster's clusterID label and propagates it as an acm-hub-cluster-id annotation on all ManagedClusters.
/cherry-pick release-4.21 release-4.20


Policy on the spoke (with hub-templates resolved)

```
-> % oc get policy -n cnfdf17 ztp-common.common-latest-config-policy -oyaml
...
        object-templates:
        - complianceType: musthave
          objectDefinition:
            apiVersion: v1
            data:
              config.yaml: |
                alertmanagerMain:
                  enabled: false
                telemeterClient:
                  enabled: false
                nodeExporter:
                  collectors:
                    buddyinfo: {}
                    cpufreq: {}
                    ksmd: {}
                    mountstats: {}
                    netclass: {}
                    netdev: {}
                    processes: {}
                    systemd: {}
                    tcpstat: {}
                prometheusK8s:
                  additionalAlertmanagerConfigs:
                  - apiVersion: v2
                    bearerToken:
                      key: token
                      name: 'observability-alertmanager-accessor-bb2c3007706f48e99bb'
                    scheme: https
                    staticConfigs: [alertmanager-open-cluster-management-observability.apps.vcl02-hv13.telco5gran.eng.rdu2.redhat.com]
                    tlsConfig:
                      ca:
                        key: service-ca.crt
                        name: 'hub-alertmanager-router-ca-bb2c3007706f48e99bb'
                      insecureSkipVerify: false
                  externalLabels:
                    managed_cluster: 'f7640ae0-d812-471d-980c-c59c33e44327'
                  retention: 24h
            kind: ConfigMap
            metadata:
              annotations:
                ran.openshift.io/ztp-deploy-wave: "1"
              name: cluster-monitoring-config
              namespace: openshift-monitoring

```



Config Map
```
-> % oc get cm -n openshift-monitoring cluster-monitoring-config -oyaml
apiVersion: v1
data:
  config.yaml: |
    alertmanagerMain:
      enabled: false
    telemeterClient:
      enabled: false
    nodeExporter:
      collectors:
        buddyinfo: {}
        cpufreq: {}
        ksmd: {}
        mountstats: {}
        netclass: {}
        netdev: {}
        processes: {}
        systemd: {}
        tcpstat: {}
    prometheusK8s:
      additionalAlertmanagerConfigs:
      - apiVersion: v2
        bearerToken:
          key: token
          name: 'observability-alertmanager-accessor-bb2c3007706f48e99bb'
        scheme: https
        staticConfigs: [alertmanager-open-cluster-management-observability.apps.vcl02-hv13.telco5gran.eng.rdu2.redhat.com]
        tlsConfig:
          ca:
            key: service-ca.crt
            name: 'hub-alertmanager-router-ca-bb2c3007706f48e99bb'
          insecureSkipVerify: false
      externalLabels:
        managed_cluster: 'f7640ae0-d812-471d-980c-c59c33e44327'
      retention: 24h
kind: ConfigMap
metadata:
  annotations:
    ran.openshift.io/ztp-deploy-wave: "1"
  creationTimestamp: "2026-04-10T03:43:22Z"
  name: cluster-monitoring-config
  namespace: openshift-monitoring
  resourceVersion: "1480995"
  uid: 82e91432-ab4c-4d35-af1e-0bc466423970
  ```