### PR TITLE
CNF-21719: Add optional cert-manager reference CRs for telco-ran

### DIFF
--- a/telco-ran/configuration/reference-crs/optional/cert-manager/README.md
+++ b/telco-ran/configuration/reference-crs/optional/cert-manager/README.md
@@ -1,0 +1,70 @@
+# Cert-Manager Configuration
+
+This directory contains optional configurations for using cert-manager to manage TLS certificates in OpenShift.
+
+## Overview
+
+Cert-manager automates the management and issuance of TLS certificates from various issuing sources. This configuration demonstrates how to:
+- Install the cert-manager operator
+- Configure an ACME issuer using DNS-01 challenge
+- Generate and use custom certificates for API Server and Ingress endpoints
+
+## Files
+
+### Operator Installation
+- `certManagerNS.yaml` - Creates the cert-manager-operator namespace
+- `certManagerOperatorgroup.yaml` - Creates the OperatorGroup for cert-manager
+- `certManagerSubscription.yaml` - Installs the OpenShift cert-manager operator
+
+### Certificate Issuer
+- `certManagerClusterIssuer.yaml` - Configures an ACME ClusterIssuer using Let's Encrypt with DNS-01 challenge
+
+### Certificate Resources
+- `apiServerCertificate.yaml` - Creates a certificate for the API Server endpoint
+- `ingressCertificate.yaml` - Creates a wildcard certificate for the Ingress/Router
+
+### OpenShift Configuration
+- `apiServerConfig.yaml` - Configures OpenShift to use the cert-manager generated API Server certificate
+- `ingressControllerConfig.yaml` - Configures OpenShift to use the cert-manager generated Ingress certificate
+
+## Customization Required
+
+Before applying these configurations, you must customize the following:
+
+1. **ClusterIssuer** (`certManagerClusterIssuer.yaml`):
+   - Update `email` with your contact email
+   - Configure the appropriate DNS provider for DNS-01 challenge (example shows Route53)
+   - Reference pre-created Secrets for DNS provider credentials via `secretRef` — do not commit credentials in manifests
+
+2. **Certificates** (`apiServerCertificate.yaml` and `ingressCertificate.yaml`):
+   - Update `commonName` and `dnsNames` to match your cluster's domain
+   - Example: Replace `api.example.com` with your actual API endpoint
+   - Example: Replace `*.apps.example.com` with your actual wildcard domain
+
+3. **APIServer Configuration** (`apiServerConfig.yaml`):
+   - Update the `names` field to match your API Server FQDN
+
+## Deployment Order
+
+1. Deploy operator installation files (NS, OperatorGroup, Subscription)
+2. Approve the generated InstallPlan for the cert-manager Subscription
+3. Wait for operator to be ready
+4. Deploy the ClusterIssuer
+5. Deploy the Certificate resources
+6. Wait for certificates to be issued and secrets created
+7. Apply the APIServer and IngressController configurations
+
+## Certificate Verification
+
+After applying these configurations, verify that:
+- Certificates are issued: `oc get certificate -A`
+- Secrets are created: `oc get secret api-server-cert -n openshift-config` and `oc get secret ingress-wildcard-cert -n openshift-ingress`
+- API Server is using the certificate: Test HTTPS connection to API endpoint
+- Ingress is using the certificate: Test HTTPS connection to any route
+
+## References
+
+- [OpenShift Cert-Manager Operator Documentation](https://docs.openshift.com/container-platform/latest/security/cert_manager_operator/index.html)
+- [Cert-Manager Documentation](https://cert-manager.io/docs/)
+- [ACME DNS-01 Challenge Configuration](https://cert-manager.io/docs/configuration/acme/dns01/)
+

--- a/telco-ran/configuration/reference-crs/optional/cert-manager/apiServerCertificate.yaml
+++ b/telco-ran/configuration/reference-crs/optional/cert-manager/apiServerCertificate.yaml
@@ -1,0 +1,19 @@
+---
+apiVersion: cert-manager.io/v1
+kind: Certificate
+metadata:
+  name: api-server-certificate
+  namespace: openshift-config
+spec:
+  commonName: "api.example.com"
+  dnsNames:
+  - "api.example.com"
+  isCA: false
+  issuerRef:
+    group: cert-manager.io
+    kind: ClusterIssuer
+    name: acme-issuer
+  privateKey:
+    algorithm: ECDSA
+    size: 256
+  secretName: api-server-cert

--- a/telco-ran/configuration/reference-crs/optional/cert-manager/apiServerConfig.yaml
+++ b/telco-ran/configuration/reference-crs/optional/cert-manager/apiServerConfig.yaml
@@ -1,0 +1,12 @@
+---
+apiVersion: config.openshift.io/v1
+kind: APIServer
+metadata:
+  name: cluster
+spec:
+  servingCerts:
+    namedCertificates:
+    - names:
+      - "api.example.com"
+      servingCertificate:
+        name: api-server-cert

--- a/telco-ran/configuration/reference-crs/optional/cert-manager/certManagerClusterIssuer.yaml
+++ b/telco-ran/configuration/reference-crs/optional/cert-manager/certManagerClusterIssuer.yaml
@@ -1,0 +1,18 @@
+---
+apiVersion: cert-manager.io/v1
+kind: ClusterIssuer
+metadata:
+  name: acme-issuer
+spec:
+  # Example based on: https://cert-manager.io/docs/configuration/acme/#creating-a-basic-acme-issuer
+  acme:
+    server: https://acme-v02.api.letsencrypt.org/directory
+    email: your-email@example.com
+    privateKeySecretRef:
+      name: acme-account-key
+    solvers:
+    - dns01:
+        route53:
+          region: us-east-1
+          # Replace with your DNS provider configuration
+          # See: https://cert-manager.io/docs/configuration/acme/dns01/

--- a/telco-ran/configuration/reference-crs/optional/cert-manager/certManagerNS.yaml
+++ b/telco-ran/configuration/reference-crs/optional/cert-manager/certManagerNS.yaml
@@ -1,0 +1,5 @@
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: cert-manager-operator

--- a/telco-ran/configuration/reference-crs/optional/cert-manager/certManagerOperatorgroup.yaml
+++ b/telco-ran/configuration/reference-crs/optional/cert-manager/certManagerOperatorgroup.yaml
@@ -1,0 +1,11 @@
+---
+apiVersion: operators.coreos.com/v1
+kind: OperatorGroup
+metadata:
+  annotations:
+    olm.operatorframework.io/bundle-install-timeout: "10m"
+    operatorframework.io/bundle-unpack-min-retry-interval: 10m
+  name: cert-manager-operator
+  namespace: cert-manager-operator
+spec:
+  upgradeStrategy: Default

--- a/telco-ran/configuration/reference-crs/optional/cert-manager/certManagerSubscription.yaml
+++ b/telco-ran/configuration/reference-crs/optional/cert-manager/certManagerSubscription.yaml
@@ -1,0 +1,14 @@
+---
+apiVersion: operators.coreos.com/v1alpha1
+kind: Subscription
+metadata:
+  name: openshift-cert-manager-operator
+  namespace: cert-manager-operator
+spec:
+  channel: stable-v1
+  name: openshift-cert-manager-operator
+  source: redhat-operators-disconnected
+  sourceNamespace: openshift-marketplace
+  installPlanApproval: Manual
+status:
+  state: AtLatestKnown

--- a/telco-ran/configuration/reference-crs/optional/cert-manager/ingressCertificate.yaml
+++ b/telco-ran/configuration/reference-crs/optional/cert-manager/ingressCertificate.yaml
@@ -1,0 +1,19 @@
+---
+apiVersion: cert-manager.io/v1
+kind: Certificate
+metadata:
+  name: ingress-wildcard-certificate
+  namespace: openshift-ingress
+spec:
+  commonName: "*.apps.example.com"
+  dnsNames:
+  - "*.apps.example.com"
+  isCA: false
+  issuerRef:
+    group: cert-manager.io
+    kind: ClusterIssuer
+    name: acme-issuer
+  privateKey:
+    algorithm: ECDSA
+    size: 256
+  secretName: ingress-wildcard-cert

--- a/telco-ran/configuration/reference-crs/optional/cert-manager/ingressControllerConfig.yaml
+++ b/telco-ran/configuration/reference-crs/optional/cert-manager/ingressControllerConfig.yaml
@@ -1,0 +1,9 @@
+---
+apiVersion: operator.openshift.io/v1
+kind: IngressController
+metadata:
+  name: default
+  namespace: openshift-ingress-operator
+spec:
+  defaultCertificate:
+    name: ingress-wildcard-cert


### PR DESCRIPTION
## Summary

- Adds cert-manager YAML reference CRs under telco-ran/configuration/reference-crs/optional/cert-manager/
- Files match the telco-core cert-manager configuration (no ArgoCD annotations, no ACM policy CRs)
- Supports the corresponding RDS MR that documents cert-manager as an optional component for RAN deployments

Cert-manager was previously removed from telco-ran in #569 due to IBU incompatibility. This restores it as an explicitly **optional** component under reference-crs/optional/, consistent with the telco-hub and telco-core directory structure.

### Files added
- certManagerNS.yaml - Namespace
- certManagerOperatorgroup.yaml - OperatorGroup
- certManagerSubscription.yaml - Subscription (Manual install plan approval)
- certManagerClusterIssuer.yaml - ACME ClusterIssuer
- apiServerCertificate.yaml - API Server certificate
- ingressCertificate.yaml - Ingress wildcard certificate
- apiServerConfig.yaml - APIServer config to use cert-manager certificate
- ingressControllerConfig.yaml - IngressController config to use cert-manager certificate
- README.md - Documentation

## Test plan
- [ ] Verify all file paths match what the RDS links expect
- [ ] Confirm no ArgoCD sync-wave annotations are present
- [ ] Confirm ACM policy CRs are not included (those are hub-side resources)