### PR TITLE
OCPBUGS-83541: telco-ran: add check for optional kubeletconfig annotation

### DIFF
--- a/telco-core/configuration/reference-crs-kube-compare/unordered_list.tmpl
+++ b/telco-core/configuration/reference-crs-kube-compare/unordered_list.tmpl
@@ -38,6 +38,8 @@
 {{- range $value := $expectedArgs }}
   {{- $result = append $result $value }}
 {{- end }}
+{{- if ne (index . 0) nil }}
     kubeletconfig.experimental: |
       {{ (dict "allowedUnsafeSysctls" $result) | toJson }}
+{{- end }}
 {{- end }}

--- a/telco-core/configuration/reference-crs-kube-compare/unordered_list.tmpl
+++ b/telco-core/configuration/reference-crs-kube-compare/unordered_list.tmpl
@@ -28,7 +28,6 @@
 {{ $values := list}}
 {{- if ne (index . 0) nil }}
 {{- $values = ((index . 0) | fromJson).allowedUnsafeSysctls }}
-{{- end}}
 {{- range $value := $values }}
   {{- if or (has $value $expectedArgs) (has $value $optionalArgs) }}
     {{- $result = append $result $value }}
@@ -38,7 +37,6 @@
 {{- range $value := $expectedArgs }}
   {{- $result = append $result $value }}
 {{- end }}
-{{- if ne (index . 0) nil }}
     kubeletconfig.experimental: |
       {{ (dict "allowedUnsafeSysctls" $result) | toJson }}
 {{- end }}

--- a/telco-ran/configuration/kube-compare-reference/functions/unordered_list.tmpl
+++ b/telco-ran/configuration/kube-compare-reference/functions/unordered_list.tmpl
@@ -63,6 +63,8 @@
 {{- range $value := $expectedArgs }}
   {{- $result = append $result $value }}
 {{- end }}
+{{- if ne (index . 0) nil }}
     kubeletconfig.experimental: |
       {{ (dict "allowedUnsafeSysctls" $result) | toJson }}
+{{- end }}
 {{- end }}

--- a/telco-ran/configuration/kube-compare-reference/functions/unordered_list.tmpl
+++ b/telco-ran/configuration/kube-compare-reference/functions/unordered_list.tmpl
@@ -53,7 +53,6 @@
 {{ $values := list}}
 {{- if ne (index . 0) nil }}
 {{- $values = ((index . 0) | fromJson).allowedUnsafeSysctls }}
-{{- end}}
 {{- range $value := $values }}
   {{- if or (has $value $expectedArgs) (has $value $optionalArgs) }}
     {{- $result = append $result $value }}
@@ -63,7 +62,6 @@
 {{- range $value := $expectedArgs }}
   {{- $result = append $result $value }}
 {{- end }}
-{{- if ne (index . 0) nil }}
     kubeletconfig.experimental: |
       {{ (dict "allowedUnsafeSysctls" $result) | toJson }}
 {{- end }}


### PR DESCRIPTION
This PR adds a check around the kubeletconfig.experimental template to not show diff if the annotation is absent