### PR TITLE
CNF-23574: Bump ZTP images from RHEL8 to RHEL9

### DIFF
--- a/telco-hub/configuration/example-overlays-config/acm/acmMirrorRegistryCM-patch.yaml
+++ b/telco-hub/configuration/example-overlays-config/acm/acmMirrorRegistryCM-patch.yaml
@@ -78,14 +78,6 @@
 
     [[registry]]
       prefix = ""
-      location = "registry.redhat.io/rhel8"
-
-      [[registry.mirror]]
-        location = "<registry.example.com:8443>/rhel8"
-        pull-from-mirror = "digest-only"
-
-    [[registry]]
-      prefix = ""
       location = "registry.redhat.io/rhel9"
 
       [[registry.mirror]]
@@ -98,14 +90,6 @@
 
       [[registry.mirror]]
         location = "<registry.example.com:8443>/ubi9"
-        pull-from-mirror = "tag-only"
-
-    [[registry]]
-      prefix = ""
-      location = "registry.redhat.io/ubi8"
-
-      [[registry.mirror]]
-        location = "<registry.example.com:8443>/ubi8"
         pull-from-mirror = "tag-only"
 
     [[registry]]

--- a/telco-hub/configuration/example-overlays-config/registry/idms-operator-mirrors-patch.yaml
+++ b/telco-hub/configuration/example-overlays-config/registry/idms-operator-mirrors-patch.yaml
@@ -9,9 +9,6 @@
     - <registry.example.com:8443>/multicluster-engine
     source: registry.redhat.io/multicluster-engine
   - mirrors:
-    - <registry.example.com:8443>/rhel8
-    source: registry.redhat.io/rhel8
-  - mirrors:
     - <registry.example.com:8443>/odf4
     source: registry.redhat.io/odf4
   - mirrors:

--- a/telco-hub/configuration/example-overlays-config/registry/itms-generic-mirrors-patch.yaml
+++ b/telco-hub/configuration/example-overlays-config/registry/itms-generic-mirrors-patch.yaml
@@ -3,17 +3,11 @@
   path: /spec/imageTagMirrors
   value:
   - mirrors:
-    - <registry.example.com:8443>/ubi8
-    source: registry.redhat.io/ubi8
-  - mirrors:
     - <registry.example.com:8443>/ubi9
     source: registry.redhat.io/ubi9
   - mirrors:
     - <registry.example.com:8443>/openshift5
     source: registry.redhat.io/openshift5
-  - mirrors:
-    - <registry.example.com:8443>/rhel8
-    source: registry.redhat.io/rhel8
   - mirrors:
     - <registry.example.com:8443>/rhel9
     source: registry.redhat.io/rhel9

--- a/telco-hub/configuration/example-overlays-config/registry/itms-generic-mirrors-patch.yaml
+++ b/telco-hub/configuration/example-overlays-config/registry/itms-generic-mirrors-patch.yaml
@@ -6,8 +6,14 @@
     - <registry.example.com:8443>/ubi8
     source: registry.redhat.io/ubi8
   - mirrors:
+    - <registry.example.com:8443>/ubi9
+    source: registry.redhat.io/ubi9
+  - mirrors:
     - <registry.example.com:8443>/openshift5
     source: registry.redhat.io/openshift5
   - mirrors:
     - <registry.example.com:8443>/rhel8
     source: registry.redhat.io/rhel8
+  - mirrors:
+    - <registry.example.com:8443>/rhel9
+    source: registry.redhat.io/rhel9

--- a/telco-hub/configuration/reference-crs-kube-compare/default_value.yaml
+++ b/telco-hub/configuration/reference-crs-kube-compare/default_value.yaml
@@ -275,6 +275,12 @@ required_acm_acmMirrorRegistryCM:
         [[registry.mirror]]
           location = "<registry.example.com:8443>/ubi8"
           pull-from-mirror = "tag-only"
+      [[registry]]
+        prefix = ""
+        location = "registry.redhat.io/ubi9"
+        [[registry.mirror]]
+          location = "<registry.example.com:8443>/ubi9"
+          pull-from-mirror = "tag-only"
 
 required_acm_observabilitySecret:
 - data:
