### PR TITLE
OCPBUGS-84688: telco-ran: kernel boot param for Intel iavf early load

### DIFF
--- a/telco-ran/configuration/kube-compare-reference/node-tuning-operator/TunedPerformancePatch.yaml
+++ b/telco-ran/configuration/kube-compare-reference/node-tuning-operator/TunedPerformancePatch.yaml
@@ -43,6 +43,7 @@ spec:
         group.ice-dplls=0:f:10:*:ice-dplls.*
         [bootloader]
         cmdline_x86_blacklist=module_blacklist=irdma,mgag200
+        cmdline_x86_iavf=rd.driver.pre=iavf
         [sysctl]
         kernel.panic_on_unrecovered_nmi=1
   recommend:

--- a/telco-ran/configuration/source-crs/node-tuning-operator/TunedPerformancePatch.yaml
+++ b/telco-ran/configuration/source-crs/node-tuning-operator/TunedPerformancePatch.yaml
@@ -43,6 +43,7 @@ spec:
         group.ice-dplls=0:f:10:*:ice-dplls.*
         [bootloader]
         cmdline_x86_blacklist=module_blacklist=irdma,mgag200
+        cmdline_x86_iavf=rd.driver.pre=iavf
         [sysctl]
         kernel.panic_on_unrecovered_nmi=1
   recommend:


### PR DESCRIPTION
This PR adds a kernel boot parameter `rd.driver.pre=iavf` to load the Intel IAVF module to initramfs before other drivers. 