### PR TITLE
CNF-23448: RAN Hardening (5.0) - Audit Kernel Modules (M5)

### DIFF
--- a/telco-ran/configuration/kube-compare-reference/informational/hardening/75-audit-kernel-modules-master.yaml
+++ b/telco-ran/configuration/kube-compare-reference/informational/hardening/75-audit-kernel-modules-master.yaml
@@ -1,0 +1,17 @@
+apiVersion: machineconfiguration.openshift.io/v1
+kind: MachineConfig
+metadata:
+  name: 75-audit-kernel-modules-master
+  labels:
+    machineconfiguration.openshift.io/role: master
+spec:
+  config:
+    ignition:
+      version: 3.2.0
+    storage:
+      files:
+      - path: /etc/audit/rules.d/75-kernel-modules.rules
+        mode: 420
+        overwrite: true
+        contents:
+          source: data:text/plain,%23%20M5%3A%20Audit%20Kernel%20Module%20Loading%20%28E8%20Compliance%29%0A%23%20Documentation%3A%20https%3A%2F%2Fsebrandon1.github.io%2Fcompliance-scripts%2Fversions%2F4.22%2Fgroups%2FM5.html%0A%0A%23%20Module%20loading%0A-a%20always%2Cexit%20-F%20arch%3Db64%20-S%20init_module%20-S%20finit_module%20-k%20module_load%0A-a%20always%2Cexit%20-F%20arch%3Db32%20-S%20init_module%20-S%20finit_module%20-k%20module_load%0A%0A%23%20Module%20unloading%0A-a%20always%2Cexit%20-F%20arch%3Db64%20-S%20delete_module%20-k%20module_unload%0A-a%20always%2Cexit%20-F%20arch%3Db32%20-S%20delete_module%20-k%20module_unload%0A

--- a/telco-ran/configuration/kube-compare-reference/informational/hardening/75-audit-kernel-modules-worker.yaml
+++ b/telco-ran/configuration/kube-compare-reference/informational/hardening/75-audit-kernel-modules-worker.yaml
@@ -1,0 +1,17 @@
+apiVersion: machineconfiguration.openshift.io/v1
+kind: MachineConfig
+metadata:
+  name: 75-audit-kernel-modules-worker
+  labels:
+    machineconfiguration.openshift.io/role: worker
+spec:
+  config:
+    ignition:
+      version: 3.2.0
+    storage:
+      files:
+      - path: /etc/audit/rules.d/75-kernel-modules.rules
+        mode: 420
+        overwrite: true
+        contents:
+          source: data:text/plain,%23%20M5%3A%20Audit%20Kernel%20Module%20Loading%20%28E8%20Compliance%29%0A%23%20Documentation%3A%20https%3A%2F%2Fsebrandon1.github.io%2Fcompliance-scripts%2Fversions%2F4.22%2Fgroups%2FM5.html%0A%0A%23%20Module%20loading%0A-a%20always%2Cexit%20-F%20arch%3Db64%20-S%20init_module%20-S%20finit_module%20-k%20module_load%0A-a%20always%2Cexit%20-F%20arch%3Db32%20-S%20init_module%20-S%20finit_module%20-k%20module_load%0A%0A%23%20Module%20unloading%0A-a%20always%2Cexit%20-F%20arch%3Db64%20-S%20delete_module%20-k%20module_unload%0A-a%20always%2Cexit%20-F%20arch%3Db32%20-S%20delete_module%20-k%20module_unload%0A


### PR DESCRIPTION
## Summary

Adds MachineConfig to deploy audit rules for kernel module loading and unloading events on both master and worker nodes.

This addresses MEDIUM severity E8 compliance checks for auditing `init_module`, `finit_module`, and `delete_module` syscalls, ensuring all kernel module operations are recorded.

- Deploys audit rules via MachineConfig
- Separate master and worker MachineConfig files

## Files

- `75-audit-kernel-modules-master.yaml`
- `75-audit-kernel-modules-worker.yaml`

## Verification

After applying to a cluster, verify with:
```bash
oc debug node/<node> -- chroot /host auditctl -l | grep -E "init_module|delete_module"
# Expected: audit rules for module syscalls
```

Compliance scan verification:
```bash
oc get compliancecheckresult -n openshift-compliance | grep audit-rules-kernel-module
# Expected: PASS
```

## Jira

- Story: [CNF-23448](https://redhat.atlassian.net/browse/CNF-23448)
- Epic: [CNF-22573](https://redhat.atlassian.net/browse/CNF-22573) (RAN Hardening for 5.0)