### PR TITLE
OCPBUGS-81498: telco-hub: add ignore for oc-mirror annotations

### DIFF
--- a/telco-hub/configuration/reference-crs-kube-compare/metadata.yaml
+++ b/telco-hub/configuration/reference-crs-kube-compare/metadata.yaml
@@ -183,6 +183,9 @@ fieldsToOmit:
         isPrefix: true
       - pathToKey: metadata.annotations."installer.open-cluster-management.io"
         isPrefix: true
+      - pathToKey: metadata.annotations.createdAt
+      - pathToKey: metadata.annotations.createdBy
+      - pathToKey: metadata.annotations."oc-mirror_version"
       - pathToKey: metadata.annotations."security.openshift.io/MinimallySufficientPodSecurityStandard"
       - pathToKey: metadata.labels."kubernetes.io/metadata.name"
       - pathToKey: metadata.labels."security.openshift.io/scc.podSecurityLabelSync"


### PR DESCRIPTION
Adds ignore in hub kube-compare reference for oc-mirror annotations 