### PR TITLE
telco-ran: update clusterinstance examples with cpuPartitioningMode

### DIFF
--- a/telco-ran/configuration/argocd/example/clusterinstance/example-3node.yaml
+++ b/telco-ran/configuration/argocd/example/clusterinstance/example-3node.yaml
@@ -14,6 +14,7 @@ spec:
   clusterName: "example-ai-3node"
   clusterType: HighlyAvailable  
   networkType: "OVNKubernetes"
+  cpuPartitioningMode: AllNodes
   # Include references to extraManifest ConfigMaps.
   extraManifestsRefs:
     - name: sno-extra-manifest-configmap

--- a/telco-ran/configuration/argocd/example/clusterinstance/example-standard.yaml
+++ b/telco-ran/configuration/argocd/example/clusterinstance/example-standard.yaml
@@ -14,6 +14,7 @@ spec:
   clusterName: "example-ai-standard"
   clusterType: HighlyAvailable  
   networkType: "OVNKubernetes"
+  cpuPartitioningMode: AllNodes
   # Include references to extraManifest ConfigMaps.
   extraManifestsRefs:
     - name: sno-extra-manifest-configmap


### PR DESCRIPTION
add cpu partitioning mode to clusterinstance examples
This is a manual 4.20 backport of https://github.com/openshift-kni/telco-reference/pull/544 without the doc change