### PR TITLE
[release-4.20] RAN: Add GNR-D PTP BoundaryClock-without-holdover configuration

### DIFF
--- a/telco-ran/configuration/kube-compare-reference/hack/default_value.yaml
+++ b/telco-ran/configuration/kube-compare-reference/hack/default_value.yaml
@@ -22,6 +22,101 @@ storage_StorageLV:
 storage_lso_StorageSubscription:
   - spec:
       source: redhat-operators-disconnected
+ptp_operator_configuration_PtpConfigGnrdBcNoHoldover:
+  - spec:
+      profile:
+        - name: "00-bc-tt"
+          ptpSettings:
+            logReduce: "true"
+        - name: "01-bc-tr"
+          ptpSettings:
+            logReduce: "true"
+          plugins:
+            e825:
+              devices:
+                - eno8703
+            e830:
+              devices:
+                - enp108s0f0
+                - enp110s0f0
+      recommend:
+        - profile: 00-bc-tt
+          priority: 4
+          match:
+            - nodeLabel: "node-role.kubernetes.io/$mcp"
+        - profile: 01-bc-tr
+          priority: 4
+          match:
+            - nodeLabel: "node-role.kubernetes.io/$mcp"
+    captureGroup_defaults:
+      leadingInterface: eno8703
+      upstreamInterface: $upstreamInterface
+      priority2: 128
+      domainNumber: 24
+      ts2phcPortConfig: |-
+        # This should be one section per Carter Flats (e830) card:
+                [enp108s0f0]
+                ts2phc.extts_polarity rising
+                ts2phc.extts_correction 0
+                ts2phc.master 0
+                ts2phc.channel 0
+                ts2phc.pin_index 1
+                [enp110s0f0]
+                ts2phc.extts_polarity rising
+                ts2phc.extts_correction 0
+                ts2phc.master 0
+                ts2phc.channel 0
+                ts2phc.pin_index 1
+      masterPorts: |-
+        # All TimeTransmitter ports should be outlined here with 'masterOnly 1'
+                #[eno8303]
+                # ** Host management interface
+                [eno8403]
+                masterOnly 1
+                #[eno8503]
+                # ** TR port (see 01-bc-tr profile)
+                [eno8603]
+                masterOnly 1
+                [eno8703]
+                masterOnly 1
+                [eno8803]
+                masterOnly 1
+                [eno8903]
+                masterOnly 1
+                [eno9003]
+                masterOnly 1
+                [enp108s0f0]
+                masterOnly 1
+                [enp108s0f1]
+                masterOnly 1
+                [enp108s0f2]
+                masterOnly 1
+                [enp108s0f3]
+                masterOnly 1
+                [enp108s0f4]
+                masterOnly 1
+                [enp108s0f5]
+                masterOnly 1
+                [enp108s0f6]
+                masterOnly 1
+                [enp108s0f7]
+                masterOnly 1
+                [enp110s0f0]
+                masterOnly 1
+                [enp110s0f1]
+                masterOnly 1
+                [enp110s0f2]
+                masterOnly 1
+                [enp110s0f3]
+                masterOnly 1
+                [enp110s0f4]
+                masterOnly 1
+                [enp110s0f5]
+                masterOnly 1
+                [enp110s0f6]
+                masterOnly 1
+                [enp110s0f7]
+                masterOnly 1
 ptp_operator_configuration_PtpConfigBoundary:
   - spec:
       profile:

--- a/telco-ran/configuration/kube-compare-reference/hack/default_value.yaml
+++ b/telco-ran/configuration/kube-compare-reference/hack/default_value.yaml
@@ -22,6 +22,92 @@ storage_StorageLV:
 storage_lso_StorageSubscription:
   - spec:
       source: redhat-operators-disconnected
+ptp_operator_configuration_PtpConfigGnrdTGM:
+  - spec:
+      profile:
+      - ptpSettings:
+          logReduce: "true"
+        plugins:
+          e825:
+            devices:
+              - eno8703
+          e830:
+            devices:
+              - enp108s0f0
+              - enp110s0f0
+      recommend:
+      - profile: grandmaster
+        priority: 4
+        match:
+          - nodeLabel: "node-role.kubernetes.io/$mcp"
+    captureGroup_defaults:
+      leadingInterface: eno8703
+      priority2: 128
+      domainNumber: 24
+      ts2phcPortConfig: |-
+        # This should be one section per Carter Flats (e830) card:
+                [enp108s0f0]
+                ts2phc.extts_polarity rising
+                ts2phc.extts_correction 0
+                ts2phc.master 0
+                ts2phc.channel 0
+                ts2phc.pin_index 1
+                [enp110s0f0]
+                ts2phc.extts_polarity rising
+                ts2phc.extts_correction 0
+                ts2phc.master 0
+                ts2phc.channel 0
+                ts2phc.pin_index 1
+      masterPorts: |-
+        # All TimeTransmitter ports should be outlined here with 'masterOnly 1'
+                #[eno8303]
+                # ** Host management interface
+                [eno8403]
+                masterOnly 1
+                [eno8503]
+                masterOnly 1
+                [eno8603]
+                masterOnly 1
+                [eno8703]
+                masterOnly 1
+                [eno8803]
+                masterOnly 1
+                [eno8903]
+                masterOnly 1
+                [eno9003]
+                masterOnly 1
+                [enp108s0f0]
+                masterOnly 1
+                [enp108s0f1]
+                masterOnly 1
+                [enp108s0f2]
+                masterOnly 1
+                [enp108s0f3]
+                masterOnly 1
+                [enp108s0f4]
+                masterOnly 1
+                [enp108s0f5]
+                masterOnly 1
+                [enp108s0f6]
+                masterOnly 1
+                [enp108s0f7]
+                masterOnly 1
+                [enp110s0f0]
+                masterOnly 1
+                [enp110s0f1]
+                masterOnly 1
+                [enp110s0f2]
+                masterOnly 1
+                [enp110s0f3]
+                masterOnly 1
+                [enp110s0f4]
+                masterOnly 1
+                [enp110s0f5]
+                masterOnly 1
+                [enp110s0f6]
+                masterOnly 1
+                [enp110s0f7]
+                masterOnly 1
 ptp_operator_configuration_PtpConfigGnrdBcNoHoldover:
   - spec:
       profile:

