### PR TITLE
Add ShellCheck GitHub Actions workflow

### DIFF
--- a/.github/workflows/shellcheck.yml
+++ b/.github/workflows/shellcheck.yml
@@ -18,7 +18,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          persist-credentials: false
 
       - name: Run ShellCheck
         run: make test-shellcheck

--- a/.github/workflows/shellcheck.yml
+++ b/.github/workflows/shellcheck.yml
@@ -1,0 +1,28 @@
+---
+name: ShellCheck
+
+on:
+  pull_request:
+    branches:
+      - main
+    paths:
+      - "**/*.sh"
+
+permissions:
+  contents: read
+
+jobs:
+  shellcheck:
+    name: Validate Shell Scripts
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Run ShellCheck
+        run: |
+          find . -name '*.sh' \
+            -not -path './.git/*' \
+            -not -path './venv/*' \
+            -not -path './.venv/*' \
+            -print0 | xargs -0 shellcheck --severity=error

--- a/.github/workflows/shellcheck.yml
+++ b/.github/workflows/shellcheck.yml
@@ -1,0 +1,24 @@
+---
+name: ShellCheck
+
+on:
+  pull_request:
+    branches:
+      - main
+    paths:
+      - "**/*.sh"
+      - "Makefile"
+
+permissions:
+  contents: read
+
+jobs:
+  shellcheck:
+    name: Validate Shell Scripts
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Run ShellCheck
+        run: make test-shellcheck

--- a/Makefile
+++ b/Makefile
@@ -44,6 +44,13 @@ check-deps:
 		echo "✗ Missing (install from: https://go.dev/dl/)"; \
 		MISSING=$$((MISSING+1)); \
 	fi; \
+	echo -n "Checking shellcheck... "; \
+	if command -v shellcheck >/dev/null 2>&1; then \
+		echo "✓ Found: $$(shellcheck --version 2>&1 | grep version: | head -1)"; \
+	else \
+		echo "✗ Missing (install: brew install shellcheck or apt-get install shellcheck)"; \
+		MISSING=$$((MISSING+1)); \
+	fi; \
 	echo ""; \
 	if [ $$MISSING -eq 0 ]; then \
 		echo "✅ All dependencies are installed!"; \
@@ -115,6 +122,10 @@ ocp-doc-check:  ## Download and run ocp-doc-checker against markdown files
 
 test-kustomize:  ## Validate all kustomization.yaml files can build
 	./hack/test-kustomize.sh
+
+.PHONY: test-shellcheck
+test-shellcheck:  ## Validate shell scripts with shellcheck
+	./hack/test-shellcheck.sh
 
 ci-validate: lintCheck check-reference-core check-reference-ran check-reference-hub
 

--- a/hack/test-shellcheck.sh
+++ b/hack/test-shellcheck.sh
@@ -1,0 +1,61 @@
+#!/bin/bash
+
+set -e
+
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+YELLOW='\033[1;33m'
+NC='\033[0m'
+
+if ! command -v shellcheck &> /dev/null; then
+    echo -e "${RED}ERROR: shellcheck is not installed${NC}"
+    echo ""
+    echo "Please install shellcheck to run this check:"
+    echo "  - macOS: brew install shellcheck"
+    echo "  - Fedora/RHEL: dnf install ShellCheck"
+    echo "  - Ubuntu/Debian: apt-get install shellcheck"
+    echo "  - Manual: https://github.com/koalaman/shellcheck#installing"
+    echo ""
+    exit 1
+fi
+
+echo "Running ShellCheck on all shell scripts..."
+echo ""
+
+ERRORS=0
+CHECKED=0
+
+shell_files=()
+while IFS= read -r file; do
+    shell_files+=("$file")
+done < <(find . -name '*.sh' -not -path './.git/*' -not -path './venv/*' -not -path '*/.venv/*' -not -path './sdk-go/*' | sort)
+
+if [ ${#shell_files[@]} -eq 0 ]; then
+    echo -e "${YELLOW}WARNING: No shell scripts found${NC}"
+    exit 0
+fi
+
+for script in "${shell_files[@]}"; do
+    echo -n "  $script: "
+    CHECKED=$((CHECKED + 1))
+    output=$(shellcheck --severity=error "$script" 2>&1)
+    if [ $? -eq 0 ]; then
+        echo -e "${GREEN}OK${NC}"
+    else
+        echo -e "${RED}FAILED${NC}"
+        echo "$output" | sed 's/^/    /'
+        echo ""
+        ERRORS=$((ERRORS + 1))
+    fi
+done
+
+echo ""
+echo "Summary: Checked $CHECKED shell scripts"
+
+if [[ $ERRORS -eq 0 ]]; then
+    echo -e "${GREEN}All shell scripts passed ShellCheck!${NC}"
+    exit 0
+else
+    echo -e "${RED}$ERRORS script(s) failed ShellCheck${NC}"
+    exit 1
+fi

--- a/telco-ran/configuration/extra-manifests-builder/01-container-mount-ns-and-kubelet-conf/test.sh
+++ b/telco-ran/configuration/extra-manifests-builder/01-container-mount-ns-and-kubelet-conf/test.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 fatal() {
-    echo "FATAL: $@"
+    echo "FATAL: $*"
     exit 1
 }
 

--- a/telco-ran/configuration/extra-manifests-builder/08-set-rcu-normal/test.sh
+++ b/telco-ran/configuration/extra-manifests-builder/08-set-rcu-normal/test.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 fatal() {
-  echo "FATAL: $@"
+  echo "FATAL: $*"
   exit 1
 }
 


### PR DESCRIPTION
## Summary

- Add a `make test-shellcheck` target and `hack/test-shellcheck.sh` wrapper script following the same pattern as `make test-kustomize` / `hack/test-kustomize.sh`
- Add a GitHub Actions workflow that calls `make test-shellcheck` when PRs touch shell scripts or the Makefile
- Add `shellcheck` to the `make check-deps` dependency verification
- Fix 2 existing ShellCheck errors (SC2145: `$@` in echo strings changed to `$*`) in extra-manifests-builder test scripts
- Runs at `severity=error` to catch real bugs without blocking on style warnings

The repo has 32 shell scripts across hack/, extra-manifests-builder/, compare utilities, and configuration scripts. Users can now validate scripts locally with `make test-shellcheck` before pushing.