### PR TITLE
[release-4.20] telco-hub: include missing obs-route-policy

### DIFF
--- a/telco-hub/configuration/reference-crs/required/acm/observabilityRoutePolicy.yaml
+++ b/telco-hub/configuration/reference-crs/required/acm/observabilityRoutePolicy.yaml
@@ -1,0 +1,85 @@
+---
+apiVersion: policy.open-cluster-management.io/v1
+kind: Policy
+metadata:
+  annotations:
+    policy.open-cluster-management.io/categories: CM Configuration Management
+    policy.open-cluster-management.io/controls: CM-2 Baseline Configuration
+    policy.open-cluster-management.io/standards: NIST SP 800-53
+    ran.openshift.io/ztp-deploy-wave: "1"
+  name: obs-route-policy
+  namespace: open-cluster-management-observability
+spec:
+  remediationAction: enforce
+  disabled: false
+  policy-templates:
+    - objectDefinition:
+        apiVersion: policy.open-cluster-management.io/v1
+        kind: ConfigurationPolicy
+        metadata:
+          name: obs-route-policy
+        spec:
+          remediationAction: enforce
+          severity: low
+          namespaceSelector:
+            exclude:
+              - kube-*
+            include:
+              - '*'
+          object-templates-raw: |
+            {{- $localCluster := (lookup "cluster.open-cluster-management.io/v1" "ManagedCluster" "" "local-cluster") }}
+            {{- $clusterID := index $localCluster.metadata.labels "clusterID" }}
+            {{- $hubID := $clusterID | replace "-" "" | trunc 19 }}
+            {{- range (lookup "cluster.open-cluster-management.io/v1" "ManagedCluster" "" "").items }}
+            - metadataComplianceType: musthave
+              objectDefinition:
+                apiVersion: cluster.open-cluster-management.io/v1
+                kind: ManagedCluster
+                metadata:
+                  name: {{ .metadata.name }}
+                  annotations:
+                    acm-alertmanager-route: '{{ (lookup "route.openshift.io/v1" "Route" "open-cluster-management-observability" "alertmanager").spec.host }}'
+                    acm-hub-cluster-id: '{{ $hubID }}'
+            {{- end }}
+---
+apiVersion: cluster.open-cluster-management.io/v1beta1
+kind: Placement
+metadata:
+  name: obs-route-policy-placement
+  namespace: open-cluster-management-observability
+spec:
+  predicates:
+    - requiredClusterSelector:
+        labelSelector:
+          matchExpressions:
+            - key: local-cluster
+              operator: In
+              values:
+                - "true"
+  tolerations:
+    - key: cluster.open-cluster-management.io/unavailable
+      operator: Exists
+    - key: cluster.open-cluster-management.io/unreachable
+      operator: Exists
+---
+apiVersion: policy.open-cluster-management.io/v1
+kind: PlacementBinding
+metadata:
+  name: obs-route-policy-placementbinding
+  namespace: open-cluster-management-observability
+placementRef:
+  name: obs-route-policy-placement
+  kind: Placement
+  apiGroup: cluster.open-cluster-management.io
+subjects:
+  - name: obs-route-policy
+    kind: Policy
+    apiGroup: policy.open-cluster-management.io
+---
+apiVersion: cluster.open-cluster-management.io/v1beta2
+kind: ManagedClusterSetBinding
+metadata:
+  name: default
+  namespace: open-cluster-management-observability
+spec:
+  clusterSet: default


### PR DESCRIPTION
This PR includes the observability route policy needed for retrieving ACM alerting URL in 4.20 branch