@@ -427,11 +433,17 @@ required_registry_itms_generic:
         - <registry.example.com:8443>/ubi8
         source: registry.redhat.io/ubi8
       - mirrors:
+        - <registry.example.com:8443>/ubi9
+        source: registry.redhat.io/ubi9
+      - mirrors:
         - <registry.example.com:8443>/openshift5
         source: registry.redhat.io/openshift5
       - mirrors:
         - <registry.example.com:8443>/rhel8
         source: registry.redhat.io/rhel8
+      - mirrors:
+        - <registry.example.com:8443>/rhel9
+        source: registry.redhat.io/rhel9
 
 required_registry_itms_release:
 - spec:

--- a/telco-hub/configuration/reference-crs-kube-compare/default_value.yaml
+++ b/telco-hub/configuration/reference-crs-kube-compare/default_value.yaml
@@ -259,22 +259,10 @@ required_acm_acmMirrorRegistryCM:
           pull-from-mirror = "digest-only"
       [[registry]]
         prefix = ""
-        location = "registry.redhat.io/rhel8"
-        [[registry.mirror]]
-          location = "<registry.example.com:8443>/rhel8"
-          pull-from-mirror = "digest-only"
-      [[registry]]
-        prefix = ""
         location = "registry.redhat.io/rhel9"
         [[registry.mirror]]
           location = "<registry.example.com:8443>/rhel9"
           pull-from-mirror = "digest-only"
-      [[registry]]
-        prefix = ""
-        location = "registry.redhat.io/ubi8"
-        [[registry.mirror]]
-          location = "<registry.example.com:8443>/ubi8"
-          pull-from-mirror = "tag-only"
       [[registry]]
         prefix = ""
         location = "registry.redhat.io/ubi9"
@@ -376,9 +364,6 @@ required_registry_idms_operator:
         - <registry.example.com:8443>/multicluster-engine
         source: registry.redhat.io/multicluster-engine
       - mirrors:
-        - <registry.example.com:8443>/rhel8
-        source: registry.redhat.io/rhel8
-      - mirrors:
         - <registry.example.com:8443>/odf4
         source: registry.redhat.io/odf4
       - mirrors:
@@ -430,17 +415,11 @@ required_registry_itms_generic:
 - spec:
     imageTagMirrors:
       - mirrors:
-        - <registry.example.com:8443>/ubi8
-        source: registry.redhat.io/ubi8
-      - mirrors:
         - <registry.example.com:8443>/ubi9
         source: registry.redhat.io/ubi9
       - mirrors:
         - <registry.example.com:8443>/openshift5
         source: registry.redhat.io/openshift5
-      - mirrors:
-        - <registry.example.com:8443>/rhel8
-        source: registry.redhat.io/rhel8
       - mirrors:
         - <registry.example.com:8443>/rhel9
         source: registry.redhat.io/rhel9

--- a/telco-hub/configuration/reference-crs/required/acm/acmMirrorRegistryCM.yaml
+++ b/telco-hub/configuration/reference-crs/required/acm/acmMirrorRegistryCM.yaml
@@ -77,22 +77,10 @@ data:
         pull-from-mirror = "digest-only"
     [[registry]]
       prefix = ""
-      location = "registry.redhat.io/rhel8"
-      [[registry.mirror]]
-        location = "<registry.example.com:8443>/rhel8"
-        pull-from-mirror = "digest-only"
-    [[registry]]
-      prefix = ""
       location = "registry.redhat.io/rhel9"
       [[registry.mirror]]
         location = "<registry.example.com:8443>/rhel9"
         pull-from-mirror = "digest-only"
-    [[registry]]
-      prefix = ""
-      location = "registry.redhat.io/ubi8"
-      [[registry.mirror]]
-        location = "<registry.example.com:8443>/ubi8"
-        pull-from-mirror = "tag-only"
     [[registry]]
       prefix = ""
       location = "registry.redhat.io/ubi9"

--- a/telco-hub/configuration/reference-crs/required/acm/acmMirrorRegistryCM.yaml
+++ b/telco-hub/configuration/reference-crs/required/acm/acmMirrorRegistryCM.yaml
@@ -93,3 +93,9 @@ data:
       [[registry.mirror]]
         location = "<registry.example.com:8443>/ubi8"
         pull-from-mirror = "tag-only"
