### PR TITLE
Fix broken pgt2acmpg documentation URL

### DIFF
--- a/telco-ran/configuration/argocd/example/acmpolicygenerator/README.md
+++ b/telco-ran/configuration/argocd/example/acmpolicygenerator/README.md
@@ -144,7 +144,7 @@ includes the statically generated Policy) or PolicyGenerator.
 
 ### Other
 
-The pgt2acmpg supports converting Policy Gen Templates to ACM Policy Generator templates. More details can be found at [link](https://github.com/openshift-kni/cnf-features-deploy/ztp/tools/pgt2acmpg/blob/main/README.md)
+The pgt2acmpg supports converting Policy Gen Templates to ACM Policy Generator templates. More details can be found at [link](https://github.com/openshift-kni/cnf-features-deploy/blob/master/ztp/tools/pgt2acmpg/README.md)
 
 ## Controlled reboot of a fleet of clusters
 


### PR DESCRIPTION
## Summary
- Fix broken link to pgt2acmpg tool README in the ACM Policy Generator documentation
- The URL had path segments in the wrong order (`cnf-features-deploy/ztp/tools/pgt2acmpg/blob/main/...` instead of `cnf-features-deploy/blob/master/ztp/tools/pgt2acmpg/...`) and referenced `main` instead of `master`

Closes #191