### PR TITLE
Enable mellanoxFirmwareReset feature gate in SriovOperatorConfig

### DIFF
--- a/telco-core/configuration/reference-crs-kube-compare/required/networking/sriov/SriovOperatorConfig.yaml
+++ b/telco-core/configuration/reference-crs-kube-compare/required/networking/sriov/SriovOperatorConfig.yaml
@@ -16,4 +16,5 @@ spec:
   disableDrain: false
   logLevel: 2
   featureGates:
+    mellanoxFirmwareReset: true
     resourceInjectorMatchCondition: true

--- a/telco-core/configuration/reference-crs/required/networking/sriov/SriovOperatorConfig.yaml
+++ b/telco-core/configuration/reference-crs/required/networking/sriov/SriovOperatorConfig.yaml
@@ -14,4 +14,5 @@ spec:
   disableDrain: false
   logLevel: 2
   featureGates:
+    mellanoxFirmwareReset: true
     resourceInjectorMatchCondition: true

--- a/telco-ran/configuration/kube-compare-reference/hack/default_value.yaml
+++ b/telco-ran/configuration/kube-compare-reference/hack/default_value.yaml
@@ -789,6 +789,8 @@ sriov_operator_SriovOperatorConfig:
         "node-role.kubernetes.io/$mcp": ""
       enableInjector: false
       enableOperatorWebhook: false
+      featureGates:
+        mellanoxFirmwareReset: true
       logLevel: 0
 sriov_operator_SriovOperatorConfigForSNO:
   - spec:
@@ -796,6 +798,8 @@ sriov_operator_SriovOperatorConfigForSNO:
         "node-role.kubernetes.io/$mcp": ""
       enableInjector: false
       enableOperatorWebhook: false
+      featureGates:
+        mellanoxFirmwareReset: true
       logLevel: 0
 sriov_operator_SriovSubscription:
   - spec:

--- a/telco-ran/configuration/kube-compare-reference/sriov-operator/SriovOperatorConfig.yaml
+++ b/telco-ran/configuration/kube-compare-reference/sriov-operator/SriovOperatorConfig.yaml
@@ -29,6 +29,8 @@ spec:
   {{- if hasKey .spec "enableOperatorWebhook" }}
   enableOperatorWebhook: false
   {{- end }}
+  featureGates:
+    mellanoxFirmwareReset: true
   {{- if hasKey .spec "logLevel" }}
   logLevel: 0
   {{- end }}

--- a/telco-ran/configuration/kube-compare-reference/sriov-operator/SriovOperatorConfigForSNO.yaml
+++ b/telco-ran/configuration/kube-compare-reference/sriov-operator/SriovOperatorConfigForSNO.yaml
@@ -31,6 +31,8 @@ spec:
   {{- if hasKey .spec "enableOperatorWebhook" }}
   enableOperatorWebhook: false
   {{- end }}
+  featureGates:
+    mellanoxFirmwareReset: true
   {{- if hasKey .spec "logLevel" }}
   logLevel: 0
   {{- end }}

--- a/telco-ran/configuration/source-crs/sriov-operator/SriovOperatorConfig-SetSelector.yaml
+++ b/telco-ran/configuration/source-crs/sriov-operator/SriovOperatorConfig-SetSelector.yaml
@@ -23,4 +23,6 @@ spec:
   #          openshift.io/<resource_name>:  "1"
   enableInjector: false
   enableOperatorWebhook: false
+  featureGates:
+    mellanoxFirmwareReset: true
   logLevel: 0

--- a/telco-ran/configuration/source-crs/sriov-operator/SriovOperatorConfig.yaml
+++ b/telco-ran/configuration/source-crs/sriov-operator/SriovOperatorConfig.yaml
@@ -23,4 +23,6 @@ spec:
   #          openshift.io/<resource_name>:  "1"
   enableInjector: false
   enableOperatorWebhook: false
+  featureGates:
+    mellanoxFirmwareReset: true
   logLevel: 0

--- a/telco-ran/configuration/source-crs/sriov-operator/SriovOperatorConfigForSNO.yaml
+++ b/telco-ran/configuration/source-crs/sriov-operator/SriovOperatorConfigForSNO.yaml
@@ -25,4 +25,6 @@ spec:
   disableDrain: true
   enableInjector: false
   enableOperatorWebhook: false
+  featureGates:
+    mellanoxFirmwareReset: true
   logLevel: 0


### PR DESCRIPTION
Explicitly enable the mellanoxFirmwareReset feature gate across all SriovOperatorConfig CRs to prevent endless node reboots caused by mstflint-4.34 depending on NIC firmware version. RHEL 9.6 (OCP 4.19-4.21) is updating to mstflint-4.34 on June 16 and RHEL 9.8 (OCP 4.22-4.23) has already updated.