+    [[registry]]
+      prefix = ""
+      location = "registry.redhat.io/ubi9"
+      [[registry.mirror]]
+        location = "<registry.example.com:8443>/ubi9"
+        pull-from-mirror = "tag-only"

--- a/telco-hub/configuration/reference-crs/required/gitops/addPluginsPolicy.yaml
+++ b/telco-hub/configuration/reference-crs/required/gitops/addPluginsPolicy.yaml
@@ -75,7 +75,7 @@ spec:
                             mountPath: "/.config"
                         terminationMessagePolicy: "File"
                         terminationMessagePath: "/dev/termination-log"
-                        image: "registry.redhat.io/openshift4/ztp-site-generate-rhel8:v4.22"
+                        image: "registry.redhat.io/openshift4/ztp-site-generate-rhel9:v4.22"
                       - name: "policy-generator-install"
                         image: "registry.redhat.io/rhacm2/multicluster-operators-subscription-rhel9:v2.17"
                         imagePullPolicy: "Always"

--- a/telco-hub/configuration/reference-crs/required/gitops/addPluginsPolicy.yaml
+++ b/telco-hub/configuration/reference-crs/required/gitops/addPluginsPolicy.yaml
@@ -75,7 +75,7 @@ spec:
                             mountPath: "/.config"
                         terminationMessagePolicy: "File"
                         terminationMessagePath: "/dev/termination-log"
-                        image: "registry.redhat.io/openshift5/ztp-site-generate-rhel8:v5.0"
+                        image: "registry.redhat.io/openshift5/ztp-site-generate-rhel9:v5.0"
                       - name: "policy-generator-install"
                         image: "registry.redhat.io/rhacm2/multicluster-operators-subscription-rhel9:v2.17"
                         imagePullPolicy: "Always"

--- a/telco-hub/configuration/reference-crs/required/gitops/get_ztp_installation.sh
+++ b/telco-hub/configuration/reference-crs/required/gitops/get_ztp_installation.sh
@@ -4,8 +4,8 @@
 # once per each Minor version.
 
 #CURRENT_OCP_VERSION=4.18
