### PR TITLE
Add hub-spoke trust config, root CA monitoring, and kubeconfig guidance

### DIFF
--- a/telco-core/configuration/reference-crs/optional/cert-manager/README.md
+++ b/telco-core/configuration/reference-crs/optional/cert-manager/README.md
@@ -16,8 +16,9 @@ Cert-manager automates the management and issuance of TLS certificates from vari
 - `certManagerOperatorgroup.yaml` - Creates the OperatorGroup for cert-manager
 - `certManagerSubscription.yaml` - Installs the OpenShift cert-manager operator
 
-### Certificate Issuer
-- `certManagerClusterIssuer.yaml` - Configures an ACME ClusterIssuer using Let's Encrypt with DNS-01 challenge
+### Certificate Issuers
+
+- `certManagerClusterIssuer.yaml` - **ACME issuer** with DNS-01 challenge (reference recommendation)
 
 ### Certificate Resources
 - `apiServerCertificate.yaml` - Creates a certificate for the API Server endpoint
@@ -34,12 +35,21 @@ Before applying these configurations, you must customize the following:
 1. **ClusterIssuer** (`certManagerClusterIssuer.yaml`):
    - Update `email` with your contact email
    - Configure the appropriate DNS provider for DNS-01 challenge (example shows Route53)
-   - Add necessary credentials for your DNS provider
+   - Reference pre-created Secrets for DNS provider credentials via `secretRef` — do not commit credentials in manifests
+
+   > **Note:** Other issuer types (e.g., CA issuer for disconnected environments with existing PKI) are allowable.
+   > Users may configure their own ClusterIssuer; currently only ACME issuer is provided in the reference.
 
 2. **Certificates** (`apiServerCertificate.yaml` and `ingressCertificate.yaml`):
    - Update `commonName` and `dnsNames` to match your cluster's domain
    - Example: Replace `api.example.com` with your actual API endpoint
    - Example: Replace `*.apps.example.com` with your actual wildcard domain
