### PR TITLE
CNF-23812: Add OLM annotation lint workflow

### DIFF
--- a/.github/workflows/olm-annotation-lint.yml
+++ b/.github/workflows/olm-annotation-lint.yml
@@ -1,0 +1,12 @@
+name: OLM Annotation Lint
+on: [pull_request]
+
+jobs:
+  olm-lint:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+      - uses: openshift-kni/olm-annotation-lint@v1
+        with:
+          path: "."
+          exclude: "testdata,vendor"

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,3 @@
-
 IMAGE_NAME ?= telco-reference
 
 CONTAINER_TOOL ?= podman
@@ -111,6 +110,27 @@ ocp-doc-check:  ## Download and run ocp-doc-checker against markdown files
 	./$$BINARY_NAME -dir . || true; \
 	rm -f ./$$BINARY_NAME; \
 	echo "ocp-doc-check completed"
+
+.PHONY: olm-annotation-lint
+olm-annotation-lint:  ## Download and run OLM annotation linter against YAML files
+	@OS=$$(uname -s | tr '[:upper:]' '[:lower:]'); \
+	ARCH=$$(uname -m); \
+	if [ "$$ARCH" = "x86_64" ]; then \
+		ARCH="amd64"; \
+	elif [ "$$ARCH" = "aarch64" ]; then \
+		ARCH="arm64"; \
+	fi; \
+	BINARY_NAME="olm-annotation-lint-$$OS-$$ARCH"; \
+	TMPBIN=$$(mktemp); \
+	trap "rm -f \"$$TMPBIN\"" EXIT; \
+	DOWNLOAD_URL="https://github.com/openshift-kni/olm-annotation-lint/releases/latest/download/$$BINARY_NAME"; \
+	echo "Downloading $$BINARY_NAME..."; \
+	if ! curl -sL -f -o "$$TMPBIN" "$$DOWNLOAD_URL"; then \
+		echo "Failed to download olm-annotation-lint binary"; \
+		exit 1; \
+	fi; \
+	chmod +x "$$TMPBIN"; \
+	"$$TMPBIN" --path . --exclude testdata,vendor
 
 test-kustomize:  ## Validate all kustomization.yaml files can build
 	./hack/test-kustomize.sh


### PR DESCRIPTION
## Summary

- Add a GitHub Actions workflow that runs [openshift-kni/olm-annotation-lint](https://github.com/openshift-kni/olm-annotation-lint) v1.0.2 on pull requests
- Validates all OLM annotations (`olm.*`, `operatorframework.io/*`) on Kubernetes resources in the repo
- Add `make olm-annotation-lint` target for running the linter locally — auto-detects OS/arch, downloads the latest release binary to a temp file, runs it, and cleans up automatically

This would have caught the invalid `olm.operatorframework.io/bundle-install-timeout` annotation that was removed in #759. Going forward, any PR introducing an unknown, mistyped, or misused OLM annotation will fail CI.

## Related to

- openshift-kni/cnf-features-deploy#4197

## What it checks

- Unknown OLM annotations
- Valid annotations on wrong resource types
- Invalid duration values
- Wrong annotation prefixes
- Case mismatches
- Controller-managed annotations set by users

## Local usage

```bash
make olm-annotation-lint
```

No dependencies required — the binary is downloaded from the latest [GitHub release](https://github.com/openshift-kni/olm-annotation-lint/releases) and removed after execution.

## Test plan

- [ ] CI passes on this PR (the linter runs against the repo and finds no violations)
- [ ] Verify the workflow appears in the Actions tab
- [ ] Verify `make olm-annotation-lint` works locally