### PR TITLE
Moving ObjectBucketClaim creation to ODF folder

### DIFF
--- a/telco-hub/configuration/reference-crs-kube-compare/metadata.yaml
+++ b/telco-hub/configuration/reference-crs-kube-compare/metadata.yaml
@@ -55,6 +55,7 @@ parts:
           - path: optional/odf-internal/odfNS.yaml
           - path: optional/odf-internal/odfOperatorGroup.yaml
           - path: optional/odf-internal/odfSubscription.yaml
+          - path: optional/odf-internal/observabilityOBC.yaml
           - path: optional/odf-internal/storageCluster.yaml
             config:
               ignore-unspecified-fields: true
@@ -85,7 +86,6 @@ parts:
             config:
               ignore-unspecified-fields: true
           - path: required/acm/observabilityNS.yaml
-          - path: required/acm/observabilityOBC.yaml
             config:
               ignore-unspecified-fields: true
           - path: required/acm/observabilityMCSB.yaml

--- a/telco-hub/configuration/reference-crs-kube-compare/optional/odf-internal/observabilityOBC.yaml
+++ b/telco-hub/configuration/reference-crs-kube-compare/optional/odf-internal/observabilityOBC.yaml
@@ -2,7 +2,7 @@
 apiVersion: objectbucket.io/v1alpha1
 kind: ObjectBucketClaim
 metadata:
-  name: observability-obc
+  name: observability-object-bucket
   annotations:
     argocd.argoproj.io/sync-wave: "-10"
     argocd.argoproj.io/sync-options: SkipDryRunOnMissingResource=true

--- a/telco-hub/configuration/reference-crs/optional/odf-internal/kustomization.yaml
+++ b/telco-hub/configuration/reference-crs/optional/odf-internal/kustomization.yaml
@@ -7,3 +7,4 @@ resources:
   - odfSubscription.yaml
   - storageCluster.yaml
   - odfReady.yaml
+  - observabilityOBC.yaml

--- a/telco-hub/configuration/reference-crs/optional/odf-internal/observabilityOBC.yaml
+++ b/telco-hub/configuration/reference-crs/optional/odf-internal/observabilityOBC.yaml
@@ -2,7 +2,7 @@
 apiVersion: objectbucket.io/v1alpha1
 kind: ObjectBucketClaim
 metadata:
-  name: observability-obc
+  name: observability-object-bucket
   annotations:
     argocd.argoproj.io/sync-wave: "-10"
     argocd.argoproj.io/sync-options: SkipDryRunOnMissingResource=true

--- a/telco-hub/configuration/reference-crs/required/acm/kustomization.yaml
+++ b/telco-hub/configuration/reference-crs/required/acm/kustomization.yaml
@@ -12,7 +12,6 @@ resources:
   - acmPerfSearch.yaml
   - acmProvisioning.yaml
   - observabilityNS.yaml
-  - observabilityOBC.yaml
   - observabilityRoutePolicy.yaml
   - observabilityRoutePlacement.yaml
   - observabilityRoutePlacementBinding.yaml

--- a/telco-hub/configuration/reference-crs/required/acm/readme.md
+++ b/telco-hub/configuration/reference-crs/required/acm/readme.md
@@ -11,22 +11,22 @@
 9. Create the pull-secret. There are two methods to create the pull-secret:
     - The pull-secret multiclusterhub-operator-pull-secret can be automatically created by the ACM policy in pullSecretPolicy.yaml. If secret multiclusterhub-operator-pull-secret exists in open-cluster-management, the policy copy it to ns open-cluster-management-observability. If the previous command returns an empty value, then copy secret pull-secret from ns openshift-config.
     - If you want to use your own pull-secret, you may update the value of .dockerconfigjson in observabilitySecret.yaml.
-10. Create the `observabilityOBC.yaml`.
-11. The Thanos secret will be automatically created by the ACM Policy
-    in `thanosSecretPolicy.yaml`.
-    - The `bucket` and the `endpoint` are copied from the ConfigMap
-      that the OBC automatically creates in its namespace. The policy
+10. The Thanos secret will be automatically created by the ACM Policy
+    in `thanosSecretPolicy.yaml`. This secret connects an S3 buckets storage with Thanos:
+    - The `bucket` and the `endpoint` are copied from a ConfigMap
+      named `observability-object-bucket`. The policy
       pulls the bucket name and host from the fields `BUCKET_NAME`
       (without any protocol or port specification) and `BUCKET_HOST`
       respectively.
-    - The `access_key` and the `secret_key` are copied from the Secret
-      that the OBC creates automatically in its namespace. The fields
+    - The `access_key` and the `secret_key` are copied from a Secret
+      named `observability-object-bucket`. The fields
       `AWS_ACCESS_KEY_ID` and `AWS_SECRET_ACCESS_KEY` are pulled from
       the secret and base64 decoded before being inserted into the
       Thanos secret.
