### PR TITLE
OCPBUGS-84293: Add evaluationInterval to core-finish MCP policies

### DIFF
--- a/telco-core/configuration/core-finish.yaml
+++ b/telco-core/configuration/core-finish.yaml
@@ -17,6 +17,25 @@ policies:
   - name: custom-mcp-unpause-22
     policyAnnotations:
       ran.openshift.io/ztp-deploy-wave: "200"
+    placement:
+      labelSelector:
+        matchExpressions:
+          - key: common
+            operator: In
+            values:
+              - "core"
+          - key: version
+            operator: In
+            values:
+              - "4.22"
+          - key: ztp-done
+            operator: DoesNotExist
+    # The policy unpauses MCPs that were paused during initial creation
+    # and sets 'maxUnavailable' parameter to 100% to speed up the deployment.
+    # This is only required once as part of the deployment optimization
+    # therefore it's not required to re-evaluate it after initial deployment.
+    evaluationInterval:
+      compliant: never
     manifests:
       # The MCPs should be added as extra manifests at installation time. Their
       # inclusion here will reset the pause to false, allowing the MCPs to update


### PR DESCRIPTION
Add evaluationInterval with `'compliant: never'` to MCP unpause policies in core-finish.yaml. These policies manage temporal MCP orchestration during ZTP deployment (pause for config staging, unpause for application, reset maxUnavailable).

Also those policies are mutually exclusive as `custom-mcp-unpause-22` sets _maxUnavailable: 100%_ while `core-custom-mcp-set-maxavailable-22` set it to _maxUnavailable: 1_

After initial compliance during wave execution, continuous re-evaluation is unnecessary and adds API server load. The one-time evaluation aligns with ZTP handoff semantics - policies apply configuration during deployment, then ownership transfers to cluster administrators.

Reduces continuous polling overhead while preserving ZTP functionality.