-#ZTP_SITE_GENERATE_IMAGE=ztp-site-generate-rhel8:v${CURRENT_OCP_VERSION}
-#podman run --log-driver=none --rm registry.redhat.io/openshift4/${ZTP_SITE_GENERATE_IMAGE=ztp-site-generate-rhel8} extract /home/ztp/argocd/deployment --tar | tar x -C "ztp-installation"
+#ZTP_SITE_GENERATE_IMAGE=ztp-site-generate-rhel9:v${CURRENT_OCP_VERSION}
+#podman run --log-driver=none --rm registry.redhat.io/openshift4/${ZTP_SITE_GENERATE_IMAGE=ztp-site-generate-rhel9} extract /home/ztp/argocd/deployment --tar | tar x -C "ztp-installation"
 
 rm ztp-installation/*
 cp ../../../../../telco-ran/configuration/argocd/deployment/* ztp-installation/
@@ -21,7 +21,7 @@ find ./ztp-installation/ -name "*.yaml" -exec yq -i eval '.metadata.annotations.
 
 # patch the ztp-site-generate version
 echo " - Patch ztp-site-generate version"
-sed -i 's|quay.io/openshift-kni/ztp-site-generator:latest|registry.redhat.io/openshift4/ztp-site-generate-rhel8:v4.21|g' ztp-installation/argocd-openshift-gitops-patch.json
+sed -i 's|quay.io/openshift-kni/ztp-site-generator:latest|registry.redhat.io/openshift4/ztp-site-generate-rhel9:v4.22|g' ztp-installation/argocd-openshift-gitops-patch.json
 
 echo  " - Adding elements to the whitelist"
 yq '.spec.namespaceResourceWhitelist += {"group": "'metal3.io'", "kind": "DataImage"}' ztp-installation/app-project.yaml

--- a/telco-hub/configuration/reference-crs/required/gitops/get_ztp_installation.sh
+++ b/telco-hub/configuration/reference-crs/required/gitops/get_ztp_installation.sh
@@ -10,8 +10,8 @@ fi
 # once per each Minor version.
 
 #CURRENT_OCP_VERSION=4.18
-#ZTP_SITE_GENERATE_IMAGE=ztp-site-generate-rhel8:v${CURRENT_OCP_VERSION}
-#podman run --log-driver=none --rm registry.redhat.io/openshift4/${ZTP_SITE_GENERATE_IMAGE=ztp-site-generate-rhel8} extract /home/ztp/argocd/deployment --tar | tar x -C "ztp-installation"
+#ZTP_SITE_GENERATE_IMAGE=ztp-site-generate-rhel9:v${CURRENT_OCP_VERSION}
+#podman run --log-driver=none --rm registry.redhat.io/openshift4/${ZTP_SITE_GENERATE_IMAGE=ztp-site-generate-rhel9} extract /home/ztp/argocd/deployment --tar | tar x -C "ztp-installation"
 
 rm ztp-installation/*
 cp ../../../../../telco-ran/configuration/argocd/deployment/* ztp-installation/
@@ -27,7 +27,7 @@ find ./ztp-installation/ -name "*.yaml" -exec yq -i eval '.metadata.annotations.
 
 # patch the ztp-site-generate version
 echo " - Patch ztp-site-generate version"
-sedi 's|quay.io/openshift-kni/ztp-site-generator:latest|registry.redhat.io/openshift4/ztp-site-generate-rhel8:v4.21|g' ztp-installation/argocd-openshift-gitops-patch.json
+sedi 's|quay.io/openshift-kni/ztp-site-generator:latest|registry.redhat.io/openshift4/ztp-site-generate-rhel9:v4.22|g' ztp-installation/argocd-openshift-gitops-patch.json
 
 echo  " - Adding elements to the whitelist"
 yq '.spec.namespaceResourceWhitelist += {"group": "'metal3.io'", "kind": "DataImage"}' ztp-installation/app-project.yaml

--- a/telco-hub/configuration/reference-crs/required/gitops/get_ztp_installation.sh
+++ b/telco-hub/configuration/reference-crs/required/gitops/get_ztp_installation.sh
@@ -9,9 +9,9 @@ fi
 # This script is only needed to create the ztp-installation manifest
 # once per each Minor version.
 
-#CURRENT_OCP_VERSION=4.18
+#CURRENT_OCP_VERSION=5.0
 #ZTP_SITE_GENERATE_IMAGE=ztp-site-generate-rhel9:v${CURRENT_OCP_VERSION}
-#podman run --log-driver=none --rm registry.redhat.io/openshift4/${ZTP_SITE_GENERATE_IMAGE=ztp-site-generate-rhel9} extract /home/ztp/argocd/deployment --tar | tar x -C "ztp-installation"
+#podman run --log-driver=none --rm registry.redhat.io/openshift5/${ZTP_SITE_GENERATE_IMAGE=ztp-site-generate-rhel9} extract /home/ztp/argocd/deployment --tar | tar x -C "ztp-installation"
 
 rm ztp-installation/*
 cp ../../../../../telco-ran/configuration/argocd/deployment/* ztp-installation/
@@ -27,7 +27,7 @@ find ./ztp-installation/ -name "*.yaml" -exec yq -i eval '.metadata.annotations.
 
 # patch the ztp-site-generate version
 echo " - Patch ztp-site-generate version"
-sedi 's|quay.io/openshift-kni/ztp-site-generator:latest|registry.redhat.io/openshift4/ztp-site-generate-rhel9:v4.22|g' ztp-installation/argocd-openshift-gitops-patch.json
+sedi 's|quay.io/openshift-kni/ztp-site-generator:latest|registry.redhat.io/openshift5/ztp-site-generate-rhel9:v5.0|g' ztp-installation/argocd-openshift-gitops-patch.json
 
 echo  " - Adding elements to the whitelist"
 yq '.spec.namespaceResourceWhitelist += {"group": "'metal3.io'", "kind": "DataImage"}' ztp-installation/app-project.yaml

--- a/telco-hub/configuration/reference-crs/required/registry/idms-operator.yaml
+++ b/telco-hub/configuration/reference-crs/required/registry/idms-operator.yaml
@@ -18,9 +18,6 @@ spec:
     - <registry.example.com:8443>/multicluster-engine
     source: registry.redhat.io/multicluster-engine
   - mirrors:
-    - <registry.example.com:8443>/rhel8
-    source: registry.redhat.io/rhel8
-  - mirrors:
     - <registry.example.com:8443>/odf4
     source: registry.redhat.io/odf4
   - mirrors:

--- a/telco-hub/configuration/reference-crs/required/registry/itms-generic.yaml
+++ b/telco-hub/configuration/reference-crs/required/registry/itms-generic.yaml
@@ -12,17 +12,11 @@ metadata:
 spec:
   imageTagMirrors:
   - mirrors:
-    - <registry.example.com:8443>/ubi8
-    source: registry.redhat.io/ubi8
-  - mirrors:
     - <registry.example.com:8443>/ubi9
     source: registry.redhat.io/ubi9
   - mirrors:
     - <registry.example.com:8443>/openshift5
     source: registry.redhat.io/openshift5
-  - mirrors:
-    - <registry.example.com:8443>/rhel8
-    source: registry.redhat.io/rhel8
   - mirrors:
     - <registry.example.com:8443>/rhel9
     source: registry.redhat.io/rhel9

--- a/telco-hub/configuration/reference-crs/required/registry/itms-generic.yaml
+++ b/telco-hub/configuration/reference-crs/required/registry/itms-generic.yaml
@@ -15,8 +15,14 @@ spec:
     - <registry.example.com:8443>/ubi8
     source: registry.redhat.io/ubi8
   - mirrors:
+    - <registry.example.com:8443>/ubi9
+    source: registry.redhat.io/ubi9
+  - mirrors:
     - <registry.example.com:8443>/openshift5
     source: registry.redhat.io/openshift5
   - mirrors:
     - <registry.example.com:8443>/rhel8
     source: registry.redhat.io/rhel8
+  - mirrors:
+    - <registry.example.com:8443>/rhel9
+    source: registry.redhat.io/rhel9

--- a/telco-hub/install/mirror-registry/imageset-config.yaml
+++ b/telco-hub/install/mirror-registry/imageset-config.yaml
@@ -102,8 +102,8 @@ mirror:
       channels:
       - name: stable-v1
   additionalImages:
-  - name: registry.redhat.io/ubi8/ubi:latest
-  - name: registry.redhat.io/openshift4/ztp-site-generate-rhel8:v4.22
-  - name: registry.redhat.io/rhel8/support-tools:latest
+  - name: registry.redhat.io/ubi9/ubi:latest
+  - name: registry.redhat.io/openshift4/ztp-site-generate-rhel9:v4.22
+  - name: registry.redhat.io/rhel9/support-tools:latest
   - name: registry.redhat.io/rhacm2/multicluster-operators-subscription-rhel9:v2.17.0-1
   helm: {}

--- a/telco-hub/install/mirror-registry/imageset-config.yaml
+++ b/telco-hub/install/mirror-registry/imageset-config.yaml
@@ -102,8 +102,8 @@ mirror:
       channels:
       - name: stable-v1
   additionalImages:
-  - name: registry.redhat.io/ubi8/ubi:latest
-  - name: registry.redhat.io/openshift5/ztp-site-generate-rhel8:v5.0
-  - name: registry.redhat.io/rhel8/support-tools:latest
+  - name: registry.redhat.io/ubi9/ubi:latest
+  - name: registry.redhat.io/openshift5/ztp-site-generate-rhel9:v5.0
+  - name: registry.redhat.io/rhel9/support-tools:latest
   - name: registry.redhat.io/rhacm2/multicluster-operators-subscription-rhel9:v2.17.0-1
   helm: {}


### PR DESCRIPTION
Update ztp-site-generate image from rhel8 to rhel9 for v5.0 in addPluginsPolicy, imageset-config, and get_ztp_installation script. Also update ubi8 and rhel8 support-tools additional images to their RHEL9 equivalents in the mirror registry imageset configuration.