### PR TITLE
Restore cert-manager to RAN profile

### DIFF
--- a/telco-ran/configuration/argocd/example/acmpolicygenerator/acm-common-ranGen.yaml
+++ b/telco-ran/configuration/argocd/example/acmpolicygenerator/acm-common-ranGen.yaml
@@ -85,3 +85,8 @@ policies:
     # - path: source-crs/data-protection/OadpSubscription.yaml
     # - path: source-crs/data-protection/OadpOperatorStatus.yaml
     #
+    # cert-manager operator for managing TLS certificates
+    # - path: source-crs/cert-manager/certManagerNS.yaml
+    # - path: source-crs/cert-manager/certManagerOperatorgroup.yaml
+    # - path: source-crs/cert-manager/certManagerSubscription.yaml
+    # - path: source-crs/cert-manager/certManagerOperatorStatus.yaml

--- a/telco-ran/configuration/kube-compare-reference/cert-manager/certManagerNS.yaml
+++ b/telco-ran/configuration/kube-compare-reference/cert-manager/certManagerNS.yaml
@@ -1,0 +1,9 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: cert-manager-operator
+  annotations:
+    workload.openshift.io/allowed: management
+    ran.openshift.io/ztp-deploy-wave: "2"
+  labels:
+    openshift.io/cluster-monitoring: "true"

--- a/telco-ran/configuration/kube-compare-reference/cert-manager/certManagerOperatorgroup.yaml
+++ b/telco-ran/configuration/kube-compare-reference/cert-manager/certManagerOperatorgroup.yaml
@@ -1,0 +1,10 @@
+apiVersion: operators.coreos.com/v1
+kind: OperatorGroup
+metadata:
+  name: cert-manager-operator
+  namespace: cert-manager-operator
+  annotations:
+    operatorframework.io/bundle-unpack-min-retry-interval: 10m
+    ran.openshift.io/ztp-deploy-wave: "2"
+spec:
+  upgradeStrategy: Default

--- a/telco-ran/configuration/kube-compare-reference/cert-manager/certManagerSubscription.yaml
+++ b/telco-ran/configuration/kube-compare-reference/cert-manager/certManagerSubscription.yaml
@@ -1,0 +1,15 @@
+apiVersion: operators.coreos.com/v1alpha1
+kind: Subscription
+metadata:
+  name: openshift-cert-manager-operator
+  namespace: cert-manager-operator
+  annotations:
+    ran.openshift.io/ztp-deploy-wave: "2"
+spec:
+  channel: "stable-v1"
+  name: openshift-cert-manager-operator
+  source: {{ .spec.source }}
+  sourceNamespace: openshift-marketplace
+  installPlanApproval: Manual
+status:
+  state: AtLatestKnown

--- a/telco-ran/configuration/kube-compare-reference/hack/compare_ignore
+++ b/telco-ran/configuration/kube-compare-reference/hack/compare_ignore
@@ -27,6 +27,7 @@ validatorCRs/informDuValidatorMaster.yaml
 validatorCRs/informDuValidatorWorker.yaml
 validatorCRs/informDuValidator.yaml
 sriov-fec-operator/AcceleratorsOperatorStatus.yaml
+cert-manager/certManagerOperatorStatus.yaml
 cluster-logging/ClusterLogOperatorStatus.yaml
 lca/LcaOperatorStatus.yaml
 storage-lvm/LVMOperatorStatus.yaml
@@ -34,6 +35,13 @@ nmstate/NMStateOperatorStatus.yaml
 ptp-operator/PtpOperatorStatus.yaml
 sriov-operator/SriovOperatorStatus.yaml
 storage-lso/StorageOperatorStatus.yaml
+
+# cert-manager config CRs (user-specific, nothing to validate)
+cert-manager/apiServerCertificate.yaml
+cert-manager/apiServerConfig.yaml
+cert-manager/certManagerClusterIssuer.yaml
+cert-manager/ingressCertificate.yaml
+cert-manager/ingressControllerConfig.yaml
 
 # ClusterLogging 5->6 upgrade helper-policy
 cluster-logging/ClusterLogging5Cleanup.yaml

