### PR TITLE
CNF-21212: RAN Hardening (5.0) - Crypto Policy (H1)

### DIFF
--- a/telco-ran/configuration/kube-compare-reference/informational/hardening/75-crypto-policy-high-master.yaml
+++ b/telco-ran/configuration/kube-compare-reference/informational/hardening/75-crypto-policy-high-master.yaml
@@ -1,0 +1,26 @@
+apiVersion: machineconfiguration.openshift.io/v1
+kind: MachineConfig
+metadata:
+  name: 75-crypto-policy-high-master
+  labels:
+    machineconfiguration.openshift.io/role: master
+spec:
+  config:
+    ignition:
+      version: 3.5.0
+    systemd:
+      units:
+        - name: configure-crypto-policy.service
+          enabled: true
+          contents: |
+            [Unit]
+            Description=Configure System Crypto Policy
+            Before=sshd.service
+            After=systemd-machine-id-commit.service
+            ConditionFirstBoot=no
+            [Service]
+            Type=oneshot
+            ExecStart=/usr/bin/update-crypto-policies --set DEFAULT:NO-SHA1
+            RemainAfterExit=yes
+            [Install]
+            WantedBy=multi-user.target

--- a/telco-ran/configuration/kube-compare-reference/informational/hardening/75-crypto-policy-high-worker.yaml
+++ b/telco-ran/configuration/kube-compare-reference/informational/hardening/75-crypto-policy-high-worker.yaml
@@ -1,0 +1,26 @@
+apiVersion: machineconfiguration.openshift.io/v1
+kind: MachineConfig
+metadata:
+  name: 75-crypto-policy-high-worker
+  labels:
+    machineconfiguration.openshift.io/role: worker
+spec:
+  config:
+    ignition:
+      version: 3.5.0
+    systemd:
+      units:
+        - name: configure-crypto-policy.service
+          enabled: true
+          contents: |
+            [Unit]
+            Description=Configure System Crypto Policy
+            Before=sshd.service
+            After=systemd-machine-id-commit.service
+            ConditionFirstBoot=no
+            [Service]
+            Type=oneshot
+            ExecStart=/usr/bin/update-crypto-policies --set DEFAULT:NO-SHA1
+            RemainAfterExit=yes
+            [Install]
+            WantedBy=multi-user.target


### PR DESCRIPTION
## Summary

Adds MachineConfig to set the system-wide crypto policy to `DEFAULT:NO-SHA1` on both master and worker nodes.

This addresses HIGH severity E8 compliance check `rhcos4-e8-configure-crypto-policy` which requires disabling SHA-1 in cryptographic signatures.

- Deploys a systemd unit that runs `update-crypto-policies --set DEFAULT:NO-SHA1` on boot
- Separate master and worker MachineConfig files

## Crypto Policy Setting

| Setting | Value | Purpose |
|---------|-------|---------|
| System crypto policy | `DEFAULT:NO-SHA1` | Disable SHA-1 in signatures (TLS, SSH, DNSSEC, Kerberos) while keeping HMAC-SHA1 for compatibility |

The `NO-SHA1` sub-policy disables SHA-1 only for signatures, not for HMAC. This is the minimum change needed to pass E8 compliance while maintaining broad compatibility.

> **Note:** The Moderate compliance profile expects FIPS mode, not just `NO-SHA1`. This remediation passes E8 but will still fail Moderate crypto policy checks.

<details>
<summary>Why this setting is not upstreamed into the RHCOS base image</summary>

We evaluated upstreaming this into the RHCOS base image but determined it is a deployment-specific hardening choice:

**RHEL 9 DEFAULT already restricts SHA-1** — The RHEL 9 DEFAULT crypto policy already disables SHA-1 for signatures in TLS, SSH, IKEv2, DNSSEC, and Kerberos. The `NO-SHA1` sub-policy goes further by disabling it in additional contexts.

**Fedora 41 completed full SHA-1 distrust** — [Fedora 41](https://discussion.fedoraproject.org/t/f41-change-proposal-make-openssl-distrust-sha-1-signatures-by-default-system-wide/119457) made OpenSSL distrust SHA-1 signatures by default. This will flow downstream to RHEL 10, making RHCOS-specific overrides unnecessary on future versions.

**Risk of breaking third-party integrations** — Forcing `NO-SHA1` at the base image level can break applications and services that still rely on SHA-1 signed certificates. Red Hat documents this as a [known compatibility concern](https://access.redhat.com/solutions/7088966). Crypto policy changes should be a conscious deployment decision, not a base image default.

**rhel-coreos-config maintainer pattern** — The maintainers prefer accepting RHEL defaults and pushing changes at the Fedora/RHEL level rather than carrying RHCOS-specific overrides ([PR #264](https://github.com/coreos/rhel-coreos-config/pull/264) established this pattern).

Until RHEL 10 inherits full SHA-1 distrust from Fedora 41, this MachineConfig remediation is needed for E8 compliance on current OCP versions.

</details>

## Files

- `75-crypto-policy-high-master.yaml`
- `75-crypto-policy-high-worker.yaml`

## Verification

After applying to a cluster, verify with:
```bash
oc debug node/<node> -- chroot /host update-crypto-policies --show
# Expected: DEFAULT:NO-SHA1
```

Compliance scan verification:
```bash
oc get compliancecheckresult -n openshift-compliance | grep configure-crypto-policy
# Expected: PASS
```

## References

- Group detail: [H1: Crypto Policy](https://sebrandon1.github.io/compliance-scripts/versions/4.22/groups/H1.html)
- Story: [CNF-21212](https://redhat.atlassian.net/browse/CNF-21212)
- Epic: [CNF-22573](https://redhat.atlassian.net/browse/CNF-22573) (RAN Hardening for 5.0)
