### PR TITLE
Move core-operator-config-4.22 to wave 6

### DIFF
--- a/telco-core/configuration/core-baseline.yaml
+++ b/telco-core/configuration/core-baseline.yaml
@@ -86,7 +86,7 @@ policies:
   # Operator configuration
   - name: core-operator-config-4.22
     policyAnnotations:
-      ran.openshift.io/ztp-deploy-wave: "7"
+      ran.openshift.io/ztp-deploy-wave: "6"
     manifests:
       - path: reference-crs/optional/logging/ClusterLogServiceAccount.yaml
       - path: reference-crs/optional/logging/ClusterLogServiceAccountAuditBinding.yaml


### PR DESCRIPTION
Change core-operator-config-4.22 wave from 7 to 6 to ensure NMState CRD registration completes before site-specific NodeNetworkConfigurationPolicy (NNCP) resources are applied in wave 7.

Problem:
When core-operator-config-4.22 runs at wave 7 alongside site-specific NNCP policies, a race condition can occur. The NMState CR triggers CRD installation by the NMState operator, but NNCP resources may attempt to create before the CRD registration completes, causing policy failures with "CRD not found" errors.

Wave 7 timeline with race condition:
  core-operator-config-4.22 (NMState CR) + site NNCP policies (simultaneous)
  → NMState operator reconciles NMState CR
  → NMState CRD installation begins
  → NNCP policies attempt creation (CRD may not exist yet)
  → Intermittent failures on fast systems

Solution:
Moving operator configuration to wave 6 creates a hard dependency boundary. TALM waits for wave 6 compliance before starting wave 7, guaranteeing CRD availability for all NNCP policies and enabling proper dependency chains for storage and monitoring configuration.

Dependency chain enabled by wave 6 placement:
  Wave 6: Operator initialization (NMState CR → CRDs installed)
  Wave 7: Site-specific VLANs (storage VLAN for ODF backend connectivity)
  Wave 8: ODF configuration (requires storage VLAN from wave 7)
  Wave 10: Monitoring (requires ODF StorageClasses from wave 8)

Benefits:
- Eliminates NMState CRD race condition for VLAN configurations
- Enables storage VLAN dependency for ODF backend network isolation
- Supports monitoring dependency on ODF-provided StorageClasses
- Improves deployment reliability and determinism
- Maintains clean wave boundaries for operator → network → storage → monitoring
- No impact on deployments without wave 7 NNCP policies
- Follows operator lifecycle pattern: install (wave 5) → configure (wave 6)

This change affects all operator initialization in core-operator-config-4.22:
- Logging ServiceAccount and RBAC bindings
- SriovOperatorConfig
- NMState CR (CRD registration trigger)
- NROP scheduler configuration