--- a/telco-ran/configuration/kube-compare-reference/hack/default_value.yaml
+++ b/telco-ran/configuration/kube-compare-reference/hack/default_value.yaml
@@ -894,6 +894,9 @@ sriov_operator_SriovOperatorConfigForSNO:
 sriov_operator_SriovSubscription:
   - spec:
       source: redhat-operators-disconnected
+cert_manager_certManagerSubscription:
+  - spec:
+      source: redhat-operators-disconnected
 global:
   lookup_substitutions:
     lookupCRs_v1_Node:

--- a/telco-ran/configuration/kube-compare-reference/metadata.yaml
+++ b/telco-ran/configuration/kube-compare-reference/metadata.yaml
@@ -82,6 +82,18 @@ parts:
                 - subscriptions
           - path: lca/LcaSubscriptionNS.yaml
           - path: lca/LcaSubscriptionOperGroup.yaml
+  - name: optional-cert-manager
+    description: |-
+      cert-manager operator for managing TLS certificates
+    components:
+      - name: cert-manager-operator
+        allOrNoneOf:
+          - path: cert-manager/certManagerSubscription.yaml
+            config:
+              fieldsToOmitRefs:
+                - subscriptions
+          - path: cert-manager/certManagerNS.yaml
+          - path: cert-manager/certManagerOperatorgroup.yaml
   - name: optional-nmstate-operator
     description: |-
       The nmstate operator is only used in multinode clusters when required by IPSec:

