### PR TITLE
Move MetalLB configuration state to core-overlay

### DIFF
--- a/telco-core/configuration/core-baseline.yaml
+++ b/telco-core/configuration/core-baseline.yaml
@@ -71,7 +71,6 @@ policies:
         patches:
         - spec:
             installPlanApproval: Manual
-      - path: reference-crs/required/networking/metallb/configurationstate.yaml
       - path: reference-crs/required/scheduling/NROPSubscriptionNS.yaml
       - path: reference-crs/required/scheduling/NROPSubscriptionOperGroup.yaml
       - path: reference-crs/required/scheduling/NROPSubscription.yaml

--- a/telco-core/configuration/core-overlay.yaml
+++ b/telco-core/configuration/core-overlay.yaml
@@ -206,6 +206,8 @@ policies:
             nodeSelector:
               node-role.kubernetes.io/worker: ""
 
+      - path: reference-crs/required/networking/metallb/configurationstate.yaml
+
       # - path: reference-crs/required/networking/metallb/bfd-profile.yaml
       # - path: reference-crs/required/networking/metallb/addr-pool.yaml
       #   patches:


### PR DESCRIPTION
When MetalLB instance is not instantiated `ConfigurationState` reports `status.result=Unknown` 