### PR TITLE
Fix macOS sed compatibility across all shell scripts

### DIFF
--- a/telco-core/configuration/compare.sh
+++ b/telco-core/configuration/compare.sh
@@ -1,5 +1,11 @@
 #! /bin/bash
 
+if sed --version 2>/dev/null | grep -q GNU; then
+  sedi() { sed -i "$@"; }
+else
+  sedi() { sed -i '' "$@"; }
+fi
+
 trap cleanup EXIT
 
 function cleanup() {
@@ -41,8 +47,8 @@ function compare_cr {
   while IFS= read -r file; do
     [[ ${file::1} != "#" ]] || continue # Skip any comment lines in the exclusionfile
     [[ -n ${file} ]] || continue # Skip empty lines
-    sed -i "/${file##*/}/d" source_file
-    sed -i "/${file##*/}/d" rendered_file
+    sedi "/${file##*/}/d" source_file
+    sedi "/${file##*/}/d" rendered_file
   done < <(cat same_file "$exclusionfile")
 
   if [[ -s source_file || -s rendered_file ]]; then

--- a/telco-hub/configuration/reference-crs-kube-compare/compare.sh
+++ b/telco-hub/configuration/reference-crs-kube-compare/compare.sh
@@ -1,5 +1,11 @@
 #! /bin/bash
 
+if sed --version 2>/dev/null | grep -q GNU; then
+  sedi() { sed -i "$@"; }
+else
+  sedi() { sed -i '' "$@"; }
+fi
+
 trap cleanup EXIT
 
 function cleanup() {
@@ -38,8 +44,8 @@ function compare_cr {
   while IFS= read -r file; do
     [[ ${file::1} != "#" ]] || continue # Skip any comment lines in the exclusionfile
     [[ -n ${file} ]] || continue # Skip empty lines
-    sed -i "/${file##*/}/d" source_file
-    sed -i "/${file##*/}/d" rendered_file
+    sedi "/${file##*/}/d" source_file
+    sedi "/${file##*/}/d" rendered_file
   done < "$exclusionfile"
 
   local source_cr rendered
@@ -65,8 +71,8 @@ function compare_cr {
   while IFS= read -r file; do
     [[ ${file::1} != "#" ]] || continue # Skip any comment lines in the exclusionfile
     [[ -n ${file} ]] || continue # Skip empty lines
-    sed -i "/${file##*/}/d" source_file
-    sed -i "/${file##*/}/d" rendered_file
+    sedi "/${file##*/}/d" source_file
+    sedi "/${file##*/}/d" rendered_file
   done < <(cat same_file "$exclusionfile")
 
   if [[ -s source_file || -s rendered_file ]]; then

--- a/telco-hub/configuration/reference-crs/required/gitops/get_ztp_installation.sh
+++ b/telco-hub/configuration/reference-crs/required/gitops/get_ztp_installation.sh
@@ -1,5 +1,11 @@
 #! /bin/bash
 
+if sed --version 2>/dev/null | grep -q GNU; then
+  sedi() { sed -i "$@"; }
+else
+  sedi() { sed -i '' "$@"; }
+fi
+
 # This script is only needed to create the ztp-installation manifest
 # once per each Minor version.
 
@@ -21,7 +27,7 @@ find ./ztp-installation/ -name "*.yaml" -exec yq -i eval '.metadata.annotations.
 
 # patch the ztp-site-generate version
 echo " - Patch ztp-site-generate version"
-sed -i 's|quay.io/openshift-kni/ztp-site-generator:latest|registry.redhat.io/openshift4/ztp-site-generate-rhel8:v4.21|g' ztp-installation/argocd-openshift-gitops-patch.json
+sedi 's|quay.io/openshift-kni/ztp-site-generator:latest|registry.redhat.io/openshift4/ztp-site-generate-rhel8:v4.21|g' ztp-installation/argocd-openshift-gitops-patch.json
 
 echo  " - Adding elements to the whitelist"
 yq '.spec.namespaceResourceWhitelist += {"group": "'metal3.io'", "kind": "DataImage"}' ztp-installation/app-project.yaml

--- a/telco-ran/configuration/hack/update_file_references.sh
+++ b/telco-ran/configuration/hack/update_file_references.sh
@@ -12,6 +12,12 @@
 
 set -euo pipefail
 
+if sed --version 2>/dev/null | grep -q GNU; then
+  sedi() { sed -i "$@"; }
+else
+  sedi() { sed -i '' "$@"; }
+fi
+
 if [[ ! -d "source-crs" ]]; then
   echo "Error: This script must be run from a directory containing 'source-crs' (e.g., the 'configuration' directory)." >&2
   exit 1
@@ -67,12 +73,12 @@ for source_file in "${source_files[@]}"; do
     # Choose the replacement strategy based on the file's content.
     if grep -q "source-crs/.*$file_name" "$target_file"; then
       # This file contains an incorrect 'source-crs' path. Fix it.
-      sed -i -e "s|source-crs/[^[:space:]\`[]*${escaped_file_name}|source-crs/$replacement_path|g" "$target_file"
+      sedi -e "s|source-crs/[^[:space:]\`[]*${escaped_file_name}|source-crs/$replacement_path|g" "$target_file"
     else
       # This file contains a different incorrect full path. Fix it.
       # This regex finds a path-like string ending in the filename.
       replacement_path=${replacement_path#%source-crs/}
-      sed -i -e "s|[^[:space:]\`[,]*${escaped_file_name}|${replacement_path}|g" "$target_file"
+      sedi -e "s|[^[:space:]\`[,]*${escaped_file_name}|${replacement_path}|g" "$target_file"
     fi
   done
 done


### PR DESCRIPTION
## Summary

- Add a portable `sedi()` wrapper function to all 4 shell scripts that use in-place sed editing
- Replace all `sed -i` invocations with `sedi` calls

### Problem

BSD sed (macOS) requires `sed -i '' 's/...'` (empty string as separate argument), while GNU sed (Linux) requires `sed -i 's/...'` (no separate argument). Using either form alone breaks the other platform. The previous `sed -i` calls worked on Linux CI but failed on macOS. Simply changing to `sed -i ''` (as attempted in the original version of this PR) fixes macOS but breaks Linux.

### Solution

A one-line wrapper detects sed flavor at runtime:
```bash
sedi() { sed --version 2>/dev/null | grep -q GNU && sed -i \"$@\" || sed -i '' \"$@\"; }
```

### Files fixed
- `telco-core/configuration/compare.sh` (2 sed calls)
- `telco-hub/configuration/reference-crs-kube-compare/compare.sh` (4 sed calls)
- `telco-hub/configuration/reference-crs/required/gitops/get_ztp_installation.sh` (1 sed call)
- `telco-ran/configuration/hack/update_file_references.sh` (2 sed calls)