--- a/telco-ran/configuration/source-crs/cert-manager/README.md
+++ b/telco-ran/configuration/source-crs/cert-manager/README.md
@@ -1,0 +1,108 @@
+# Cert-Manager Configuration
+
+This directory contains optional configurations for using cert-manager to manage TLS certificates in OpenShift.
+
+## Overview
+
+Cert-manager automates the management and issuance of TLS certificates from various issuing sources. This configuration demonstrates how to:
+- Install the cert-manager operator
+- Configure an ACME issuer using DNS-01 challenge
+- Generate and use custom certificates for API Server and Ingress endpoints
+
+## Files
+
+### Operator Installation
+- `certManagerNS.yaml` - Creates the cert-manager-operator namespace
+- `certManagerOperatorgroup.yaml` - Creates the OperatorGroup for cert-manager
+- `certManagerSubscription.yaml` - Installs the OpenShift cert-manager operator
+
+### Certificate Issuers
+
+- `certManagerClusterIssuer.yaml` - **ACME issuer** with DNS-01 challenge (reference recommendation)
+
+### Certificate Resources
+- `apiServerCertificate.yaml` - Creates a certificate for the API Server endpoint
+- `ingressCertificate.yaml` - Creates a wildcard certificate for the Ingress/Router
+
+### OpenShift Configuration
+- `apiServerConfig.yaml` - Configures OpenShift to use the cert-manager generated API Server certificate
+- `ingressControllerConfig.yaml` - Configures OpenShift to use the cert-manager generated Ingress certificate
+
+## Customization Required
+
+Before applying these configurations, you must customize the following:
+
+1. **ClusterIssuer** (`certManagerClusterIssuer.yaml`):
+   - Update `email` with your contact email
+   - Configure the appropriate DNS provider for DNS-01 challenge (example shows Route53)
+   - Reference pre-created Secrets for DNS provider credentials via `secretRef` — do not commit credentials in manifests
+
+   > **Note:** Other issuer types (e.g., CA issuer for disconnected environments with existing PKI) are allowable.
+   > Users may configure their own ClusterIssuer; currently only ACME issuer is provided in the reference.
+
+2. **Certificates** (`apiServerCertificate.yaml` and `ingressCertificate.yaml`):
+   - Update `commonName` and `dnsNames` to match your cluster's domain
+   - Example: Replace `api.example.com` with your actual API endpoint
+   - Example: Replace `*.apps.example.com` with your actual wildcard domain
+
+3. **APIServer Configuration** (`apiServerConfig.yaml`):
+   - Update the `names` field to match your API Server FQDN
+
+## Deployment Order
+
+1. Deploy operator installation files (NS, OperatorGroup, Subscription)
+2. Wait for operator to be ready
+3. Deploy the ClusterIssuer
+4. Deploy the Certificate resources
+5. Wait for certificates to be issued and secrets created
+6. Apply the APIServer and IngressController configurations
+
+## Certificate Verification
+
+After applying these configurations, verify that:
+- Certificates are issued: `oc get certificate -A`
+- Secrets are created: `oc get secret api-server-cert -n openshift-config` and `oc get secret ingress-wildcard-cert -n openshift-ingress`
+- API Server is using the certificate: Test HTTPS connection to API endpoint
+- Ingress is using the certificate: Test HTTPS connection to any route
+
+## Important: Kubeconfig Trust After API Server Cert Replacement
+
+> **Note:** This section applies only when using a CA issuer with a private PKI (e.g., disconnected
+> environments). If you are using the reference ACME issuer with a publicly trusted CA such as
+> Let's Encrypt, the issued certificates are already in public trust stores and you can skip this
+> section entirely.
+
+> **Warning:** When using a non-publicly-trusted issuer, you must complete the kubeconfig update below
+> *before* applying the APIServer configuration (step 6 in the deployment order above).
+> Applying the APIServer configuration first will lock you out — the embedded
+> `certificate-authority-data` in existing kubeconfig files still references the original cluster CA
+> and cannot verify the new certificate. All `oc` and API client commands will fail with
+> `x509: certificate signed by unknown authority`.
+
+### Updating kubeconfig
+
+1. Extract the new root CA certificate (replace `root-ca-secret` with the `secretName` configured in your CA issuer):
+   ```bash
+   oc get secret root-ca-secret -n cert-manager -o jsonpath='{.data.tls\.crt}' | base64 -d > /tmp/root-ca.crt
+   ```
+
+2. Update your kubeconfig to trust the new CA:
+   ```bash
+   oc config set-cluster $(oc config current-context | cut -d/ -f2) \
+     --certificate-authority=/tmp/root-ca.crt --embed-certs
+   ```
+
+3. Verify connectivity:
+   ```bash
+   oc cluster-info
+   ```
+
+### Best practice for PKI environments
+
+Generate a root CA once and use it as the root for your PKI (the ACME issuer or CA issuer your clusters will use). Add the root CA PEM to `/etc/pki/ca-trust/source/anchors/` on your workstation and run `update-ca-trust`. All certificates issued from that root CA will then be trusted without per-cluster kubeconfig updates.
+
+## References
+
+- [OpenShift Cert-Manager Operator Documentation](https://docs.openshift.com/container-platform/latest/security/cert_manager_operator/index.html)
+- [Cert-Manager Documentation](https://cert-manager.io/docs/)
+- [ACME DNS-01 Challenge Configuration](https://cert-manager.io/docs/configuration/acme/dns01/)

--- a/telco-ran/configuration/source-crs/cert-manager/apiServerCertificate.yaml
+++ b/telco-ran/configuration/source-crs/cert-manager/apiServerCertificate.yaml
@@ -1,0 +1,20 @@
+apiVersion: cert-manager.io/v1
+kind: Certificate
+metadata:
+  name: api-server-certificate
+  namespace: openshift-config
+  annotations:
+    ran.openshift.io/ztp-deploy-wave: "10"
+spec:
+  commonName: "api.example.com"
+  dnsNames:
+  - "api.example.com"
+  isCA: false
+  issuerRef:
+    group: cert-manager.io
+    kind: ClusterIssuer
+    name: acme-issuer
+  privateKey:
+    algorithm: ECDSA
+    size: 256
+  secretName: api-server-cert

--- a/telco-ran/configuration/source-crs/cert-manager/apiServerConfig.yaml
+++ b/telco-ran/configuration/source-crs/cert-manager/apiServerConfig.yaml
@@ -1,0 +1,13 @@
+apiVersion: config.openshift.io/v1
+kind: APIServer
+metadata:
+  name: cluster
+  annotations:
+    ran.openshift.io/ztp-deploy-wave: "10"
+spec:
+  servingCerts:
+    namedCertificates:
+    - names:
+      - "api.example.com"
+      servingCertificate:
+        name: api-server-cert

--- a/telco-ran/configuration/source-crs/cert-manager/certManagerClusterIssuer.yaml
+++ b/telco-ran/configuration/source-crs/cert-manager/certManagerClusterIssuer.yaml
@@ -1,0 +1,18 @@
+apiVersion: cert-manager.io/v1
+kind: ClusterIssuer
+metadata:
+  name: acme-issuer
+  annotations:
+    ran.openshift.io/ztp-deploy-wave: "10"
+spec:
+  # Example based on: https://cert-manager.io/docs/configuration/acme/#creating-a-basic-acme-issuer
+  acme:
+    server: https://acme-v02.api.letsencrypt.org/directory
+    email: your-email@example.com
+    privateKeySecretRef:
+      name: acme-account-key
+    solvers:
+    - dns01:
+        route53:
+          region: us-east-1
+          # See: https://cert-manager.io/docs/configuration/acme/dns01/

--- a/telco-ran/configuration/source-crs/cert-manager/certManagerNS.yaml
+++ b/telco-ran/configuration/source-crs/cert-manager/certManagerNS.yaml
@@ -1,0 +1,9 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: cert-manager-operator
+  annotations:
+    workload.openshift.io/allowed: management
+    ran.openshift.io/ztp-deploy-wave: "2"
+  labels:
+    openshift.io/cluster-monitoring: "true"

--- a/telco-ran/configuration/source-crs/cert-manager/certManagerOperatorStatus.yaml
+++ b/telco-ran/configuration/source-crs/cert-manager/certManagerOperatorStatus.yaml
@@ -1,0 +1,26 @@
+# This CR verifies the installation/upgrade of the cert-manager Operator
+apiVersion: operators.coreos.com/v1
+kind: Operator
+metadata:
+  name: openshift-cert-manager-operator.cert-manager-operator
+  annotations:
+    ran.openshift.io/ztp-deploy-wave: "2"
+status:
+  components:
+    refs:
+    - kind: Subscription
+      namespace: cert-manager-operator
+      conditions:
+      - type: CatalogSourcesUnhealthy
+        status: "False"
+    - kind: InstallPlan
+      namespace: cert-manager-operator
+      conditions:
+      - type: Installed
+        status: "True"
+    - kind: ClusterServiceVersion
+      namespace: cert-manager-operator
+      conditions:
+      - type: Succeeded
+        status: "True"
+        reason: InstallSucceeded

--- a/telco-ran/configuration/source-crs/cert-manager/certManagerOperatorgroup.yaml
+++ b/telco-ran/configuration/source-crs/cert-manager/certManagerOperatorgroup.yaml
@@ -1,0 +1,10 @@
+apiVersion: operators.coreos.com/v1
+kind: OperatorGroup
+metadata:
+  name: cert-manager-operator
+  namespace: cert-manager-operator
+  annotations:
+    operatorframework.io/bundle-unpack-min-retry-interval: 10m
+    ran.openshift.io/ztp-deploy-wave: "2"
+spec:
+  upgradeStrategy: Default

--- a/telco-ran/configuration/source-crs/cert-manager/certManagerSubscription.yaml
+++ b/telco-ran/configuration/source-crs/cert-manager/certManagerSubscription.yaml
@@ -1,0 +1,15 @@
+apiVersion: operators.coreos.com/v1alpha1
+kind: Subscription
+metadata:
+  name: openshift-cert-manager-operator
+  namespace: cert-manager-operator
+  annotations:
+    ran.openshift.io/ztp-deploy-wave: "2"
+spec:
+  channel: "stable-v1"
+  name: openshift-cert-manager-operator
+  source: redhat-operators-disconnected
+  sourceNamespace: openshift-marketplace
+  installPlanApproval: Manual
+status:
+  state: AtLatestKnown

--- a/telco-ran/configuration/source-crs/cert-manager/ingressCertificate.yaml
+++ b/telco-ran/configuration/source-crs/cert-manager/ingressCertificate.yaml
@@ -1,0 +1,20 @@
+apiVersion: cert-manager.io/v1
+kind: Certificate
+metadata:
+  name: ingress-wildcard-certificate
+  namespace: openshift-ingress
+  annotations:
+    ran.openshift.io/ztp-deploy-wave: "10"
+spec:
+  commonName: "*.apps.example.com"
+  dnsNames:
+  - "*.apps.example.com"
+  isCA: false
+  issuerRef:
+    group: cert-manager.io
+    kind: ClusterIssuer
+    name: acme-issuer
+  privateKey:
+    algorithm: ECDSA
+    size: 256
+  secretName: ingress-wildcard-cert

--- a/telco-ran/configuration/source-crs/cert-manager/ingressControllerConfig.yaml
+++ b/telco-ran/configuration/source-crs/cert-manager/ingressControllerConfig.yaml
@@ -1,0 +1,10 @@
+apiVersion: operator.openshift.io/v1
+kind: IngressController
+metadata:
+  name: default
+  namespace: openshift-ingress-operator
+  annotations:
+    ran.openshift.io/ztp-deploy-wave: "10"
+spec:
+  defaultCertificate:
+    name: ingress-wildcard-cert


### PR DESCRIPTION
## Summary

- Restores cert-manager as an optional component in the RAN profile after removal for 4.22 GA (PR #801, OCPBUGS-86666)
- Branches have been cut, so it is safe to merge back to main per Ian's confirmation
- README updated with ACME-only issuer wording and kubeconfig trust guidance aligned with hub cert-manager improvements (PR #773)
- **Uses ECDSA P-256 certificates per TLS 1.3 requirements** (see PR #773 for rationale)

## Certificate Algorithm Note

Companion PR #773 uses **ECDSA P-256** for all Certificate resources, which is required for TLS 1.3 compatibility. RSA key exchange has been removed from TLS 1.3 as it does not provide Forward Secrecy.

**Once this PR is merged**, the restored RAN Certificate resources will already use ECDSA per the TLS 1.3 standard. This aligns with the hub/core profiles from PR #773.

## Files Restored

**Source CRs** (`telco-ran/configuration/source-crs/cert-manager/`):
- Operator installation: NS, OperatorGroup, Subscription, OperatorStatus
- ACME ClusterIssuer with DNS-01 challenge
- API Server and Ingress certificates + OpenShift configs
- README with ACME recommendation, kubeconfig trust guidance

**Kube-Compare Templates** (`telco-ran/configuration/kube-compare-reference/cert-manager/`):
- NS, OperatorGroup, Subscription (templated source)

**Shared Config Updates**:
- `metadata.yaml` — `optional-cert-manager` component restored
- `compare_ignore` — OperatorStatus + config CRs re-added
- `default_value.yaml` — Subscription source default restored
- `acm-common-ranGen.yaml` — Commented-out PolicyGenerator entries restored

## Changes vs. Original (PR #773 alignment)

- README uses "ACME issuer with DNS-01 challenge (reference recommendation)" wording
- README notes other issuer types are allowable but only ACME is in the reference
- README includes kubeconfig trust guidance for non-publicly-trusted issuers
- ClusterIssuer comment references `secretRef` for DNS provider credentials
- Certificates use ECDSA P-256 per TLS 1.3 requirements

## Related

- Previous removal: #801 (OCPBUGS-86666)
- Hub cert-manager improvements: #773
- RDS updates: [MR !192](https://gitlab.cee.redhat.com/reference-configurations/reference-design-specifications/-/merge_requests/192)
