### PR TITLE
CNF-23445: Add namespace field to MultiNetworkPolicy reference CRs

### DIFF
--- a/telco-core/configuration/reference-crs-kube-compare/required/networking/multinetworkpolicy/multiNetworkPolicyAllowPortProtocol.yaml
+++ b/telco-core/configuration/reference-crs-kube-compare/required/networking/multinetworkpolicy/multiNetworkPolicyAllowPortProtocol.yaml
@@ -2,6 +2,7 @@ apiVersion: k8s.cni.cncf.io/v1beta1
 kind: MultiNetworkPolicy
 metadata:
   name: allow-port-and-protocol
+  namespace: {{ .metadata.namespace }}
   annotations:
     {{ if .metadata.annotations }}
     k8s.v1.cni.cncf.io/policy-for: {{ index .metadata.annotations "k8s.v1.cni.cncf.io/policy-for" }}

--- a/telco-core/configuration/reference-crs-kube-compare/required/networking/multinetworkpolicy/multiNetworkPolicyDenyAll.yaml
+++ b/telco-core/configuration/reference-crs-kube-compare/required/networking/multinetworkpolicy/multiNetworkPolicyDenyAll.yaml
@@ -2,6 +2,7 @@ apiVersion: k8s.cni.cncf.io/v1beta1
 kind: MultiNetworkPolicy
 metadata:
   name: deny-all
+  namespace: {{ .metadata.namespace }}
 {{- if .metadata.annotations }}
   {{- if ne (index .metadata.annotations "k8s.v1.cni.cncf.io/policy-for") nil }}
   annotations:

--- a/telco-core/configuration/reference-crs/required/networking/multinetworkpolicy/multiNetworkPolicyAllowPortProtocol.yaml
+++ b/telco-core/configuration/reference-crs/required/networking/multinetworkpolicy/multiNetworkPolicyAllowPortProtocol.yaml
@@ -3,6 +3,7 @@ apiVersion: k8s.cni.cncf.io/v1beta1
 kind: MultiNetworkPolicy
 metadata:
   name: allow-port-and-protocol
+  namespace: $namespace
   annotations:
     k8s.v1.cni.cncf.io/policy-for: $networkName
 spec:

--- a/telco-core/configuration/reference-crs/required/networking/multinetworkpolicy/multiNetworkPolicyDenyAll.yaml
+++ b/telco-core/configuration/reference-crs/required/networking/multinetworkpolicy/multiNetworkPolicyDenyAll.yaml
@@ -3,6 +3,7 @@ apiVersion: k8s.cni.cncf.io/v1beta1
 kind: MultiNetworkPolicy
 metadata:
   name: deny-all
+  namespace: $namespace
   annotations:
     k8s.v1.cni.cncf.io/policy-for: $networkName
 spec:


### PR DESCRIPTION
## Summary
- Add missing `namespace` field to MultiNetworkPolicy reference CRs
- `MultiNetworkPolicy` is a [namespaced resource](https://docs.redhat.com/en/documentation/openshift_container_platform/4.18/html-single/network_apis/index#multinetworkpolicy-k8s-cni-cncf-io-v1beta1), and per the [Kubernetes API conventions](https://github.com/kubernetes/community/blob/main/contributors/devel/sig-architecture/api-conventions.md#metadata), namespaced resources must include `metadata.namespace`
- Without this field, kube-compare produces false-positive diffs when validating clusters against the reference configuration
- Follows the existing pattern used by `networkAttachmentDefinition.yaml` for templated namespace fields

Closes #153