### PR TITLE
CNF-22981: Update renovate config to use allow-automatic-merge label

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -4,18 +4,28 @@
     "automergeType": "pr",
     "prConcurrentLimit": 0,
     "pruneBranchAfterAutomerge": true,
+    "packageRules": [
+        {
+            "addLabels": [
+                "allow-automatic-merge"
+            ],
+            "matchFileNames": [
+                "**/rpms.lock.yaml"
+            ]
+        }
+    ],
     "tekton": {
-        "autoApprove": true,
-        "automerge": true,
-        "enabled": true,
-        "managerFilePatterns": [
-            "/\\.yaml$/",
-            "/\\.yml$/"
+        "addLabels": [
+            "allow-automatic-merge"
         ],
+        "enabled": true,
         "ignoreTests": false,
         "includePaths": [
             ".tekton/**"
         ],
-        "platformAutomerge": true
+        "managerFilePatterns": [
+            "/\\.yaml$/",
+            "/\\.yml$/"
+        ]
     }
 }


### PR DESCRIPTION
Replace autoApprove/automerge/platformAutomerge options in tekton manager with addLabels for allow-automatic-merge. Add packageRule to label RPM lockfile update PRs for automatic merge.