### PR TITLE
Add ConfigurationState validation for MetalLB

### DIFF
--- a/telco-core/configuration/core-baseline.yaml
+++ b/telco-core/configuration/core-baseline.yaml
@@ -71,6 +71,7 @@ policies:
         patches:
         - spec:
             installPlanApproval: Manual
+      - path: reference-crs/required/networking/metallb/configurationstate.yaml
       - path: reference-crs/required/scheduling/NROPSubscriptionNS.yaml
       - path: reference-crs/required/scheduling/NROPSubscriptionOperGroup.yaml
       - path: reference-crs/required/scheduling/NROPSubscription.yaml

--- a/telco-core/configuration/reference-crs-kube-compare/metadata.yaml
+++ b/telco-core/configuration/reference-crs-kube-compare/metadata.yaml
@@ -51,6 +51,10 @@ parts:
           - path: required/networking/metallb/bfd-profile.yaml
           - path: required/networking/metallb/bgp-advr.yaml
           - path: required/networking/metallb/bgp-peer.yaml
+          - path: required/networking/metallb/configurationstate.yaml
+            config:
+              fieldsToOmitRefs:
+                - allowStatusCheck
           - path: required/networking/metallb/metallb.yaml
           - path: required/networking/metallb/metallbNS.yaml
           - path: required/networking/metallb/metallbOperGroup.yaml

--- a/telco-core/configuration/reference-crs-kube-compare/required/networking/metallb/configurationstate.yaml
+++ b/telco-core/configuration/reference-crs-kube-compare/required/networking/metallb/configurationstate.yaml
@@ -1,0 +1,7 @@
+apiVersion: metallb.io/v1beta1
+kind: ConfigurationState
+metadata:
+  name: {{ .metadata.name }}
+  namespace: metallb-system
+status:
+  result: Valid

--- a/telco-core/configuration/reference-crs/required/networking/metallb/configurationstate.yaml
+++ b/telco-core/configuration/reference-crs/required/networking/metallb/configurationstate.yaml
@@ -1,0 +1,11 @@
+# This resource is created automatically by MetalLB. Do not deploy manually.
+# It is included here as a reference for the expected state after successful configuration.
+# count: 1-N (1 controller + 1 per worker node)
+---
+apiVersion: metallb.io/v1beta1
+kind: ConfigurationState
+metadata:
+  name: controller
+  namespace: metallb-system
+status:
+  result: Valid


### PR DESCRIPTION
MetalLB's ConfigurationState CRD (metallb.io/v1beta1) reports whether MetalLB components successfully processed the user's configuration. Previously, configuration errors (e.g. a BGPPeer referencing a nonexistent BFD profile) were only visible in pod logs.

Add a kube-compare template and reference CR for ConfigurationState so that cluster-compare validates not just that MetalLB CRs exist, but that MetalLB accepted and processed them successfully (status.result: Valid).

The template uses a name wildcard to match all ConfigurationState resources (controller + per-node speaker instances) and is placed in the networking-metallb allOf group with fieldsToOmitRefs: allowStatusCheck to enable status field comparison.