### PR TITLE
Allow mpls and vrf kernel modules in Worker and Control Plane files

### DIFF
--- a/telco-core/configuration/reference-crs-kube-compare/optional/other/control-plane-load-kernel-modules.yaml
+++ b/telco-core/configuration/reference-crs-kube-compare/optional/other/control-plane-load-kernel-modules.yaml
@@ -31,7 +31,7 @@ spec:
           # nf_reject_ipv4
           # nf_reject_ipv6
           # nfnetlink_log
-          source: data:text/plain;charset=utf-8;base64,aXBfZ3JlCm5mX3RhYmxlcwpuZl9jb25udHJhY2sKbmZ0X2N0Cm5mdF9saW1pdApuZnRfbG9nCm5mdF9uYXQKbmZ0X2NoYWluX25hdApuZl9yZWplY3RfaXB2NApuZl9yZWplY3RfaXB2NgpuZm5ldGxpbmtfbG9nCg==
+          source: {{ template "validateBase64List" (list $userSource (list "ip_gre" "nf_tables" "nf_conntrack" "nft_ct" "nft_limit" "nft_log" "nft_nat" "nft_chain_nat" "nf_reject_ipv4" "nf_reject_ipv6" "nfnetlink_log" "mpls" "vrf")) }}
         mode: 420
         overwrite: true
         path: /etc/modules-load.d/kernel-load.conf

--- a/telco-core/configuration/reference-crs-kube-compare/optional/other/worker-load-kernel-modules.yaml
+++ b/telco-core/configuration/reference-crs-kube-compare/optional/other/worker-load-kernel-modules.yaml
@@ -31,7 +31,7 @@ spec:
           # nf_reject_ipv4
           # nf_reject_ipv6
           # nfnetlink_log
-          source: data:text/plain;charset=utf-8;base64,aXBfZ3JlCm5mX3RhYmxlcwpuZl9jb25udHJhY2sKbmZ0X2N0Cm5mdF9saW1pdApuZnRfbG9nCm5mdF9uYXQKbmZ0X2NoYWluX25hdApuZl9yZWplY3RfaXB2NApuZl9yZWplY3RfaXB2NgpuZm5ldGxpbmtfbG9nCg==
+          source: {{ template "validateBase64List" (list $userSource (list "ip_gre" "nf_tables" "nf_conntrack" "nft_ct" "nft_limit" "nft_log" "nft_nat" "nft_chain_nat" "nf_reject_ipv4" "nf_reject_ipv6" "nfnetlink_log" "mpls" "vrf")) }}
         mode: 420
         overwrite: true
         path: /etc/modules-load.d/kernel-load.conf


### PR DESCRIPTION
Updated base64-encoded allowed kernel modules in Worker and Control Plane files
(reference-crs-kube-compare) to include mpls and vrf as acceptable variations.

The changes were made by decoding the files, adding mpls and vrf to the allowed modules list, and encoding them back to Base64.

Ticket: https://redhat.atlassian.net/browse/CNF-21265