-12. Create the `observabilityMCO.yaml`.
-13. When all the installation is done. Apply the `acmPerfSearch.yaml` .This will configure Search CR called `search-v2-operator` considering different performance and scale optimizations.
-14. When ACM Observability is configured on a managed cluster through the Core or RAN profile, the default ACM Observability configuration must be merged with the RAN monitoring tuning [ReduceMonitoringFootprint.yaml](../../../../../telco-ran/configuration/source-crs/ReduceMonitoringFootprint.yaml) or Core monitoring config [monitoring-config-cm.yaml](../../../../../telco-core/configuration/reference-crs/optional/other/monitoring-config-cm.yaml) respectively.
+    - Both, the Secret and the Configmap, are provided automatically if you use the option `odf-external` component. If not, the user needs the provide both CRs, according to its buckets storage information.
+11. Create the `observabilityMCO.yaml`.
+12. When all the installation is done. Apply the `acmPerfSearch.yaml` .This will configure Search CR called `search-v2-operator` considering different performance and scale optimizations.
+13. When ACM Observability is configured on a managed cluster through the Core or RAN profile, the default ACM Observability configuration must be merged with the RAN monitoring tuning [ReduceMonitoringFootprint.yaml](../../../../../telco-ran/configuration/source-crs/ReduceMonitoringFootprint.yaml) or Core monitoring config [monitoring-config-cm.yaml](../../../../../telco-core/configuration/reference-crs/optional/other/monitoring-config-cm.yaml) respectively.
     * To ensure that these changes persist, ACM has to stop managing the cluster-monitoring-config ConfigMap, which is achieved through this annotation [here](../../../../../telco-hub/configuration/reference-crs/required/acm/observabilityMCO.yaml#L13).
     * When mco-alerting is disabled, the [obs-route-policy](observabilityRoutePolicy.yaml) should be used for propagating the alertmanager URL from the ACM observability route to all managed clusters through the `acm-alertmanager-route` annotation.
 

--- a/telco-hub/configuration/reference-crs/required/acm/thanosSecretPolicy.yaml
+++ b/telco-hub/configuration/reference-crs/required/acm/thanosSecretPolicy.yaml
@@ -27,8 +27,8 @@ spec:
         severity: high
         object-templates-raw: |
           {{- /* read the bucket data and noobaa endpoint access data */ -}}
-          {{- $objBucket := (lookup "v1" "ConfigMap" "open-cluster-management-observability" "observability-obc") }}
-          {{- $awsAccess := (lookup "v1" "Secret" "open-cluster-management-observability" "observability-obc") }}
+          {{- $objBucket := (lookup "v1" "ConfigMap" "open-cluster-management-observability" "observability-object-bucket") }}
+          {{- $awsAccess := (lookup "v1" "Secret" "open-cluster-management-observability" "observability-object-bucket") }}
           {{- /* create the thanos config file as a template */ -}}
           {{- $thanosConfig := `
           type: s3

--- a/telco-hub/configuration/reference-crs/required/gitops/addPluginsPolicy.yaml
+++ b/telco-hub/configuration/reference-crs/required/gitops/addPluginsPolicy.yaml
@@ -75,9 +75,9 @@ spec:
                             mountPath: "/.config"
                         terminationMessagePolicy: "File"
                         terminationMessagePath: "/dev/termination-log"
-                        image: "registry.redhat.io/openshift4/ztp-site-generate-rhel8:v4.22"
+                        image: "registry.redhat.io/openshift4/ztp-site-generate-rhel8:v4.21"
                       - name: "policy-generator-install"
-                        image: "registry.redhat.io/rhacm2/multicluster-operators-subscription-rhel9:v2.17"
+                        image: "registry.redhat.io/rhacm2/multicluster-operators-subscription-rhel9:v2.16"
                         imagePullPolicy: "Always"
                         volumeMounts:
                           - name: "kustomize"


### PR DESCRIPTION
OBC (ObjectBucketClaim) is a CR managed by ODF. So, unless we have installed ODF, the Manifest will never work. 

The OBC was created to configure Thanos for Observability (MCO) storage. As it is now, we are making ACM dependent on ODF.  If ODF is not installed, the OBC creation, that is in the ACM folder, cannot be created and Observability will never work.

With this PR, we  make Observability Policy, that configures Thanos storage, to depend on existing CM and Secret with the S3 info. If you have ODF, these are created by the OBC, if not the user needs to provide them. 

Note: I have changed ztp-site-generate and acm to version of release-4.21, just for testing purpose. We have to fix this if we agree to merge