### PR TITLE
CNF-21719: Consolidate cert-manager config into core-overlay-base policy

### DIFF
--- a/telco-core/configuration/core-overlay.yaml
+++ b/telco-core/configuration/core-overlay.yaml
@@ -34,6 +34,30 @@ policies:
         complianceType: mustonlyhave
       - path: reference-crs/optional/networking/multus/tap_cni/mc_rootless_pods_selinux.yaml
 
+      # Cert-manager configuration (optional component)
+      # - path: reference-crs/optional/cert-manager/certManagerClusterIssuer.yaml
+      #   patches:
+      #   - spec:
+      #       acme:
+      #         server: https://acme-v02.api.letsencrypt.org/directory
+      #         email: your-email@example.com
+      #         privateKeySecretRef:
+      #           name: acme-account-key
+      # - path: reference-crs/optional/cert-manager/ingressCertificate.yaml
+      #   patches:
+      #   - spec:
+      #       commonName: "*.apps.example.com"
+      #       dnsNames:
+      #       - "*.apps.example.com"
+      # - path: reference-crs/optional/cert-manager/ingressControllerConfig.yaml
+      # - path: reference-crs/optional/cert-manager/apiServerCertificate.yaml
+      #   patches:
+      #   - spec:
+      #       commonName: "api.example.com"
+      #       dnsNames:
+      #       - "api.example.com"
+      # - path: reference-crs/optional/cert-manager/apiServerConfig.yaml
+
   # Custom networking, operator and cluster configuration
   - name: core-overlay-config-4.22
     policyAnnotations:
@@ -305,32 +329,3 @@ policies:
                   apiVersion: "v1"
                   staticConfigs:
                   - "10.11.12.14:9999"
-
-  # Cert-manager configuration (optional component)
-  # For consistency the name of this policy will be updated in a future release to `core-overlay-cert-manager-4.22`
-  # - name: config-cert-manager-4.22
-  #   policyAnnotations:
-  #     ran.openshift.io/ztp-deploy-wave: "10"
-  #   manifests:
-  #     - path: reference-crs/optional/cert-manager/certManagerClusterIssuer.yaml
-  #       patches:
-  #       - spec:
-  #           acme:
-  #             server: https://acme-v02.api.letsencrypt.org/directory
-  #             email: your-email@example.com
-  #             privateKeySecretRef:
-  #               name: acme-account-key
-  #     - path: reference-crs/optional/cert-manager/ingressCertificate.yaml
-  #       patches:
-  #       - spec:
-  #           commonName: "*.apps.example.com"
-  #           dnsNames:
-  #           - "*.apps.example.com"
-  #     - path: reference-crs/optional/cert-manager/ingressControllerConfig.yaml
-  #     - path: reference-crs/optional/cert-manager/apiServerCertificate.yaml
-  #       patches:
-  #       - spec:
-  #           commonName: "api.example.com"
-  #           dnsNames:
-  #           - "api.example.com"
-  #     - path: reference-crs/optional/cert-manager/apiServerConfig.yaml


### PR DESCRIPTION
## Summary
- Moves the cert-manager path entries from a standalone policy into the `core-overlay-base-4.22` policy in `core-overlay.yaml`
- Removes the old `config-cert-manager-4.22` policy wrapper (name, annotations, manifests key)
- Keeps overlay config in one policy for simpler and faster rollout

## Test plan
- [ ] Verify YAML is valid (`yamllint` passes)
- [ ] Confirm cert-manager paths are now inside `core-overlay-base-4.22` manifests
- [ ] Confirm no standalone cert-manager policy remains