### PR TITLE
Remove invalid olm.operatorframework.io/bundle-install-timeout annotation

### DIFF
--- a/telco-core/configuration/reference-crs-kube-compare/optional/cert-manager/certManagerOperatorgroup.yaml
+++ b/telco-core/configuration/reference-crs-kube-compare/optional/cert-manager/certManagerOperatorgroup.yaml
@@ -3,7 +3,6 @@ apiVersion: operators.coreos.com/v1
 kind: OperatorGroup
 metadata:
   annotations:
-    olm.operatorframework.io/bundle-install-timeout: "10m"
     operatorframework.io/bundle-unpack-min-retry-interval: 10m
   name: cert-manager-operator
   namespace: cert-manager-operator

--- a/telco-core/configuration/reference-crs/optional/cert-manager/certManagerOperatorgroup.yaml
+++ b/telco-core/configuration/reference-crs/optional/cert-manager/certManagerOperatorgroup.yaml
@@ -3,7 +3,6 @@ apiVersion: operators.coreos.com/v1
 kind: OperatorGroup
 metadata:
   annotations:
-    olm.operatorframework.io/bundle-install-timeout: "10m"
     operatorframework.io/bundle-unpack-min-retry-interval: 10m
   name: cert-manager-operator
   namespace: cert-manager-operator

--- a/telco-hub/configuration/reference-crs-kube-compare/optional/cert-manager/certManagerOperatorgroup.yaml
+++ b/telco-hub/configuration/reference-crs-kube-compare/optional/cert-manager/certManagerOperatorgroup.yaml
@@ -4,7 +4,6 @@ kind: OperatorGroup
 metadata:
   annotations:
     argocd.argoproj.io/sync-wave: "-40"
-    olm.operatorframework.io/bundle-install-timeout: "10m"
     operatorframework.io/bundle-unpack-min-retry-interval: 10m
   name: cert-manager-operator
   namespace: cert-manager-operator

--- a/telco-hub/configuration/reference-crs/optional/cert-manager/certManagerOperatorgroup.yaml
+++ b/telco-hub/configuration/reference-crs/optional/cert-manager/certManagerOperatorgroup.yaml
@@ -4,7 +4,6 @@ kind: OperatorGroup
 metadata:
   annotations:
     argocd.argoproj.io/sync-wave: "-40"
-    olm.operatorframework.io/bundle-install-timeout: "10m"
     operatorframework.io/bundle-unpack-min-retry-interval: 10m
   name: cert-manager-operator
   namespace: cert-manager-operator

--- a/telco-ran/configuration/kube-compare-reference/cert-manager/certManagerOperatorgroup.yaml
+++ b/telco-ran/configuration/kube-compare-reference/cert-manager/certManagerOperatorgroup.yaml
@@ -3,7 +3,6 @@ kind: OperatorGroup
 metadata:
   annotations:
     ran.openshift.io/ztp-deploy-wave: "2"
-    olm.operatorframework.io/bundle-install-timeout: "10m"
     operatorframework.io/bundle-unpack-min-retry-interval: 10m
   name: cert-manager-operator
   namespace: cert-manager-operator

--- a/telco-ran/configuration/source-crs/cert-manager/certManagerOperatorgroup.yaml
+++ b/telco-ran/configuration/source-crs/cert-manager/certManagerOperatorgroup.yaml
@@ -3,7 +3,6 @@ kind: OperatorGroup
 metadata:
   annotations:
     ran.openshift.io/ztp-deploy-wave: "2"
-    olm.operatorframework.io/bundle-install-timeout: "10m"
     operatorframework.io/bundle-unpack-min-retry-interval: 10m
   name: cert-manager-operator
   namespace: cert-manager-operator


### PR DESCRIPTION
## Summary

- Remove the `olm.operatorframework.io/bundle-install-timeout` annotation from all 6 cert-manager OperatorGroup files across telco-core, telco-hub, and telco-ran

This annotation does not exist in OLM. It is not defined anywhere in [operator-framework/operator-lifecycle-manager](https://github.com/operator-framework/operator-lifecycle-manager) or [operator-framework/api](https://github.com/operator-framework/api), and a [GitHub-wide code search](https://github.com/search?q=%22bundle-install-timeout%22&type=code) confirms it appears nowhere outside this repo. It was introduced in #458 and has been silently ignored by Kubernetes/OLM since.

The valid OLM OperatorGroup timeout annotations (defined in [bundle_unpacker.go](https://github.com/operator-framework/operator-lifecycle-manager/blob/master/pkg/controller/bundle/bundle_unpacker.go)) are:
- `operatorframework.io/bundle-unpack-timeout`
- `operatorframework.io/bundle-unpack-min-retry-interval`

The valid `bundle-unpack-min-retry-interval` annotation already present on these OperatorGroups is unchanged.

## Test plan

- [ ] Verify no remaining references to `bundle-install-timeout` in the repo
- [ ] CI linting passes