--- a/telco-ran/configuration/kube-compare-reference/metadata.yaml
+++ b/telco-ran/configuration/kube-compare-reference/metadata.yaml
@@ -230,6 +230,21 @@ parts:
       - name: ptp-config
         oneOf:
           # TODO: the INI files embedded in PtpConfig objects are not handled. CNF-13528
+          - path: ptp-operator/configuration/PtpConfigGnrdBcNoHoldover.yaml
+            config:
+              perField:
+                - pathToKey: spec.profile.0.ptp4lConf
+                  inlineDiffFunc: capturegroups
+                - pathToKey: spec.profile.1.ptp4lConf
+                  inlineDiffFunc: capturegroups
+                - pathToKey: spec.profile.1.phc2sysOpts
+                  inlineDiffFunc: capturegroups
+                - pathToKey: spec.profile.1.ptpSettings.leadingInterface
+                  inlineDiffFunc: capturegroups
+                - pathToKey: spec.profile.1.ptpSettings.upstreamPort
+                  inlineDiffFunc: capturegroups
+                - pathToKey: spec.profile.1.ts2phcConf
+                  inlineDiffFunc: capturegroups
           - path: ptp-operator/configuration/PtpConfigBoundary.yaml
             config:
               perField:

--- a/telco-ran/configuration/kube-compare-reference/metadata.yaml
+++ b/telco-ran/configuration/kube-compare-reference/metadata.yaml
@@ -230,6 +230,15 @@ parts:
       - name: ptp-config
         oneOf:
           # TODO: the INI files embedded in PtpConfig objects are not handled. CNF-13528
+          - path: ptp-operator/configuration/PtpConfigGnrdTGM.yaml
+            config:
+              perField:
+                - pathToKey: spec.profile.0.ptp4lConf
+                  inlineDiffFunc: capturegroups
+                - pathToKey: spec.profile.0.phc2sysOpts
+                  inlineDiffFunc: capturegroups
+                - pathToKey: spec.profile.0.ts2phcConf
+                  inlineDiffFunc: capturegroups
           - path: ptp-operator/configuration/PtpConfigGnrdBcNoHoldover.yaml
             config:
               perField:

