### PR TITLE
OCPBUGS-83763: telco-ran: enable ptp operator config for event in example

### DIFF
--- a/telco-ran/configuration/argocd/example/acmpolicygenerator/acm-group-du-sno-ranGen.yaml
+++ b/telco-ran/configuration/argocd/example/acmpolicygenerator/acm-group-du-sno-ranGen.yaml
@@ -62,6 +62,12 @@ policies:
 #      - spec:
 #          daemonNodeSelector:
 #            node-role.kubernetes.io/worker: ""
+    - path: source-crs/ptp-operator/PtpOperatorConfig-SetSelector.yaml
+      complianceType: "mustonlyhave"
+      patches:
+      - spec:
+          daemonNodeSelector:
+            node-role.kubernetes.io/master: ""
     - path: source-crs/ptp-operator/configuration/PtpConfigSlave.yaml
       patches:
         - metadata:


### PR DESCRIPTION
Un comment ptp operator config for event in ran manifests