### PR TITLE
CNF-21196: RAN Hardening (5.0) - Kernel Sysctl Hardening (M2)

### DIFF
--- a/telco-ran/configuration/kube-compare-reference/informational/hardening/75-sysctl-kernel-hardening-master.yaml
+++ b/telco-ran/configuration/kube-compare-reference/informational/hardening/75-sysctl-kernel-hardening-master.yaml
@@ -1,0 +1,24 @@
+apiVersion: machineconfiguration.openshift.io/v1
+kind: MachineConfig
+metadata:
+  name: 75-sysctl-kernel-hardening-master
+  labels:
+    machineconfiguration.openshift.io/role: master
+spec:
+  config:
+    ignition:
+      version: 3.5.0
+    storage:
+      files:
+      - path: /etc/sysctl.d/75-kernel-hardening.conf
+        mode: 420
+        overwrite: true
+        contents:
+          # # Memory protection - Full ASLR
+          # kernel.randomize_va_space = 2
+          # # BPF security - Prevent privilege escalation
+          # kernel.unprivileged_bpf_disabled = 1
+          # net.core.bpf_jit_harden = 2
+          # # Process tracing restriction
+          # kernel.yama.ptrace_scope = 1
+          source: data:text/plain,%23%20MEDIUM%20Severity%20Kernel%20Hardening%20%28E8%20Compliance%29%0A%23%20Documentation%3A%20https%3A%2F%2Fsebrandon1.github.io%2Fcompliance-scripts%2Fversions%2F4.21%2Fgroups%2FM2.html%0A%0A%23%20Memory%20protection%20-%20Full%20ASLR%0Akernel.randomize_va_space%20%3D%202%0A%0A%23%20BPF%20security%20-%20Prevent%20privilege%20escalation%0Akernel.unprivileged_bpf_disabled%20%3D%201%0Anet.core.bpf_jit_harden%20%3D%202%0A%0A%23%20Process%20tracing%20restriction%0Akernel.yama.ptrace_scope%20%3D%201%0A

--- a/telco-ran/configuration/kube-compare-reference/informational/hardening/75-sysctl-kernel-hardening-worker.yaml
+++ b/telco-ran/configuration/kube-compare-reference/informational/hardening/75-sysctl-kernel-hardening-worker.yaml
@@ -1,0 +1,24 @@
+apiVersion: machineconfiguration.openshift.io/v1
+kind: MachineConfig
+metadata:
+  name: 75-sysctl-kernel-hardening-worker
+  labels:
+    machineconfiguration.openshift.io/role: worker
+spec:
+  config:
+    ignition:
+      version: 3.5.0
+    storage:
+      files:
+      - path: /etc/sysctl.d/75-kernel-hardening.conf
+        mode: 420
+        overwrite: true
+        contents:
+          # # Memory protection - Full ASLR
+          # kernel.randomize_va_space = 2
+          # # BPF security - Prevent privilege escalation
+          # kernel.unprivileged_bpf_disabled = 1
+          # net.core.bpf_jit_harden = 2
+          # # Process tracing restriction
+          # kernel.yama.ptrace_scope = 1
+          source: data:text/plain,%23%20MEDIUM%20Severity%20Kernel%20Hardening%20%28E8%20Compliance%29%0A%23%20Documentation%3A%20https%3A%2F%2Fsebrandon1.github.io%2Fcompliance-scripts%2Fversions%2F4.21%2Fgroups%2FM2.html%0A%0A%23%20Memory%20protection%20-%20Full%20ASLR%0Akernel.randomize_va_space%20%3D%202%0A%0A%23%20BPF%20security%20-%20Prevent%20privilege%20escalation%0Akernel.unprivileged_bpf_disabled%20%3D%201%0Anet.core.bpf_jit_harden%20%3D%202%0A%0A%23%20Process%20tracing%20restriction%0Akernel.yama.ptrace_scope%20%3D%201%0A


### PR DESCRIPTION
## Summary

Adds MachineConfig to apply kernel sysctl hardening settings on both master and worker nodes.

This addresses MEDIUM severity E8 compliance checks for kernel parameter hardening including address space layout randomization, core dump restrictions, and related security sysctls.

- Deploys sysctl configuration via MachineConfig
- Separate master and worker MachineConfig files

## Sysctl Settings

| Setting | Value | Purpose |
|---------|-------|---------|
| `kernel.randomize_va_space` | `2` | Full ASLR — randomize stack, VDSO, shared memory, and data segments |
| `kernel.unprivileged_bpf_disabled` | `1` | Prevent unprivileged BPF access to mitigate privilege escalation |
| `net.core.bpf_jit_harden` | `2` | Harden BPF JIT compiler against spraying attacks for all users |
| `kernel.yama.ptrace_scope` | `1` | Restrict ptrace to parent-child process relationships |

<details>
<summary>Why these settings are not upstreamed into the RHCOS base image</summary>

We evaluated upstreaming each of these settings into [coreos/rhel-coreos-config](https://github.com/coreos/rhel-coreos-config) and opened [PR #264](https://github.com/coreos/rhel-coreos-config/pull/264). It was closed with the following feedback:

**`kernel.randomize_va_space=2`** — Already the kernel default. No override needed at the RHCOS level.

**`kernel.unprivileged_bpf_disabled=1`** — Already defaults to `2` (disabled) via `BPF_UNPRIV_DEFAULT_OFF` in modern kernels. No RHCOS-specific override needed.

**`net.core.bpf_jit_harden=2`** — Maintainer prefers accepting RHEL defaults and pushing changes at the Fedora/RHEL level. A [Fedora 44 Change Proposal](https://www.mail-archive.com/devel@lists.fedoraproject.org/msg209291.html) changed `bpf_jit_harden` from `0` to `2` by default — this may flow downstream to RHEL 10, making the RHCOS override unnecessary.

**`kernel.yama.ptrace_scope=1`** — The kernel default is already `1`, but the `elfutils` RPM overrides it to `0` via `/usr/lib/sysctl.d/10-default-yama-scope.conf`. The same Fedora 44 Change Proposal changed `ptrace_scope` from `1` to `2` by default. Maintainer position: accept RHEL defaults rather than carry RHCOS-specific overrides.

Until these Fedora/RHEL default changes propagate to the RHCOS base image, this MachineConfig remediation is needed for compliance on current OCP versions.

</details>

## Files

- `75-sysctl-kernel-hardening-master.yaml`
- `75-sysctl-kernel-hardening-worker.yaml`

## Verification

After applying to a cluster, verify with:
```bash
oc debug node/<node> -- chroot /host sysctl \
  kernel.randomize_va_space \
  kernel.unprivileged_bpf_disabled \
  net.core.bpf_jit_harden \
  kernel.yama.ptrace_scope
```

Expected output:
```
kernel.randomize_va_space = 2
kernel.unprivileged_bpf_disabled = 1
net.core.bpf_jit_harden = 2
kernel.yama.ptrace_scope = 1
```

Compliance scan verification:
```bash
oc get compliancecheckresult -n openshift-compliance | grep sysctl-kernel
# Expected: PASS
```

## References

- Group detail: [M2: Kernel Hardening (Sysctl)](https://sebrandon1.github.io/compliance-scripts/versions/4.22/groups/M2.html)
- Story: [CNF-21196](https://redhat.atlassian.net/browse/CNF-21196)
- Epic: [CNF-22573](https://redhat.atlassian.net/browse/CNF-22573) (RAN Hardening for 5.0)