--- a/telco-ran/configuration/kube-compare-reference/ptp-operator/configuration/PtpConfigGnrdBcNoHoldover.yaml
+++ b/telco-ran/configuration/kube-compare-reference/ptp-operator/configuration/PtpConfigGnrdBcNoHoldover.yaml
@@ -1,0 +1,304 @@
+# Note:  This example configuration should be customized to match the desired configuration
+# For this GNR-D boundary clock configuration, we support one Time Reciever port on the NAC,
+# and up to 23 Time Transmitter ports including any other NAC ports and any additional
+# Carter Flats ports.
+apiVersion: ptp.openshift.io/v1
+kind: PtpConfig
+metadata:
+  name: gnrd-bc
+  namespace: openshift-ptp
+  annotations:
+    ran.openshift.io/ztp-deploy-wave: "10"
+spec:
+  profile:
+  {{- range .spec.profile }}
+  {{- if eq .name "00-bc-tt" }}
+    - name: 00-bc-tt
+      ptp4lConf: |
+        (?<masterPorts>((\[[[:alnum:]]+\]
+        masterOnly 1| *#.*| *)(\n|$))+)
+        [global]
+        #
+        # Default Data Set
+        #
+        twoStepFlag 1
+        slaveOnly 0
+        priority1 128
+        priority2 (?<priority2>[0-9]+)
+        domainNumber (?<domainNumber>[0-9]+)
+        #utc_offset 37
+        clockClass 248
+        clockAccuracy 0xFE
+        offsetScaledLogVariance 0xFFFF
+        free_running 0
+        freq_est_interval 1
+        dscp_event 0
+        dscp_general 0
+        dataset_comparison G.8275.x
+        G.8275.defaultDS.localPriority 128
+        #
+        # Port Data Set
+        #
+        logAnnounceInterval -3
+        logSyncInterval -4
+        logMinDelayReqInterval -4
+        logMinPdelayReqInterval -4
+        announceReceiptTimeout 3
+        syncReceiptTimeout 0
+        delayAsymmetry 0
+        fault_reset_interval -4
+        neighborPropDelayThresh 20000000
+        masterOnly 0
+        G.8275.portDS.localPriority 128
+        #
+        # Run time options
+        #
+        assume_two_step 0
+        logging_level 6
+        path_trace_enabled 0
+        follow_up_info 0
+        hybrid_e2e 0
+        inhibit_multicast_service 0
+        net_sync_monitor 0
+        tc_spanning_tree 0
+        tx_timestamp_timeout 50
+        unicast_listen 0
+        unicast_master_table 0
+        unicast_req_duration 3600
+        use_syslog 1
+        verbose 0
+        summary_interval 0
+        kernel_leap 1
+        check_fup_sync 0
+        clock_class_threshold 135
+        #
+        # Servo Options
+        #
+
+        # NGEN TEST MODIFIED
+        # New:
+        # pi_proportional_const 0.60
+        # pi_integral_const 0.0003
+        # Old:
+        # pi_proportional_const 0.0
+        # pi_integral_const 0.0
+        # END TEST MOD
+
+        pi_proportional_const 0.60
+        pi_integral_const 0.001
+        pi_proportional_scale 0.0
+        pi_proportional_exponent -0.3
+        pi_proportional_norm_max 0.7
+        pi_integral_scale 0.0
+        pi_integral_exponent 0.4
+        pi_integral_norm_max 0.3
+        step_threshold 2.0
+        # end T-BC experiment
+        first_step_threshold 0.00002
+        max_frequency 900000000
+        clock_servo pi
+        sanity_freq_limit 200000000
+        ntpshm_segment 0
+        #
+        # Transport options
+        #
+        transportSpecific 0x0
+        ptp_dst_mac 01:1B:19:00:00:00
+        p2p_dst_mac 01:80:C2:00:00:0E
+        udp_ttl 1
+        udp6_scope 0x0E
+        uds_address /var/run/ptp4l
+        #
+        # Default interface options
+        #
+        clock_type BC
+        network_transport L2
+        delay_mechanism E2E
+        time_stamping hardware
+        tsproc_mode filter
+        delay_filter moving_median
+        delay_filter_length 10
+        egressLatency 0
+        ingressLatency 0
+        boundary_clock_jbod 1
+        #
+        # Clock description
+        #
+        productDescription ;;
+        revisionData ;;
+        manufacturerIdentity 00:00:00
+        userDescription ;
+        timeSource 0xA0
+      ptp4lOpts: -2 --summary_interval -4
+      ptpSchedulingPolicy: SCHED_FIFO
+      ptpSchedulingPriority: 10
+      ptpSettings:
+        controllingProfile: 01-bc-tr
+        logReduce: {{ template "mustReMatchOneOf" (list .ptpSettings.logReduce "^true" "^enhanced")}}
+  {{- end }}
+  {{- if eq .name "01-bc-tr" }}
+    - name: 01-bc-tr
+      phc2sysOpts: -r -n (?<domainNumber>[0-9]+) -N 8 -R 16 -u 0 -m -s (?<upstreamInterface>[[:alnum:]]+)
+      ptp4lConf: |
+        [(?<upstreamInterface>[[:alnum:]]+)]
+        masterOnly 0
+        [global]
+        #
+        # Default Data Set
+        #
+        twoStepFlag 1
+        slaveOnly 0
+        priority1 128
+        priority2 (?<priority2>[0-9]+)
+        domainNumber (?<domainNumber>[0-9]+)
+        #utc_offset 37
+        clockClass 248
+        clockAccuracy 0xFE
+        offsetScaledLogVariance 0xFFFF
+        free_running 0
+        freq_est_interval 1
+        dscp_event 0
+        dscp_general 0
+        dataset_comparison G.8275.x
+        G.8275.defaultDS.localPriority 128
+        #
+        # Port Data Set
+        #
+        logAnnounceInterval -3
+        logSyncInterval -4
+        logMinDelayReqInterval -4
+        logMinPdelayReqInterval -4
+        announceReceiptTimeout 3
+        syncReceiptTimeout 0
+        delayAsymmetry 0
+        fault_reset_interval -4
+        neighborPropDelayThresh 20000000
+        masterOnly 0
+        G.8275.portDS.localPriority 128
+        #
+        # Run time options
+        #
+        assume_two_step 0
+        logging_level 6
+        path_trace_enabled 0
+        follow_up_info 0
+        hybrid_e2e 0
+        inhibit_multicast_service 0
+        net_sync_monitor 0
+        tc_spanning_tree 0
+        tx_timestamp_timeout 50
+        unicast_listen 0
+        unicast_master_table 0
+        unicast_req_duration 3600
+        use_syslog 1
+        verbose 0
+        summary_interval 0
+        kernel_leap 1
+        check_fup_sync 0
+        clock_class_threshold 135
+        #
+        # Servo Options
+        #
+
+        # NGEN TEST MODIFIED
+        # New:
+        # pi_proportional_const 0.60
+        # pi_integral_const 0.0003
+        # Old:
+        # pi_proportional_const 0.0
+        # pi_integral_const 0.0
+        # END TEST MOD
+
+        pi_proportional_const 0.60
+        pi_integral_const 0.001
+        pi_proportional_scale 0.0
+        pi_proportional_exponent -0.3
+        pi_proportional_norm_max 0.7
+        pi_integral_scale 0.0
+        pi_integral_exponent 0.4
+        pi_integral_norm_max 0.3
+        step_threshold 2.0
+        # end T-BC experiment
+        first_step_threshold 0.00002
+        max_frequency 900000000
+        clock_servo pi
+        sanity_freq_limit 200000000
+        ntpshm_segment 0
+        #
+        # Transport options
+        #
+        transportSpecific 0x0
+        ptp_dst_mac 01:1B:19:00:00:00
+        p2p_dst_mac 01:80:C2:00:00:0E
+        udp_ttl 1
+        udp6_scope 0x0E
+        uds_address /var/run/ptp4l
+        #
+        # Default interface options
+        #
+        clock_type OC
+        network_transport L2
+        delay_mechanism E2E
+        time_stamping hardware
+        tsproc_mode filter
+        delay_filter moving_median
+        delay_filter_length 10
+        egressLatency 0
+        ingressLatency 0
+        boundary_clock_jbod 1
+        #
+        # Clock description
+        #
+        productDescription ;;
+        revisionData ;;
+        manufacturerIdentity 00:00:00
+        userDescription ;
+        timeSource 0xA0
+      ptp4lOpts: -2 --summary_interval -4
+      ptpSchedulingPolicy: SCHED_FIFO
+      ptpSchedulingPriority: 10
+      ptpSettings:
+        clockType: T-BC
+        inSyncConditionThreshold: "10"
+        inSyncConditionTimes: "12"
+        logReduce: {{ template "mustReMatchOneOf" (list .ptpSettings.logReduce "^true" "^enhanced")}}
+        leadingInterface: (?<leadingInterface>[[:alnum:]]+)
+        upstreamPort: (?<upstreamInterface>[[:alnum:]]+)
+      plugins:
+        e825:
+          devices:
+            {{- .plugins.e825.devices | toYaml | nindent 12 }}
+          settings:
+            LocalMaxHoldoverOffSet: 500
+            LocalHoldoverTimeout: 0
+            MaxInSpecOffset: 100
+        {{- if .plugins.e830 }}
+        e830:
+          devices:
+            {{- .plugins.e830.devices | toYaml | nindent 12 }}
+        {{- end }}
+      ts2phcConf: |
+        [global]
+        use_syslog  0
+        verbose 1
+        logging_level 7
+        ts2phc.pulsewidth 500000000
+        leapfile  /usr/share/zoneinfo/leap-seconds.list
+        domainNumber (?<domainNumber>[0-9]+)
+        uds_address /var/run/ptp4l.1.socket
+        [(?<leadingInterface>[[:alnum:]]+)]
+        ts2phc.extts_correction 0
+        ts2phc.master 0
+        ts2phc.channel 0
+        ts2phc.pin_index 1
+        (?<ts2phcPortConfig>((\[[[:alnum:]]+\]
+        ts2phc.extts_polarity rising
+        ts2phc.extts_correction 0
+        ts2phc.master 0
+        ts2phc.channel 0
+        ts2phc.pin_index 1| *#.*| *)(\n|$))*)
+      ts2phcOpts: -s generic -a --ts2phc.rh_external_pps 1
+  {{- end }}
+  {{- end }}
+  recommend:
+    {{- .spec.recommend | toYaml | nindent 4 }}

--- a/telco-ran/configuration/kube-compare-reference/ptp-operator/configuration/PtpConfigGnrdTGM.yaml
+++ b/telco-ran/configuration/kube-compare-reference/ptp-operator/configuration/PtpConfigGnrdTGM.yaml
@@ -1,0 +1,221 @@
+# Note:  This example configuration should be customized to match the desired
+# configuration For this GNR-D T-GM configuration, we support GNSS incoming to
+# the onboard connection, and up to 24 Time Transmitter ports including any NAC
+# ports and any additional Carter Flats ports.
+apiVersion: ptp.openshift.io/v1
+kind: PtpConfig
+metadata:
+  name: gnrd-tgm
+  namespace: openshift-ptp
+  annotations:
+    ran.openshift.io/ztp-deploy-wave: "10"
+spec:
+  profile:
+  {{- range .spec.profile }}
+    - name: "grandmaster"
+      ptp4lOpts: "-2 --summary_interval -4"
+      phc2sysOpts: -r -u 0 -m -w -N 8 -R 16 -n (?<domainNumber>[0-9]+) -s (?<leadingInterface>[[:alnum:]]+)
+      ptpSchedulingPolicy: SCHED_FIFO
+      ptpSchedulingPriority: 10
+      ptpSettings:
+        logReduce: {{ template "mustReMatchOneOf" (list .ptpSettings.logReduce "^true" "^enhanced")}}
+      plugins:
+        {{- if .plugins.e830 }}
+        e830:
+          devices:
+            {{- .plugins.e830.devices | toYaml | nindent 12 }}
+        {{- end }}
+        e825:
+          devices:
+            {{- .plugins.e825.devices | toYaml | nindent 12 }}
+          settings:
+            LocalMaxHoldoverOffSet: 1500
+            LocalHoldoverTimeout: 14400
+            MaxInSpecOffset: 100
+          ublxCmds:
+            - args: #ubxtool -P 29.20 -z CFG-HW-ANT_CFG_VOLTCTRL,1
+                - "-P"
+                - "29.25"
+                - "-z"
+                - "CFG-HW-ANT_CFG_VOLTCTRL,1"
+              reportOutput: false
+            - args: #ubxtool -P 29.20 -e GPS
+                - "-P"
+                - "29.25"
+                - "-e"
+                - "GPS"
+              reportOutput: false
+            - args: #ubxtool -P 29.20 -d Galileo
+                - "-P"
+                - "29.25"
+                - "-d"
+                - "Galileo"
+              reportOutput: false
+            - args: #ubxtool -P 29.20 -d GLONASS
+                - "-P"
+                - "29.25"
+                - "-d"
+                - "GLONASS"
+              reportOutput: false
+            - args: #ubxtool -P 29.20 -d BeiDou
+                - "-P"
+                - "29.25"
+                - "-d"
+                - "BeiDou"
+              reportOutput: false
+            - args: #ubxtool -P 29.20 -d SBAS
+                - "-P"
+                - "29.25"
+                - "-d"
+                - "SBAS"
+              reportOutput: false
+            - args: #ubxtool -P 29.20 -t -w 5 -v 1 -e SURVEYIN,600,50000
+                - "-P"
+                - "29.25"
+                - "-t"
+                - "-w"
+                - "5"
+                - "-v"
+                - "1"
+                - "-e"
+                - "SURVEYIN,600,50000"
+              reportOutput: true
+            - args: #ubxtool -P 29.20 -p MON-HW
+                - "-P"
+                - "29.25"
+                - "-p"
+                - "MON-HW"
+              reportOutput: true
+            - args: #ubxtool -P 29.20 -p CFG-MSG,1,38,300
+                - "-P"
+                - "29.25"
+                - "-p"
+                - "CFG-MSG,1,38,248"
+              reportOutput: true
+      #ts2phcOpts: "--ts2phc.holdover 10 --servo_offset_threshold 5 --servo_num_offset_values 10"
+      ts2phcOpts: "-m"
+      ts2phcConf: |
+        [nmea]
+        ts2phc.master 1
+        [global]
+        use_syslog  0
+        verbose 1
+        logging_level 7
+        ts2phc.pulsewidth 100000000
+        ts2phc.nmea_serialport /dev/ttyACM0 
+        [(?<leadingInterface>[[:alnum:]]+)]
+        ts2phc.extts_polarity rising
+        ts2phc.extts_correction 0
+        ts2phc.master  0
+        ts2phc.channel 0
+        ts2phc.pin_index 1
+        (?<ts2phcPortConfig>((\[[[:alnum:]]+\]
+        ts2phc.extts_polarity rising
+        ts2phc.extts_correction 0
+        ts2phc.master 0
+        ts2phc.channel 0
+        ts2phc.pin_index 1| *#.*| *)(\n|$))*)
+      ptp4lConf: |
+        (?<masterPorts>((\[[[:alnum:]]+\]
+        masterOnly 1| *#.*| *)(\n|$))+)
+        [global]
+        #
+        # Default Data Set
+        #
+        twoStepFlag 1
+        priority1 128
+        priority2 (?<priority2>[0-9]+)
+        domainNumber (?<domainNumber>[0-9]+)
+        #utc_offset 37
+        clockClass 6
+        clockAccuracy 0x27
+        offsetScaledLogVariance 0xFFFF
+        free_running 0
+        freq_est_interval 1
+        dscp_event 0
+        dscp_general 0
+        dataset_comparison G.8275.x
+        G.8275.defaultDS.localPriority 128
+        #
+        # Port Data Set
+        #
+        logAnnounceInterval -3
+        logSyncInterval -4
+        logMinDelayReqInterval -4
+        logMinPdelayReqInterval 0
+        announceReceiptTimeout 3
+        syncReceiptTimeout 0
+        delayAsymmetry 0
+        fault_reset_interval 4
+        neighborPropDelayThresh 20000000
+        masterOnly 0
+        G.8275.portDS.localPriority 128
+        #
+        # Run time options
+        #
+        assume_two_step 0
+        logging_level 6
+        path_trace_enabled 0
+        follow_up_info 0
+        hybrid_e2e 0
+        inhibit_multicast_service 0
+        net_sync_monitor 0
+        tc_spanning_tree 0
+        tx_timestamp_timeout 50
+        unicast_listen 0
+        unicast_master_table 0
+        unicast_req_duration 3600
+        use_syslog 1
+        verbose 0
+        summary_interval -4
+        kernel_leap 1
+        check_fup_sync 0
+        #
+        # Servo Options
+        #
+        pi_proportional_const 0.0
+        pi_integral_const 0.0
+        pi_proportional_scale 0.0
+        pi_proportional_exponent -0.3
+        pi_proportional_norm_max 0.7
+        pi_integral_scale 0.0
+        pi_integral_exponent 0.4
+        pi_integral_norm_max 0.3
+        step_threshold 0.0
+        first_step_threshold 0.00002
+        clock_servo pi
+        sanity_freq_limit  200000000
+        ntpshm_segment 0
+        #
+        # Transport options
+        #
+        transportSpecific 0x0
+        ptp_dst_mac 01:1B:19:00:00:00
+        p2p_dst_mac 01:80:C2:00:00:0E
+        udp_ttl 1
+        udp6_scope 0x0E
+        uds_address /var/run/ptp4l
+        #
+        # Default interface options
+        #
+        clock_type BC
+        network_transport L2
+        delay_mechanism E2E
+        time_stamping hardware
+        tsproc_mode filter
+        delay_filter moving_median
+        delay_filter_length 10
+        egressLatency 0
+        ingressLatency 0
+        boundary_clock_jbod 1
+        #
+        # Clock description
+        #
+        productDescription ;;
+        revisionData ;;
+        manufacturerIdentity 00:00:00
+        userDescription ;
+        timeSource 0x20
+  {{- end }}
+  recommend:
+    {{- .spec.recommend | toYaml | nindent 4 }}

--- a/telco-ran/configuration/source-crs/ptp-operator/configuration/PtpConfigGnrdBcNoHoldover.yaml
+++ b/telco-ran/configuration/source-crs/ptp-operator/configuration/PtpConfigGnrdBcNoHoldover.yaml
@@ -1,0 +1,358 @@
+# Note:  This example configuration should be customized to match the desired configuration
+# For this GNR-D boundary clock configuration, we support one Time Reciever port on the NAC,
+# and up to 23 Time Transmitter ports including any other NAC ports and any additional
+# Carter Flats ports.
+apiVersion: ptp.openshift.io/v1
+kind: PtpConfig
+metadata:
+  name: gnrd-bc
+  namespace: openshift-ptp
+  annotations:
+    ran.openshift.io/ztp-deploy-wave: "10"
+spec:
+  profile:
+    - name: 00-bc-tt
+      ptp4lConf: |
+        # All TimeTransmitter ports should be outlined here with 'masterOnly 1'
+        #[eno8303]
+        # ** Host management interface
+        [eno8403]
+        masterOnly 1
+        #[eno8503]
+        # ** TR port (see 01-bc-tr profile)
+        [eno8603]
+        masterOnly 1
+        [eno8703]
+        masterOnly 1
+        [eno8803]
+        masterOnly 1
+        [eno8903]
+        masterOnly 1
+        [eno9003]
+        masterOnly 1
+        [enp108s0f0]
+        masterOnly 1
+        [enp108s0f1]
+        masterOnly 1
+        [enp108s0f2]
+        masterOnly 1
+        [enp108s0f3]
+        masterOnly 1
+        [enp108s0f4]
+        masterOnly 1
+        [enp108s0f5]
+        masterOnly 1
+        [enp108s0f6]
+        masterOnly 1
+        [enp108s0f7]
+        masterOnly 1
+        [enp110s0f0]
+        masterOnly 1
+        [enp110s0f1]
+        masterOnly 1
+        [enp110s0f2]
+        masterOnly 1
+        [enp110s0f3]
+        masterOnly 1
+        [enp110s0f4]
+        masterOnly 1
+        [enp110s0f5]
+        masterOnly 1
+        [enp110s0f6]
+        masterOnly 1
+        [enp110s0f7]
+        masterOnly 1
+        [global]
+        #
+        # Default Data Set
+        #
+        twoStepFlag 1
+        slaveOnly 0
+        priority1 128
+        priority2 128
+        domainNumber 24
+        #utc_offset 37
+        clockClass 248
+        clockAccuracy 0xFE
+        offsetScaledLogVariance 0xFFFF
+        free_running 0
+        freq_est_interval 1
+        dscp_event 0
+        dscp_general 0
+        dataset_comparison G.8275.x
+        G.8275.defaultDS.localPriority 128
+        #
+        # Port Data Set
+        #
+        logAnnounceInterval -3
+        logSyncInterval -4
+        logMinDelayReqInterval -4
+        logMinPdelayReqInterval -4
+        announceReceiptTimeout 3
+        syncReceiptTimeout 0
+        delayAsymmetry 0
+        fault_reset_interval -4
+        neighborPropDelayThresh 20000000
+        masterOnly 0
+        G.8275.portDS.localPriority 128
+        #
+        # Run time options
+        #
+        assume_two_step 0
+        logging_level 6
+        path_trace_enabled 0
+        follow_up_info 0
+        hybrid_e2e 0
+        inhibit_multicast_service 0
+        net_sync_monitor 0
+        tc_spanning_tree 0
+        tx_timestamp_timeout 50
+        unicast_listen 0
+        unicast_master_table 0
+        unicast_req_duration 3600
+        use_syslog 1
+        verbose 0
+        summary_interval 0
+        kernel_leap 1
+        check_fup_sync 0
+        clock_class_threshold 135
+        #
+        # Servo Options
+        #
+
+        # NGEN TEST MODIFIED
+        # New:
+        # pi_proportional_const 0.60
+        # pi_integral_const 0.0003
+        # Old:
+        # pi_proportional_const 0.0
+        # pi_integral_const 0.0
+        # END TEST MOD
+
+        pi_proportional_const 0.60
+        pi_integral_const 0.001
+        pi_proportional_scale 0.0
+        pi_proportional_exponent -0.3
+        pi_proportional_norm_max 0.7
+        pi_integral_scale 0.0
+        pi_integral_exponent 0.4
+        pi_integral_norm_max 0.3
+        step_threshold 2.0
+        # end T-BC experiment
+        first_step_threshold 0.00002
+        max_frequency 900000000
+        clock_servo pi
+        sanity_freq_limit 200000000
+        ntpshm_segment 0
+        #
+        # Transport options
+        #
+        transportSpecific 0x0
+        ptp_dst_mac 01:1B:19:00:00:00
+        p2p_dst_mac 01:80:C2:00:00:0E
+        udp_ttl 1
+        udp6_scope 0x0E
+        uds_address /var/run/ptp4l
+        #
+        # Default interface options
+        #
+        clock_type BC
+        network_transport L2
+        delay_mechanism E2E
+        time_stamping hardware
+        tsproc_mode filter
+        delay_filter moving_median
+        delay_filter_length 10
+        egressLatency 0
+        ingressLatency 0
+        boundary_clock_jbod 1
+        #
+        # Clock description
+        #
+        productDescription ;;
+        revisionData ;;
+        manufacturerIdentity 00:00:00
+        userDescription ;
+        timeSource 0xA0
+      ptp4lOpts: -2 --summary_interval -4
+      ptpSchedulingPolicy: SCHED_FIFO
+      ptpSchedulingPriority: 10
+      ptpSettings:
+        controllingProfile: 01-bc-tr
+        logReduce: "true"
+    - name: 01-bc-tr
+      phc2sysOpts: -r -n 24 -N 8 -R 16 -u 0 -m -s $upstreamInterface
+      ptp4lConf: |
+        [$upstreamInterface]
+        masterOnly 0
+        [global]
+        #
+        # Default Data Set
+        #
+        twoStepFlag 1
+        slaveOnly 0
+        priority1 128
+        priority2 128
+        domainNumber 24
+        #utc_offset 37
+        clockClass 248
+        clockAccuracy 0xFE
+        offsetScaledLogVariance 0xFFFF
+        free_running 0
+        freq_est_interval 1
+        dscp_event 0
+        dscp_general 0
+        dataset_comparison G.8275.x
+        G.8275.defaultDS.localPriority 128
+        #
+        # Port Data Set
+        #
+        logAnnounceInterval -3
+        logSyncInterval -4
+        logMinDelayReqInterval -4
+        logMinPdelayReqInterval -4
+        announceReceiptTimeout 3
+        syncReceiptTimeout 0
+        delayAsymmetry 0
+        fault_reset_interval -4
+        neighborPropDelayThresh 20000000
+        masterOnly 0
+        G.8275.portDS.localPriority 128
+        #
+        # Run time options
+        #
+        assume_two_step 0
+        logging_level 6
+        path_trace_enabled 0
+        follow_up_info 0
+        hybrid_e2e 0
+        inhibit_multicast_service 0
+        net_sync_monitor 0
+        tc_spanning_tree 0
+        tx_timestamp_timeout 50
+        unicast_listen 0
+        unicast_master_table 0
+        unicast_req_duration 3600
+        use_syslog 1
+        verbose 0
+        summary_interval 0
+        kernel_leap 1
+        check_fup_sync 0
+        clock_class_threshold 135
+        #
+        # Servo Options
+        #
+
+        # NGEN TEST MODIFIED
+        # New:
+        # pi_proportional_const 0.60
+        # pi_integral_const 0.0003
+        # Old:
+        # pi_proportional_const 0.0
+        # pi_integral_const 0.0
+        # END TEST MOD
+
+        pi_proportional_const 0.60
+        pi_integral_const 0.001
+        pi_proportional_scale 0.0
+        pi_proportional_exponent -0.3
+        pi_proportional_norm_max 0.7
+        pi_integral_scale 0.0
+        pi_integral_exponent 0.4
+        pi_integral_norm_max 0.3
+        step_threshold 2.0
+        # end T-BC experiment
+        first_step_threshold 0.00002
+        max_frequency 900000000
+        clock_servo pi
+        sanity_freq_limit 200000000
+        ntpshm_segment 0
+        #
+        # Transport options
+        #
+        transportSpecific 0x0
+        ptp_dst_mac 01:1B:19:00:00:00
+        p2p_dst_mac 01:80:C2:00:00:0E
+        udp_ttl 1
+        udp6_scope 0x0E
+        uds_address /var/run/ptp4l
+        #
+        # Default interface options
+        #
+        clock_type OC
+        network_transport L2
+        delay_mechanism E2E
+        time_stamping hardware
+        tsproc_mode filter
+        delay_filter moving_median
+        delay_filter_length 10
+        egressLatency 0
+        ingressLatency 0
+        boundary_clock_jbod 1
+        #
+        # Clock description
+        #
+        productDescription ;;
+        revisionData ;;
+        manufacturerIdentity 00:00:00
+        userDescription ;
+        timeSource 0xA0
+      ptp4lOpts: -2 --summary_interval -4
+      ptpSchedulingPolicy: SCHED_FIFO
+      ptpSchedulingPriority: 10
+      ptpSettings:
+        clockType: T-BC
+        inSyncConditionThreshold: "10"
+        inSyncConditionTimes: "12"
+        logReduce: "true"
+        leadingInterface: eno8703
+        upstreamPort: $upstreamInterface
+      plugins:
+        e825:
+          devices:
+            - eno8703
+          settings:
+            LocalMaxHoldoverOffSet: 500
+            LocalHoldoverTimeout: 0
+            MaxInSpecOffset: 100
+        e830:
+          devices:
+            - enp108s0f0
+            - enp110s0f0
+      ts2phcConf: |
+        [global]
+        use_syslog  0
+        verbose 1
+        logging_level 7
+        ts2phc.pulsewidth 500000000
+        leapfile  /usr/share/zoneinfo/leap-seconds.list
+        domainNumber 24
+        uds_address /var/run/ptp4l.1.socket
+        [eno8703]
+        ts2phc.extts_correction 0
+        ts2phc.master 0
+        ts2phc.channel 0
+        ts2phc.pin_index 1
+        # This should be one section per Carter Flats (e830) card:
+        [enp108s0f0]
+        ts2phc.extts_polarity rising
+        ts2phc.extts_correction 0
+        ts2phc.master 0
+        ts2phc.channel 0
+        ts2phc.pin_index 1
+        [enp110s0f0]
+        ts2phc.extts_polarity rising
+        ts2phc.extts_correction 0
+        ts2phc.master 0
+        ts2phc.channel 0
+        ts2phc.pin_index 1
+      ts2phcOpts: -s generic -a --ts2phc.rh_external_pps 1
+  recommend:
+    - match:
+      - nodeLabel: node-role.kubernetes.io/$mcp
+      priority: 4
+      profile: 00-bc-tt
+    - match:
+      - nodeLabel: node-role.kubernetes.io/$mcp
+      priority: 4
+      profile: 01-bc-tr

--- a/telco-ran/configuration/source-crs/ptp-operator/configuration/PtpConfigGnrdTGM.yaml
+++ b/telco-ran/configuration/source-crs/ptp-operator/configuration/PtpConfigGnrdTGM.yaml
@@ -1,0 +1,275 @@
+# Note:  This example configuration should be customized to match the desired
+# configuration For this GNR-D T-GM configuration, we support GNSS incoming to
+# the onboard connection, and up to 24 Time Transmitter ports including any NAC
+# ports and any additional Carter Flats ports.
+apiVersion: ptp.openshift.io/v1
+kind: PtpConfig
+metadata:
+  name: gnrd-tgm
+  namespace: openshift-ptp
+  annotations:
+    ran.openshift.io/ztp-deploy-wave: "10"
+spec:
+  profile:
+    - name: "grandmaster"
+      ptp4lOpts: "-2 --summary_interval -4"
+      phc2sysOpts: -r -u 0 -m -w -N 8 -R 16 -n 24 -s eno8703
+      ptpSchedulingPolicy: SCHED_FIFO
+      ptpSchedulingPriority: 10
+      ptpSettings:
+        logReduce: "true"
+      plugins:
+        e830:
+          devices:
+            - enp108s0f0
+            - enp110s0f0
+        e825:
+          devices:
+            - eno8703
+          settings:
+            LocalMaxHoldoverOffSet: 1500
+            LocalHoldoverTimeout: 14400
+            MaxInSpecOffset: 100
+          ublxCmds:
+            - args: #ubxtool -P 29.20 -z CFG-HW-ANT_CFG_VOLTCTRL,1
+                - "-P"
+                - "29.25"
+                - "-z"
+                - "CFG-HW-ANT_CFG_VOLTCTRL,1"
+              reportOutput: false
+            - args: #ubxtool -P 29.20 -e GPS
+                - "-P"
+                - "29.25"
+                - "-e"
+                - "GPS"
+              reportOutput: false
+            - args: #ubxtool -P 29.20 -d Galileo
+                - "-P"
+                - "29.25"
+                - "-d"
+                - "Galileo"
+              reportOutput: false
+            - args: #ubxtool -P 29.20 -d GLONASS
+                - "-P"
+                - "29.25"
+                - "-d"
+                - "GLONASS"
+              reportOutput: false
+            - args: #ubxtool -P 29.20 -d BeiDou
+                - "-P"
+                - "29.25"
+                - "-d"
+                - "BeiDou"
+              reportOutput: false
+            - args: #ubxtool -P 29.20 -d SBAS
+                - "-P"
+                - "29.25"
+                - "-d"
+                - "SBAS"
+              reportOutput: false
+            - args: #ubxtool -P 29.20 -t -w 5 -v 1 -e SURVEYIN,600,50000
+                - "-P"
+                - "29.25"
+                - "-t"
+                - "-w"
+                - "5"
+                - "-v"
+                - "1"
+                - "-e"
+                - "SURVEYIN,600,50000"
+              reportOutput: true
+            - args: #ubxtool -P 29.20 -p MON-HW
+                - "-P"
+                - "29.25"
+                - "-p"
+                - "MON-HW"
+              reportOutput: true
+            - args: #ubxtool -P 29.20 -p CFG-MSG,1,38,300
+                - "-P"
+                - "29.25"
+                - "-p"
+                - "CFG-MSG,1,38,248"
+              reportOutput: true
+      #ts2phcOpts: "--ts2phc.holdover 10 --servo_offset_threshold 5 --servo_num_offset_values 10"
+      ts2phcOpts: "-m"
+      ts2phcConf: |
+        [nmea]
+        ts2phc.master 1
+        [global]
+        use_syslog  0
+        verbose 1
+        logging_level 7
+        ts2phc.pulsewidth 100000000
+        ts2phc.nmea_serialport /dev/ttyACM0 
+        [eno8703]
+        ts2phc.extts_polarity rising
+        ts2phc.extts_correction 0
+        ts2phc.master  0
+        ts2phc.channel 0
+        ts2phc.pin_index 1
+        # This should be one section per Carter Flats (e830) card:
+        [enp108s0f0]
+        ts2phc.extts_polarity rising
+        ts2phc.extts_correction 0
+        ts2phc.master 0
+        ts2phc.channel 0
+        ts2phc.pin_index 1
+        [enp110s0f0]
+        ts2phc.extts_polarity rising
+        ts2phc.extts_correction 0
+        ts2phc.master 0
+        ts2phc.channel 0
+        ts2phc.pin_index 1
+      ptp4lConf: |
+        # All TimeTransmitter ports should be outlined here with 'masterOnly 1'
+        #[eno8303]
+        # ** Host management interface
+        [eno8403]
+        masterOnly 1
+        [eno8503]
+        masterOnly 1
+        [eno8603]
+        masterOnly 1
+        [eno8703]
+        masterOnly 1
+        [eno8803]
+        masterOnly 1
+        [eno8903]
+        masterOnly 1
+        [eno9003]
+        masterOnly 1
+        [enp108s0f0]
+        masterOnly 1
+        [enp108s0f1]
+        masterOnly 1
+        [enp108s0f2]
+        masterOnly 1
+        [enp108s0f3]
+        masterOnly 1
+        [enp108s0f4]
+        masterOnly 1
+        [enp108s0f5]
+        masterOnly 1
+        [enp108s0f6]
+        masterOnly 1
+        [enp108s0f7]
+        masterOnly 1
+        [enp110s0f0]
+        masterOnly 1
+        [enp110s0f1]
+        masterOnly 1
+        [enp110s0f2]
+        masterOnly 1
+        [enp110s0f3]
+        masterOnly 1
+        [enp110s0f4]
+        masterOnly 1
+        [enp110s0f5]
+        masterOnly 1
+        [enp110s0f6]
+        masterOnly 1
+        [enp110s0f7]
+        masterOnly 1
+        [global]
+        #
+        # Default Data Set
+        #
+        twoStepFlag 1
+        priority1 128
+        priority2 128
+        domainNumber 24
+        #utc_offset 37
+        clockClass 6
+        clockAccuracy 0x27
+        offsetScaledLogVariance 0xFFFF
+        free_running 0
+        freq_est_interval 1
+        dscp_event 0
+        dscp_general 0
+        dataset_comparison G.8275.x
+        G.8275.defaultDS.localPriority 128
+        #
+        # Port Data Set
+        #
+        logAnnounceInterval -3
+        logSyncInterval -4
+        logMinDelayReqInterval -4
+        logMinPdelayReqInterval 0
+        announceReceiptTimeout 3
+        syncReceiptTimeout 0
+        delayAsymmetry 0
+        fault_reset_interval 4
+        neighborPropDelayThresh 20000000
+        masterOnly 0
+        G.8275.portDS.localPriority 128
+        #
+        # Run time options
+        #
+        assume_two_step 0
+        logging_level 6
+        path_trace_enabled 0
+        follow_up_info 0
+        hybrid_e2e 0
+        inhibit_multicast_service 0
+        net_sync_monitor 0
+        tc_spanning_tree 0
+        tx_timestamp_timeout 50
+        unicast_listen 0
+        unicast_master_table 0
+        unicast_req_duration 3600
+        use_syslog 1
+        verbose 0
+        summary_interval -4
+        kernel_leap 1
+        check_fup_sync 0
+        #
+        # Servo Options
+        #
+        pi_proportional_const 0.0
+        pi_integral_const 0.0
+        pi_proportional_scale 0.0
+        pi_proportional_exponent -0.3
+        pi_proportional_norm_max 0.7
+        pi_integral_scale 0.0
+        pi_integral_exponent 0.4
+        pi_integral_norm_max 0.3
+        step_threshold 0.0
+        first_step_threshold 0.00002
+        clock_servo pi
+        sanity_freq_limit  200000000
+        ntpshm_segment 0
+        #
+        # Transport options
+        #
+        transportSpecific 0x0
+        ptp_dst_mac 01:1B:19:00:00:00
+        p2p_dst_mac 01:80:C2:00:00:0E
+        udp_ttl 1
+        udp6_scope 0x0E
+        uds_address /var/run/ptp4l
+        #
+        # Default interface options
+        #
+        clock_type BC
+        network_transport L2
+        delay_mechanism E2E
+        time_stamping hardware
+        tsproc_mode filter
+        delay_filter moving_median
+        delay_filter_length 10
+        egressLatency 0
+        ingressLatency 0
+        boundary_clock_jbod 1
+        #
+        # Clock description
+        #
+        productDescription ;;
+        revisionData ;;
+        manufacturerIdentity 00:00:00
+        userDescription ;
+        timeSource 0x20
+  recommend:
+    - match:
+      - nodeLabel: node-role.kubernetes.io/$mcp
+      priority: 4
+      profile: grandmaster


### PR DESCRIPTION
This is a manual cherry-pick of #725