+
+   > **Important:** The reference configuration uses ECDSA P-256 for Certificate resources, which is the recommended algorithm for TLS 1.3.
+   > While RSA certificates are still supported for authentication in TLS 1.3, RSA key exchange was removed and RSA does not provide Forward Secrecy.
+   > 
+   > **Note:** Lifecycle-agent currently has limited support for ECDSA certificates (being addressed in lifecycle-agent PR #7610).
+   > For testing purposes, QE may temporarily use RSA certificates, but production deployments should use ECDSA.
 
 3. **APIServer Configuration** (`apiServerConfig.yaml`):
    - Update the `names` field to match your API Server FQDN
@@ -61,9 +71,75 @@ After applying these configurations, verify that:
 - API Server is using the certificate: Test HTTPS connection to API endpoint
 - Ingress is using the certificate: Test HTTPS connection to any route
 
+## Important: Kubeconfig Trust After API Server Cert Replacement
+
+> **Note:** When using a non-publicly-trusted issuer, you must complete this kubeconfig update
+> *before* applying the APIServer configuration (step 6 in the deployment order above).
+> Applying the APIServer configuration first will lock you out.
+
+> **Warning:** When cert-manager replaces the API server certificate with one signed by a non-publicly-trusted CA,
+> existing kubeconfig files become invalid. The embedded `certificate-authority-data` still references
+> the original cluster CA and cannot verify the new certificate. All `oc` and API client commands
+> will fail with `x509: certificate signed by unknown authority`.
+
+### Updating kubeconfig
+
+1. Extract the new root CA certificate:
+   ```bash
+   oc get secret root-ca-secret -n cert-manager -o jsonpath='{.data.tls\.crt}' | base64 -d > /tmp/root-ca.crt
+   ```
+
+2. Update your kubeconfig to trust the new CA:
+   ```bash
+   oc config set-cluster $(oc config current-context | cut -d/ -f2) \
+     --certificate-authority=/tmp/root-ca.crt --embed-certs
+   ```
+
+3. Verify connectivity:
+   ```bash
+   oc cluster-info
+   ```
+
+### Best practice for PKI environments
+
+Generate a root CA once and use it as the root for your PKI (the ACME issuer or CA issuer your clusters will use). Add this root CA to your workstation's system trust store so all certificates issued from it are automatically trusted by workstation tools and browsers. Note that adding the CA to your system trust store does not automatically update existing kubeconfigs with embedded certificate data — see the "Clearing kubeconfig certificate data" section below.
+
+#### Adding CA to system trust store
+
+**Red Hat/Fedora/CentOS:**
+```bash
+sudo cp /tmp/root-ca.crt /etc/pki/ca-trust/source/anchors/
+sudo update-ca-trust
+```
+
+**Debian/Ubuntu:**
+```bash
+sudo cp /tmp/root-ca.crt /usr/local/share/ca-certificates/root-ca.crt
+sudo update-ca-certificates
+```
+
+**macOS:**
+```bash
+sudo security add-trusted-cert -d -r trustRoot -k /Library/Keychains/System.keychain /tmp/root-ca.crt
+```
+
+#### Clearing kubeconfig certificate data
+
+**Important:** `oc` and `kubectl` do NOT fall back to the OS trust store if your kubeconfig contains embedded certificate data (`certificate-authority-data` field). You must clear this field to use the system trust store:
+
+```bash
+# Remove embedded certificate data from current cluster
+CLUSTER_NAME=$(oc config view --minify -o jsonpath='{.clusters[0].name}')
+oc config unset "clusters.${CLUSTER_NAME}.certificate-authority-data"
+
+# Verify the OS trust store is now used
+oc cluster-info
+```
+
+After completing these steps, all future clusters using certificates signed by your root CA will be automatically trusted without per-cluster kubeconfig updates.
+
 ## References
 
 - [OpenShift Cert-Manager Operator Documentation](https://docs.openshift.com/container-platform/latest/security/cert_manager_operator/index.html)
 - [Cert-Manager Documentation](https://cert-manager.io/docs/)
 - [ACME DNS-01 Challenge Configuration](https://cert-manager.io/docs/configuration/acme/dns01/)
-

--- a/telco-core/install/example-standard-clusterinstance.yaml
+++ b/telco-core/install/example-standard-clusterinstance.yaml
@@ -31,6 +31,10 @@ spec:
       common: "core"
       version: "4.22"
       region: "zone-1"
+  # Uncomment to apply KlusterletConfig for cert-manager hub-spoke trust (optional)
+  # extraAnnotations:
+  #   ManagedCluster:
+  #     agent.open-cluster-management.io/klusterlet-config: "cert-manager-ca-config"
   clusterNetwork:
     - cidr: 10.128.0.0/14
       hostPrefix: 23

--- a/telco-hub/configuration/reference-crs-kube-compare/compare_ignore
+++ b/telco-hub/configuration/reference-crs-kube-compare/compare_ignore
@@ -33,6 +33,10 @@ required/gitops/addPluginsPolicy.yaml
 # not include the full policy content due to policy templating.
 required/acm/observabilityRoutePolicy.yaml
 
+# cert-manager config CRs (user-specific, and policies with hub-side templating)
+optional/cert-manager/certManagerRootCAExpirationPolicy.yaml
+optional/cert-manager/kustomization.yaml
+
 required/gitops/extra-manifests-policy.yaml
 # ArgoCD files
 kustomization.yaml

--- a/telco-hub/configuration/reference-crs-kube-compare/default_value.yaml
+++ b/telco-hub/configuration/reference-crs-kube-compare/default_value.yaml
@@ -479,6 +479,12 @@ optional_cert_manager_certManagerCertificatePolicy:
       include:
         - openshift-ingress
         - openshift-config
+        - cert-manager
+
+optional_cert_manager_certManagerHubCAConfigMap:
+- data:
+    ca-bundle.crt: |
+      <replace with root CA PEM>
 
 optional_cert_manager_certManagerSubscription:
 - spec:

--- a/telco-hub/configuration/reference-crs-kube-compare/metadata.yaml
+++ b/telco-hub/configuration/reference-crs-kube-compare/metadata.yaml
@@ -31,6 +31,16 @@ parts:
         allOrNoneOf:
           - path: optional/cert-manager/apiServerCertificate.yaml
           - path: optional/cert-manager/apiServerConfig.yaml
+      - name: cert-manager-hub-spoke-trust
+        description: |-
+          Hub-spoke CA trust distribution via KlusterletConfig
+        allOrNoneOf:
+          - path: optional/cert-manager/certManagerHubCAConfigMap.yaml
+            config:
+              ignore-unspecified-fields: true
+          - path: optional/cert-manager/certManagerKlusterletConfig.yaml
+            config:
+              ignore-unspecified-fields: true
       - name: cert-manager-monitoring
         description: |-
           Certificate monitoring policy for RHACM
@@ -38,6 +48,17 @@ parts:
           - path: optional/cert-manager/certManagerCertificatePolicy.yaml
           - path: optional/cert-manager/certManagerCertificatePolicyPlacement.yaml
           - path: optional/cert-manager/certManagerCertificatePolicyPlacementBinding.yaml
+      - name: cert-manager-root-ca-monitoring
+        description: |-
+          Root CA expiration monitoring via PrometheusRule
+        allOrNoneOf:
+          - path: optional/cert-manager/certManagerRootCAExpirationPolicy.yaml
+            config:
+              ignore-unspecified-fields: true
+              fieldsToOmitRefs:
+                - templates
+          - path: optional/cert-manager/certManagerRootCAExpirationPolicyPlacement.yaml
+          - path: optional/cert-manager/certManagerRootCAExpirationPolicyPlacementBinding.yaml
   - name: optional-storage
     components:
       - name: local-storage-operator

--- a/telco-hub/configuration/reference-crs-kube-compare/optional/cert-manager/certManagerCertificatePolicy.yaml
+++ b/telco-hub/configuration/reference-crs-kube-compare/optional/cert-manager/certManagerCertificatePolicy.yaml
@@ -19,7 +19,7 @@ spec:
         spec:
           minimumDuration: {{ .spec.minimumDuration | default "720h" }}
           namespaceSelector:
-            include:{{- template "unorderedListAllowExtra" (list .spec.namespaceSelector.include (list "openshift-ingress" "openshift-config") ) }}
+            include:{{- template "unorderedListAllowExtra" (list .spec.namespaceSelector.include (list "openshift-ingress" "openshift-config" "cert-manager") ) }}
           remediationAction: inform
           severity: low
   remediationAction: inform

--- a/telco-hub/configuration/reference-crs-kube-compare/optional/cert-manager/certManagerHubCAConfigMap.yaml
+++ b/telco-hub/configuration/reference-crs-kube-compare/optional/cert-manager/certManagerHubCAConfigMap.yaml
@@ -1,0 +1,18 @@
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: cert-manager-hub-ca-bundle
+  namespace: multicluster-engine
+  labels:
+    import.open-cluster-management.io/ca-bundle: "true"
+  annotations:
+    argocd.argoproj.io/sync-wave: "-29"
+    argocd.argoproj.io/sync-options: SkipDryRunOnMissingResource=true
+data:
+{{- if .data }}
+  # Populate with the root CA PEM used by cert-manager to sign hub API/ingress certs.
+  # Extract from the hub: oc get secret root-ca-secret -n cert-manager -o jsonpath='{.data.tls\.crt}' | base64 -d
+  ca-bundle.crt: |
+{{ index .data "ca-bundle.crt" | trimSuffix "\n" | indent 4 }}
+{{- end }}

--- a/telco-hub/configuration/reference-crs-kube-compare/optional/cert-manager/certManagerKlusterletConfig.yaml
+++ b/telco-hub/configuration/reference-crs-kube-compare/optional/cert-manager/certManagerKlusterletConfig.yaml
@@ -1,0 +1,16 @@
+---
+apiVersion: config.open-cluster-management.io/v1alpha1
+kind: KlusterletConfig
+metadata:
+  name: {{ .metadata.name | default "cert-manager-ca-config" }}
+  annotations:
+    argocd.argoproj.io/sync-wave: "-29"
+    argocd.argoproj.io/sync-options: SkipDryRunOnMissingResource=true
+spec:
+  hubKubeAPIServerConfig:
+    serverVerificationStrategy: UseCustomCABundles
+    trustedCABundles:
+    - name: cert-manager-hub-ca-bundle
+      caBundle:
+        namespace: multicluster-engine
+        name: cert-manager-hub-ca-bundle

--- a/telco-hub/configuration/reference-crs-kube-compare/optional/cert-manager/certManagerRootCAExpirationPolicyPlacement.yaml
+++ b/telco-hub/configuration/reference-crs-kube-compare/optional/cert-manager/certManagerRootCAExpirationPolicyPlacement.yaml
@@ -1,0 +1,18 @@
+---
+apiVersion: cluster.open-cluster-management.io/v1beta1
+kind: Placement
+metadata:
+  name: root-ca-expiration-placement
+  namespace: default
+  annotations:
+    argocd.argoproj.io/sync-wave: "-11"
+    argocd.argoproj.io/sync-options: SkipDryRunOnMissingResource=true
+spec:
+  predicates:
+    - requiredClusterSelector:
+        labelSelector:
+          matchExpressions:
+            - key: local-cluster
+              operator: In
+              values:
+                - "true"

--- a/telco-hub/configuration/reference-crs-kube-compare/optional/cert-manager/certManagerRootCAExpirationPolicyPlacementBinding.yaml
+++ b/telco-hub/configuration/reference-crs-kube-compare/optional/cert-manager/certManagerRootCAExpirationPolicyPlacementBinding.yaml
@@ -1,0 +1,17 @@
+---
+apiVersion: policy.open-cluster-management.io/v1
+kind: PlacementBinding
+metadata:
+  name: root-ca-expiration-placementbinding
+  namespace: default
+  annotations:
+    argocd.argoproj.io/sync-wave: "-11"
+    argocd.argoproj.io/sync-options: SkipDryRunOnMissingResource=true
+placementRef:
+  name: root-ca-expiration-placement
+  apiGroup: cluster.open-cluster-management.io
+  kind: Placement
+subjects:
+  - name: root-ca-expiration-monitor
+    apiGroup: policy.open-cluster-management.io
+    kind: Policy

--- a/telco-hub/configuration/reference-crs/optional/cert-manager/README.md
+++ b/telco-hub/configuration/reference-crs/optional/cert-manager/README.md
@@ -16,8 +16,9 @@ Cert-manager automates the management and issuance of TLS certificates from vari
 - `certManagerOperatorgroup.yaml` - Creates the OperatorGroup for cert-manager
 - `certManagerSubscription.yaml` - Installs the OpenShift cert-manager operator
 
-### Certificate Issuer
-- `certManagerClusterIssuer.yaml` - Configures an ACME ClusterIssuer using Let's Encrypt with DNS-01 challenge
+### Certificate Issuers
+
+- `certManagerClusterIssuer.yaml` - **ACME issuer** with DNS-01 challenge (reference recommendation)
 
 ### Certificate Resources
 - `apiServerCertificate.yaml` - Creates a certificate for the API Server endpoint
@@ -34,12 +35,21 @@ Before applying these configurations, you must customize the following:
 1. **ClusterIssuer** (`certManagerClusterIssuer.yaml`):
    - Update `email` with your contact email
    - Configure the appropriate DNS provider for DNS-01 challenge (example shows Route53)
-   - Add necessary credentials for your DNS provider
+   - Reference pre-created Secrets for DNS provider credentials via `secretRef` — do not commit credentials in manifests
+
+   > **Note:** Other issuer types (e.g., CA issuer for disconnected environments with existing PKI) are allowable.
+   > Users may configure their own ClusterIssuer; currently only ACME issuer is provided in the reference.
 
 2. **Certificates** (`apiServerCertificate.yaml` and `ingressCertificate.yaml`):
    - Update `commonName` and `dnsNames` to match your cluster's domain
    - Example: Replace `api.example.com` with your actual API endpoint
    - Example: Replace `*.apps.example.com` with your actual wildcard domain
+
+   > **Important:** The reference configuration uses ECDSA P-256 for Certificate resources, which is the recommended algorithm for TLS 1.3.
+   > While RSA certificates are still supported for authentication in TLS 1.3, RSA key exchange was removed and RSA does not provide Forward Secrecy.
+   > 
+   > **Note:** Lifecycle-agent currently has limited support for ECDSA certificates (being addressed in lifecycle-agent PR #7610).
+   > For testing purposes, QE may temporarily use RSA certificates, but production deployments should use ECDSA.
 
 3. **APIServer Configuration** (`apiServerConfig.yaml`):
    - Update the `names` field to match your API Server FQDN
@@ -49,8 +59,9 @@ Before applying these configurations, you must customize the following:
 1. Deploy operator installation files (NS, OperatorGroup, Subscription)
 2. Wait for operator to be ready
 3. Deploy the ClusterIssuer
-4. Wait for certificates to be issued and secrets created
-5. Apply the APIServer and IngressController configurations
+4. Deploy the Certificate resources
+5. Wait for certificates to be issued and secrets created
+6. Apply the APIServer and IngressController configurations
 
 ## Certificate Verification
 
@@ -60,9 +71,156 @@ After applying these configurations, verify that:
 - API Server is using the certificate: Test HTTPS connection to API endpoint
 - Ingress is using the certificate: Test HTTPS connection to any route
 
+## Important: Kubeconfig Trust After API Server Cert Replacement
+
+> **Note:** When using a non-publicly-trusted issuer, you must complete this kubeconfig update
+> *before* applying the APIServer configuration (step 6 in the deployment order above).
+> Applying the APIServer configuration first will lock you out.
+
+> **Warning:** When cert-manager replaces the API server certificate with one signed by a non-publicly-trusted CA,
+> existing kubeconfig files become invalid. The embedded `certificate-authority-data` still references
+> the original cluster CA and cannot verify the new certificate. All `oc` and API client commands
+> will fail with `x509: certificate signed by unknown authority`.
+
+### Updating kubeconfig
+
+1. Extract the new root CA certificate:
+   ```bash
+   oc get secret root-ca-secret -n cert-manager -o jsonpath='{.data.tls\.crt}' | base64 -d > /tmp/root-ca.crt
+   ```
+
+2. Update your kubeconfig to trust the new CA:
+   ```bash
+   oc config set-cluster $(oc config current-context | cut -d/ -f2) \
+     --certificate-authority=/tmp/root-ca.crt --embed-certs
+   ```
+
+3. Verify connectivity:
+   ```bash
+   oc cluster-info
+   ```
+
+### Best practice for PKI environments
+
+Generate a root CA once and use it as the root for your PKI (the ACME issuer or CA issuer your clusters will use). Add this root CA to your workstation's system trust store so all certificates issued from it are automatically trusted by workstation tools and browsers. Note that adding the CA to your system trust store does not automatically update existing kubeconfigs with embedded certificate data — see the "Clearing kubeconfig certificate data" section below.
+
+#### Adding CA to system trust store
+
+**Red Hat/Fedora/CentOS:**
+```bash
+sudo cp /tmp/root-ca.crt /etc/pki/ca-trust/source/anchors/
+sudo update-ca-trust
+```
+
+**Debian/Ubuntu:**
+```bash
+sudo cp /tmp/root-ca.crt /usr/local/share/ca-certificates/root-ca.crt
+sudo update-ca-certificates
+```
+
+**macOS:**
+```bash
+sudo security add-trusted-cert -d -r trustRoot -k /Library/Keychains/System.keychain /tmp/root-ca.crt
+```
+
+#### Clearing kubeconfig certificate data
+
+**Important:** `oc` and `kubectl` do NOT fall back to the OS trust store if your kubeconfig contains embedded certificate data (`certificate-authority-data` field). You must clear this field to use the system trust store:
+
+```bash
+# Remove embedded certificate data from current cluster
+CLUSTER_NAME=$(oc config view --minify -o jsonpath='{.clusters[0].name}')
+oc config unset "clusters.${CLUSTER_NAME}.certificate-authority-data"
+
+# Verify the OS trust store is now used
+oc cluster-info
+```
+
+After completing these steps, all future clusters using certificates signed by your root CA will be automatically trusted without per-cluster kubeconfig updates.
+
+## Hub-Spoke Trust with ACM
+
+When cert-manager issues certificates for the hub's API server and ingress, managed spokes must trust the cert-manager root CA to maintain connectivity. The reference configuration includes a `KlusterletConfig` and CA ConfigMap to distribute the root CA to spokes automatically.
+
+> **Requirements:** ACM 2.11 or later. The `serverVerificationStrategy` feature used by the KlusterletConfig was introduced in ACM 2.11 and is not available in earlier versions.
+
+### Hub-spoke trust files
+
+- `certManagerHubCAConfigMap.yaml` — ConfigMap in `multicluster-engine` namespace containing the cert-manager root CA, labeled for the import controller
+- `certManagerKlusterletConfig.yaml` — KlusterletConfig that switches spoke CA verification from auto-detected leaf cert to the custom root CA bundle
+
+### Why this is needed
+
+By default, ACM embeds the hub's leaf serving cert (`CA:FALSE`) in the klusterlet bootstrap kubeconfig. This means every cert rotation requires a ManifestWork update, and a full CA replacement breaks all spokes immediately. The `KlusterletConfig` with `UseCustomCABundles` replaces the leaf cert with the root CA (`CA:TRUE`), so any certificate signed by that root — current or rotated — is automatically trusted.
+
+### Applying the KlusterletConfig to managed clusters
+
+#### ZTP deployment (recommended)
+
+For fully automated ZTP deployments, configure the ManagedCluster annotation via ClusterInstance `extraAnnotations`:
+
+```yaml
+apiVersion: siteconfig.open-cluster-management.io/v1alpha1
+kind: ClusterInstance
+metadata:
+  name: spoke-cluster-name
+  namespace: spoke-cluster-namespace
+spec:
+  clusterName: spoke-cluster-name
+  extraAnnotations:
+    ManagedCluster:
+      agent.open-cluster-management.io/klusterlet-config: "cert-manager-ca-config"
+  # ... rest of ClusterInstance spec
+```
+
+The siteconfig operator automatically applies annotations from `extraAnnotations.ManagedCluster` to the generated ManagedCluster resource, eliminating manual post-deployment steps.
+
+#### Manual deployment
+
+For manual cluster imports or retrofitting existing clusters, annotate the managed cluster after deploying the hub-spoke trust files:
+
+```bash
+oc annotate managedcluster <spoke-name> \
+  agent.open-cluster-management.io/klusterlet-config=cert-manager-ca-config
+```
+
+### Greenfield (cert-manager before spoke deployment)
+
+1. Deploy cert-manager on the hub, create the CA, issue hub API/ingress certs
+2. Deploy `certManagerHubCAConfigMap.yaml` and `certManagerKlusterletConfig.yaml`
+3. Ensure the KlusterletConfig annotation is configured on managed clusters (see [Applying the KlusterletConfig](#applying-the-klusterletconfig-to-managed-clusters) above)
+4. Deploy spokes — they register with the root CA in their trust store
+5. Cert rotations are seamless with no intervention required
+
+### Brownfield (cert-manager on existing hub with connected spokes)
+
+The order matters — distribute the CA **before** replacing the hub certs:
+
+1. Install cert-manager on the hub, create the CA — but **do not apply certs to the APIServer/IngressController yet**
+2. Deploy `certManagerHubCAConfigMap.yaml` with the root CA PEM
+3. Deploy `certManagerKlusterletConfig.yaml`
+4. Ensure the KlusterletConfig annotation is configured on all managed clusters (see [Applying the KlusterletConfig](#applying-the-klusterletconfig-to-managed-clusters) above)
+5. Wait for the import controller to regenerate bootstrap kubeconfigs (check logs for `create a new bootstrap kubeconfig`)
+6. **Now** apply the cert-manager certs to the APIServer and IngressController
+7. Spokes stay connected because they already trust the root CA
+
+### Cert rotation
+
+Once the root CA is in the klusterlet's trust store, cert rotations are seamless. The klusterlet trusts any certificate signed by the root CA regardless of serial number, with no ManifestWork timing dependency.
+
+## Root CA Expiration Monitoring
+
+The `certManagerRootCAExpirationPolicy.yaml` creates a PrometheusRule that monitors the root CA certificate expiration using the `certmanager_certificate_expiration_timestamp_seconds` metric:
+
+- **Warning** at 90 days before expiry
+- **Critical** at 30 days before expiry
+
+This is distinct from the existing `certManagerCertificatePolicy.yaml` which monitors leaf certificate expiration in `openshift-ingress`, `openshift-config`, and `cert-manager` namespaces via ACM CertificatePolicy. Both should be deployed together for comprehensive certificate monitoring.
+
 ## References
 
 - [OpenShift Cert-Manager Operator Documentation](https://docs.openshift.com/container-platform/latest/security/cert_manager_operator/index.html)
 - [Cert-Manager Documentation](https://cert-manager.io/docs/)
 - [ACME DNS-01 Challenge Configuration](https://cert-manager.io/docs/configuration/acme/dns01/)
-
+- [Hub-Spoke Trust — Complete Solution](https://gist.github.com/sebrandon1/7265d68c5add6adb1313dce5b695e40d)
+- [Hub-Spoke Trust Test Results](https://gist.github.com/sebrandon1/483180614951d23174c4e365a9a02a34)

--- a/telco-hub/configuration/reference-crs/optional/cert-manager/certManagerCertificatePolicy.yaml
+++ b/telco-hub/configuration/reference-crs/optional/cert-manager/certManagerCertificatePolicy.yaml
@@ -22,6 +22,7 @@ spec:
             include:
               - openshift-ingress
               - openshift-config
+              - cert-manager
           remediationAction: inform
           severity: low
   remediationAction: inform

--- a/telco-hub/configuration/reference-crs/optional/cert-manager/certManagerHubCAConfigMap.yaml
+++ b/telco-hub/configuration/reference-crs/optional/cert-manager/certManagerHubCAConfigMap.yaml
@@ -1,0 +1,16 @@
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: cert-manager-hub-ca-bundle
+  namespace: multicluster-engine
+  labels:
+    import.open-cluster-management.io/ca-bundle: "true"
+  annotations:
+    argocd.argoproj.io/sync-wave: "-29"
+    argocd.argoproj.io/sync-options: SkipDryRunOnMissingResource=true
+data:
+  # Populate with the root CA PEM used by cert-manager to sign hub API/ingress certs.
+  # Extract from the hub: oc get secret root-ca-secret -n cert-manager -o jsonpath='{.data.tls\.crt}' | base64 -d
+  ca-bundle.crt: |
+    <replace with root CA PEM>

--- a/telco-hub/configuration/reference-crs/optional/cert-manager/certManagerKlusterletConfig.yaml
+++ b/telco-hub/configuration/reference-crs/optional/cert-manager/certManagerKlusterletConfig.yaml
@@ -1,0 +1,16 @@
+---
+apiVersion: config.open-cluster-management.io/v1alpha1
+kind: KlusterletConfig
+metadata:
+  name: cert-manager-ca-config
+  annotations:
+    argocd.argoproj.io/sync-wave: "-29"
+    argocd.argoproj.io/sync-options: SkipDryRunOnMissingResource=true
+spec:
+  hubKubeAPIServerConfig:
+    serverVerificationStrategy: UseCustomCABundles
+    trustedCABundles:
+    - name: cert-manager-hub-ca-bundle
+      caBundle:
+        namespace: multicluster-engine
+        name: cert-manager-hub-ca-bundle

--- a/telco-hub/configuration/reference-crs/optional/cert-manager/certManagerRootCAExpirationPolicy.yaml
+++ b/telco-hub/configuration/reference-crs/optional/cert-manager/certManagerRootCAExpirationPolicy.yaml
@@ -1,0 +1,59 @@
+---
+# ACM Policy to create a PrometheusRule that alerts on root CA
+# certificate expiration. Monitors the cert-manager certificate
+# expiration metric and fires warnings at 90 days and critical
+# alerts at 30 days before expiry.
+apiVersion: policy.open-cluster-management.io/v1
+kind: Policy
+metadata:
+  name: root-ca-expiration-monitor
+  namespace: default
+  annotations:
+    policy.open-cluster-management.io/categories: SC System and Communications Protection
+    policy.open-cluster-management.io/controls: SC-8 Transmission Confidentiality and Integrity
+    policy.open-cluster-management.io/standards: NIST 800-53
+    argocd.argoproj.io/sync-wave: "-10"
+    argocd.argoproj.io/sync-options: SkipDryRunOnMissingResource=true
+spec:
+  disabled: false
+  policy-templates:
+    - objectDefinition:
+        apiVersion: policy.open-cluster-management.io/v1
+        kind: ConfigurationPolicy
+        metadata:
+          name: root-ca-expiration-prometheusrule
+        spec:
+          remediationAction: enforce
+          severity: high
+          object-templates:
+            - complianceType: musthave
+              objectDefinition:
+                apiVersion: monitoring.coreos.com/v1
+                kind: PrometheusRule
+                metadata:
+                  name: cert-manager-root-ca-expiration
+                  namespace: cert-manager-operator
+                spec:
+                  groups:
+                    - name: cert-manager-root-ca
+                      rules:
+                        - alert: CertManagerRootCAExpiringSoon
+                          annotations:
+                            summary: 'Root CA certificate {{`{{ $labels.name }}`}} is expiring soon'
+                            description: 'The root CA certificate {{`{{ $labels.name }}`}} in namespace {{`{{ $labels.namespace }}`}} expires in less than 90 days.'
+                          # Update name="root-ca" if your cert-manager Certificate resource uses a different name
+                          expr: |
+                            certmanager_certificate_expiration_timestamp_seconds{name="root-ca",namespace="cert-manager"} - time() < 90 * 24 * 3600
+                          for: 1h
+                          labels:
+                            severity: warning
+                        - alert: CertManagerRootCAExpirationCritical
+                          annotations:
+                            summary: 'Root CA certificate {{`{{ $labels.name }}`}} is about to expire'
+                            description: 'The root CA certificate {{`{{ $labels.name }}`}} in namespace {{`{{ $labels.namespace }}`}} expires in less than 30 days. Immediate action required.'
+                          expr: |
+                            certmanager_certificate_expiration_timestamp_seconds{name="root-ca",namespace="cert-manager"} - time() < 30 * 24 * 3600
+                          for: 1h
+                          labels:
+                            severity: critical
+  remediationAction: enforce

--- a/telco-hub/configuration/reference-crs/optional/cert-manager/certManagerRootCAExpirationPolicyPlacement.yaml
+++ b/telco-hub/configuration/reference-crs/optional/cert-manager/certManagerRootCAExpirationPolicyPlacement.yaml
@@ -1,0 +1,18 @@
+---
+apiVersion: cluster.open-cluster-management.io/v1beta1
+kind: Placement
+metadata:
+  name: root-ca-expiration-placement
+  namespace: default
+  annotations:
+    argocd.argoproj.io/sync-wave: "-11"
+    argocd.argoproj.io/sync-options: SkipDryRunOnMissingResource=true
+spec:
+  predicates:
+    - requiredClusterSelector:
+        labelSelector:
+          matchExpressions:
+            - key: local-cluster
+              operator: In
+              values:
+                - "true"

--- a/telco-hub/configuration/reference-crs/optional/cert-manager/certManagerRootCAExpirationPolicyPlacementBinding.yaml
+++ b/telco-hub/configuration/reference-crs/optional/cert-manager/certManagerRootCAExpirationPolicyPlacementBinding.yaml
@@ -1,0 +1,17 @@
+---
+apiVersion: policy.open-cluster-management.io/v1
+kind: PlacementBinding
+metadata:
+  name: root-ca-expiration-placementbinding
+  namespace: default
+  annotations:
+    argocd.argoproj.io/sync-wave: "-11"
+    argocd.argoproj.io/sync-options: SkipDryRunOnMissingResource=true
+placementRef:
+  name: root-ca-expiration-placement
+  apiGroup: cluster.open-cluster-management.io
+  kind: Placement
+subjects:
+  - name: root-ca-expiration-monitor
+    apiGroup: policy.open-cluster-management.io
+    kind: Policy

--- a/telco-hub/configuration/reference-crs/optional/cert-manager/kustomization.yaml
+++ b/telco-hub/configuration/reference-crs/optional/cert-manager/kustomization.yaml
@@ -13,3 +13,8 @@ resources:
   - certManagerCertificatePolicy.yaml
   - certManagerCertificatePolicyPlacement.yaml
   - certManagerCertificatePolicyPlacementBinding.yaml
+  - certManagerHubCAConfigMap.yaml
+  - certManagerKlusterletConfig.yaml
+  - certManagerRootCAExpirationPolicy.yaml
+  - certManagerRootCAExpirationPolicyPlacement.yaml
+  - certManagerRootCAExpirationPolicyPlacementBinding.yaml

--- a/telco-ran/configuration/argocd/example/clusterinstance/example-3node.yaml
+++ b/telco-ran/configuration/argocd/example/clusterinstance/example-3node.yaml
@@ -30,6 +30,10 @@ spec:
       # ran-group-du-3node-templated.yaml will apply to all clusters with 'group-du-3nc-zone' and 'hardware-type'
       group-du-3nc-zone: "zone-1"
       hardware-type: "hw-type-platform-1"
+  # Uncomment to apply KlusterletConfig for cert-manager hub-spoke trust (optional)
+  # extraAnnotations:
+  #   ManagedCluster:
+  #     agent.open-cluster-management.io/klusterlet-config: "cert-manager-ca-config"
   clusterNetwork:
     - cidr: 1001:1::/48
       hostPrefix: 64

--- a/telco-ran/configuration/argocd/example/clusterinstance/example-sno.yaml
+++ b/telco-ran/configuration/argocd/example/clusterinstance/example-sno.yaml
@@ -47,6 +47,10 @@ spec:
       # ran-group-du-sno-templated.yaml will apply to all clusters with 'group-du-sno-zone' and 'hardware-type'
       group-du-sno-zone: "zone-1"
       hardware-type: "hw-type-platform-1"
+  # Uncomment to apply KlusterletConfig for cert-manager hub-spoke trust (optional)
+  # extraAnnotations:
+  #   ManagedCluster:
+  #     agent.open-cluster-management.io/klusterlet-config: "cert-manager-ca-config"
   clusterNetwork:
     - cidr: 1001:1::/48
       hostPrefix: 64

--- a/telco-ran/configuration/argocd/example/clusterinstance/example-standard.yaml
+++ b/telco-ran/configuration/argocd/example/clusterinstance/example-standard.yaml
@@ -30,6 +30,10 @@ spec:
       # ran-group-du-standard-templated.yaml will apply to all clusters with 'group-du-standard-zone' and 'hardware-type'
       group-du-standard-zone: "zone-1"
       hardware-type: "hw-type-platform-1"
+  # Uncomment to apply KlusterletConfig for cert-manager hub-spoke trust (optional)
+  # extraAnnotations:
+  #   ManagedCluster:
+  #     agent.open-cluster-management.io/klusterlet-config: "cert-manager-ca-config"
   clusterNetwork:
     - cidr: 1001:1::/48
       hostPrefix: 64


### PR DESCRIPTION
## Summary

Adds hub-spoke trust configuration, root CA expiration monitoring, and kubeconfig trust recovery guidance for cert-manager deployments.

**Companion RDS MR:** [reference-design-specifications!192](https://gitlab.cee.redhat.com/reference-configurations/reference-design-specifications/-/merge_requests/192)

## Changes

### Hub-Spoke Trust Distribution ([OCPBUGS-85774](https://issues.redhat.com/browse/OCPBUGS-85774))

**Requires ACM 2.11+** for `serverVerificationStrategy` support.

Adds KlusterletConfig and CA ConfigMap to distribute the cert-manager root CA to managed spokes. Spokes trust the root CA instead of the hub's leaf certificate, enabling seamless cert rotation with no ManifestWork timing dependency.

**New resources:**
- `certManagerHubCAConfigMap.yaml` - Root CA bundle ConfigMap
- `certManagerKlusterletConfig.yaml` - KlusterletConfig with `UseCustomCABundles`

> **Implementation Note:** This configuration uses KlusterletConfig `serverVerificationStrategy: UseCustomCABundles`, a feature introduced in ACM 2.11 for custom CA trust scenarios. While fully supported and validated in production testing, this pattern has limited public documentation and examples as of ACM 2.13. The implementation follows the official OCM foundation documentation and has been validated through extensive source code research.

### Root CA Expiration Monitoring ([OCPBUGS-85777](https://issues.redhat.com/browse/OCPBUGS-85777))

Adds PrometheusRule alerting on root CA expiration (warning at 90 days, critical at 30 days). Extends existing `certManagerCertificatePolicy` to monitor the `cert-manager` namespace.

### Kubeconfig Trust Recovery ([OCPBUGS-85776](https://issues.redhat.com/browse/OCPBUGS-85776))

Documents kubeconfig update procedure for non-publicly-trusted CAs. When cert-manager replaces the API server cert, existing kubeconfigs become invalid and must be updated to trust the new root CA.

### Certificate Algorithm

All Certificate resources use ECDSA P-256 (recommended for TLS 1.3). While RSA certificates are still supported for authentication in TLS 1.3, ECDSA provides Forward Secrecy and better performance.

**Note:** Lifecycle-agent has limited ECDSA support (being addressed in [lifecycle-agent#7610](https://github.com/openshift-kni/lifecycle-agent/pull/7610)). QE may use RSA for testing; production should use ECDSA.

### Issuer Guidance

ACME is the reference recommendation. Other issuer types (CA issuer for disconnected environments) are allowable—users may configure their own ClusterIssuer.

## Testing

### OCP 4.21.15 Validation
Validated on OCP 4.21.15 hub+spoke (SNO, ZTP, bare metal) with cert-manager v1.19.0:
- [Solution documentation](https://gist.github.com/sebrandon1/7265d68c5add6adb1313dce5b695e40d)
- [Test results](https://gist.github.com/sebrandon1/483180614951d23174c4e365a9a02a34)

### OCP 4.22 Verification (2026-07-08)
Full end-to-end validation on OCP 4.21.22 hub + OCP 4.22 spoke with ACM 2.13:
- **Environment:** ZTP-deployed hub-spoke (cnfdd7)
- **All phases passed:** ConfigMap label fix, root CA distribution, hub cert rollout, spoke reconnection, certificate rotation
- **Key validations:**
  - Bootstrap kubeconfig contains root CA (`CA:TRUE`) ✅
  - Spoke remained `AVAILABLE=True` during hub cert rollout ✅
  - Certificate rotation succeeded with zero x509 errors ✅
  - No manual ManifestWork updates required ✅
- **Results:** [Verification summary](https://gist.github.com/sebrandon1/bba27f3e662c16e62fb552ea24c90d02)
