### PR TITLE
CNF-22724: Add External Secrets Operator reference configuration

### DIFF
--- a/telco-core/configuration/core-baseline.yaml
+++ b/telco-core/configuration/core-baseline.yaml
@@ -52,6 +52,14 @@ policies:
       # - path: reference-crs/optional/cert-manager/certManagerOperatorgroup.yaml
       # - path: reference-crs/optional/cert-manager/certManagerSubscription.yaml
 
+      # External Secrets Operator (optional component - included by default)
+      - path: reference-crs/optional/external-secrets/esoNS.yaml
+      - path: reference-crs/optional/external-secrets/esoOperatorgroup.yaml
+      - path: reference-crs/optional/external-secrets/esoSubscription.yaml
+        patches:
+        - spec:
+            installPlanApproval: Manual
+
       - path: reference-crs/required/networking/sriov/SriovSubscriptionNS.yaml
       - path: reference-crs/required/networking/sriov/SriovSubscriptionOperGroup.yaml
       - path: reference-crs/required/networking/sriov/SriovSubscription.yaml
@@ -89,6 +97,11 @@ policies:
     policyAnnotations:
       ran.openshift.io/ztp-deploy-wave: "6"
     manifests:
+      # External Secrets Operator configuration (optional component - included by default)
+      - path: reference-crs/optional/external-secrets/esoExternalSecretsConfig.yaml
+      - path: reference-crs/optional/external-secrets/esoClusterSecretStore.yaml
+      - path: reference-crs/optional/external-secrets/esoNetworkPolicy.yaml
+
       - path: reference-crs/optional/logging/ClusterLogServiceAccount.yaml
       - path: reference-crs/optional/logging/ClusterLogServiceAccountAuditBinding.yaml
       - path: reference-crs/optional/logging/ClusterLogServiceAccountInfrastructureBinding.yaml

--- a/telco-core/configuration/reference-crs-kube-compare/metadata.yaml
+++ b/telco-core/configuration/reference-crs-kube-compare/metadata.yaml
@@ -206,6 +206,22 @@ parts:
         allOf:
           - path: optional/other/mount_namespace_config_master.yaml
           - path: optional/other/mount_namespace_config_worker.yaml
+  - name: optional-external-secrets
+    description: |-
+      External Secrets Operator for secure secret management via external stores
+    components:
+      - name: external-secrets-operator
+        allOrNoneOf:
+          - path: optional/external-secrets/esoNS.yaml
+          - path: optional/external-secrets/esoOperatorgroup.yaml
+          - path: optional/external-secrets/esoSubscription.yaml
+          - path: optional/external-secrets/esoExternalSecretsConfig.yaml
+          - path: optional/external-secrets/esoClusterSecretStore.yaml
+            config:
+              ignore-unspecified-fields: true
+          - path: optional/external-secrets/esoNetworkPolicy.yaml
+            config:
+              ignore-unspecified-fields: true
   - name: optional-cert-manager
     description: |-
       Cert-manager operator for automated certificate management

--- a/telco-core/configuration/reference-crs-kube-compare/optional/external-secrets/esoClusterSecretStore.yaml
+++ b/telco-core/configuration/reference-crs-kube-compare/optional/external-secrets/esoClusterSecretStore.yaml
@@ -1,0 +1,21 @@
+---
+apiVersion: external-secrets.io/v1
+kind: ClusterSecretStore
+metadata:
+  name: ztp-secret-provider
+spec:
+  conditions:
+    - namespaceSelector:
+        matchExpressions:
+          - key: cluster.open-cluster-management.io/managedCluster
+            operator: Exists
+  provider:
+    vault:
+      server: {{ .spec.provider.vault.server | quote }}
+      path: {{ .spec.provider.vault.path | quote }}
+      version: {{ .spec.provider.vault.version | quote }}
+      auth:
+        tokenSecretRef:
+          name: {{ .spec.provider.vault.auth.tokenSecretRef.name }}
+          key: {{ .spec.provider.vault.auth.tokenSecretRef.key }}
+          namespace: {{ .spec.provider.vault.auth.tokenSecretRef.namespace }}

--- a/telco-core/configuration/reference-crs-kube-compare/optional/external-secrets/esoExternalSecretsConfig.yaml
+++ b/telco-core/configuration/reference-crs-kube-compare/optional/external-secrets/esoExternalSecretsConfig.yaml
@@ -1,0 +1,6 @@
+---
+apiVersion: operator.openshift.io/v1alpha1
+kind: ExternalSecretsConfig
+metadata:
+  name: cluster
+spec: {}

--- a/telco-core/configuration/reference-crs-kube-compare/optional/external-secrets/esoNS.yaml
+++ b/telco-core/configuration/reference-crs-kube-compare/optional/external-secrets/esoNS.yaml
@@ -1,0 +1,7 @@
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+  annotations:
+    workload.openshift.io/allowed: management
+  name: external-secrets-operator

--- a/telco-core/configuration/reference-crs-kube-compare/optional/external-secrets/esoNetworkPolicy.yaml
+++ b/telco-core/configuration/reference-crs-kube-compare/optional/external-secrets/esoNetworkPolicy.yaml
@@ -1,0 +1,20 @@
+---
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: allow-secret-store-egress
+  namespace: external-secrets
+spec:
+  podSelector:
+    matchLabels:
+      app.kubernetes.io/name: external-secrets
+  policyTypes:
+    - Egress
+  egress:
+    - to:
+        - namespaceSelector:
+            matchLabels:
+              kubernetes.io/metadata.name: vault
+      ports:
+        - port: 8200
+          protocol: TCP

--- a/telco-core/configuration/reference-crs-kube-compare/optional/external-secrets/esoOperatorgroup.yaml
+++ b/telco-core/configuration/reference-crs-kube-compare/optional/external-secrets/esoOperatorgroup.yaml
@@ -1,0 +1,11 @@
+---
+apiVersion: operators.coreos.com/v1
+kind: OperatorGroup
+metadata:
+  annotations:
+    operatorframework.io/bundle-unpack-timeout: "10m"
+    operatorframework.io/bundle-unpack-min-retry-interval: 10m
+  name: openshift-external-secrets-operator
+  namespace: external-secrets-operator
+spec:
+  upgradeStrategy: Default

--- a/telco-core/configuration/reference-crs-kube-compare/optional/external-secrets/esoSubscription.yaml
+++ b/telco-core/configuration/reference-crs-kube-compare/optional/external-secrets/esoSubscription.yaml
@@ -1,0 +1,14 @@
+---
+apiVersion: operators.coreos.com/v1alpha1
+kind: Subscription
+metadata:
+  name: openshift-external-secrets-operator
+  namespace: external-secrets-operator
+spec:
+  channel: stable-v1
+  name: openshift-external-secrets-operator
+  source: redhat-operators-disconnected
+  sourceNamespace: openshift-marketplace
+  installPlanApproval: Manual
+status:
+  state: AtLatestKnown

--- a/telco-core/configuration/reference-crs/optional/external-secrets/esoClusterSecretStore.yaml
+++ b/telco-core/configuration/reference-crs/optional/external-secrets/esoClusterSecretStore.yaml
@@ -1,0 +1,22 @@
+---
+apiVersion: external-secrets.io/v1
+kind: ClusterSecretStore
+metadata:
+  name: ztp-secret-provider
+spec:
+  # Restrict store usage to RHACM managed-cluster namespaces only
+  conditions:
+    - namespaceSelector:
+        matchExpressions:
+          - key: cluster.open-cluster-management.io/managedCluster
+            operator: Exists
+  provider:
+    vault:
+      server: "https://vault.example.com:8200"
+      path: "secret"
+      version: "v2"
+      auth:
+        tokenSecretRef:
+          name: vault-token
+          key: token
+          namespace: external-secrets-operator

--- a/telco-core/configuration/reference-crs/optional/external-secrets/esoExternalSecretsConfig.yaml
+++ b/telco-core/configuration/reference-crs/optional/external-secrets/esoExternalSecretsConfig.yaml
@@ -1,0 +1,6 @@
+---
+apiVersion: operator.openshift.io/v1alpha1
+kind: ExternalSecretsConfig
+metadata:
+  name: cluster
+spec: {}

--- a/telco-core/configuration/reference-crs/optional/external-secrets/esoNS.yaml
+++ b/telco-core/configuration/reference-crs/optional/external-secrets/esoNS.yaml
@@ -1,0 +1,7 @@
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+  annotations:
+    workload.openshift.io/allowed: management
+  name: external-secrets-operator

--- a/telco-core/configuration/reference-crs/optional/external-secrets/esoNetworkPolicy.yaml
+++ b/telco-core/configuration/reference-crs/optional/external-secrets/esoNetworkPolicy.yaml
@@ -1,0 +1,20 @@
+---
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: allow-secret-store-egress
+  namespace: external-secrets
+spec:
+  podSelector:
+    matchLabels:
+      app.kubernetes.io/name: external-secrets
+  policyTypes:
+    - Egress
+  egress:
+    - to:
+        - namespaceSelector:
+            matchLabels:
+              kubernetes.io/metadata.name: vault
+      ports:
+        - port: 8200
+          protocol: TCP

--- a/telco-core/configuration/reference-crs/optional/external-secrets/esoOperatorgroup.yaml
+++ b/telco-core/configuration/reference-crs/optional/external-secrets/esoOperatorgroup.yaml
@@ -1,0 +1,10 @@
+---
+apiVersion: operators.coreos.com/v1
+kind: OperatorGroup
+metadata:
+  annotations:
+    operatorframework.io/bundle-unpack-min-retry-interval: 10m
+  name: openshift-external-secrets-operator
+  namespace: external-secrets-operator
+spec:
+  upgradeStrategy: Default

--- a/telco-core/configuration/reference-crs/optional/external-secrets/esoSubscription.yaml
+++ b/telco-core/configuration/reference-crs/optional/external-secrets/esoSubscription.yaml
@@ -1,0 +1,14 @@
+---
+apiVersion: operators.coreos.com/v1alpha1
+kind: Subscription
+metadata:
+  name: openshift-external-secrets-operator
+  namespace: external-secrets-operator
+spec:
+  channel: stable-v1
+  name: openshift-external-secrets-operator
+  source: redhat-operators-disconnected
+  sourceNamespace: openshift-marketplace
+  installPlanApproval: Manual
+status:
+  state: AtLatestKnown

--- a/telco-hub/configuration/example-overlays-config/external-secrets/cluster-secret-store-patch.yaml
+++ b/telco-hub/configuration/example-overlays-config/external-secrets/cluster-secret-store-patch.yaml
@@ -1,0 +1,9 @@
+# Patch the ClusterSecretStore with your secret store server address.
+# Update the server URL and path to match your environment.
+- op: replace
+  path: /spec/provider/vault/server
+  value: "https://vault.example.com:8200"
+
+- op: replace
+  path: /spec/provider/vault/path
+  value: "secret"

--- a/telco-hub/configuration/example-overlays-config/external-secrets/kustomization.yaml
+++ b/telco-hub/configuration/example-overlays-config/external-secrets/kustomization.yaml
@@ -1,0 +1,23 @@
+---
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+resources:
+  - ../../reference-crs/optional/external-secrets/
+
+patches:
+  # Customize ClusterSecretStore for your secret store backend
+  - target:
+      group: external-secrets.io
+      version: v1
+      kind: ClusterSecretStore
+      name: ztp-secret-provider
+    path: cluster-secret-store-patch.yaml
+
+  # Customize NetworkPolicy target for your secret store namespace/port
+  - target:
+      group: networking.k8s.io
+      version: v1
+      kind: NetworkPolicy
+      name: allow-secret-store-egress
+    path: network-policy-patch.yaml

--- a/telco-hub/configuration/example-overlays-config/external-secrets/network-policy-patch.yaml
+++ b/telco-hub/configuration/example-overlays-config/external-secrets/network-policy-patch.yaml
@@ -1,0 +1,9 @@
+# Patch the NetworkPolicy to target your secret store namespace and port.
+# Update the namespace label and port to match your environment.
+- op: replace
+  path: /spec/egress/0/to/0/namespaceSelector/matchLabels/kubernetes.io~1metadata.name
+  value: "vault"
+
+- op: replace
+  path: /spec/egress/0/ports/0/port
+  value: 8200

--- a/telco-hub/configuration/kustomization.yaml
+++ b/telco-hub/configuration/kustomization.yaml
@@ -10,6 +10,9 @@ resources:
   # if you use ODF, edit and configure storage settings
   - example-overlays-config/odf/
 
+  # external secrets operator (optional, included by default, customize before deploying)
+  - example-overlays-config/external-secrets/
+
   # other not optional overlays
   - example-overlays-config/gitops/
   - example-overlays-config/acm/

--- a/telco-hub/configuration/reference-crs-kube-compare/metadata.yaml
+++ b/telco-hub/configuration/reference-crs-kube-compare/metadata.yaml
@@ -38,6 +38,28 @@ parts:
           - path: optional/cert-manager/certManagerCertificatePolicy.yaml
           - path: optional/cert-manager/certManagerCertificatePolicyPlacement.yaml
           - path: optional/cert-manager/certManagerCertificatePolicyPlacementBinding.yaml
+  - name: optional-external-secrets
+    description: |-
+      External Secrets Operator for secure secret management via external stores
+    components:
+      - name: external-secrets-operator
+        allOrNoneOf:
+          - path: optional/external-secrets/esoNS.yaml
+          - path: optional/external-secrets/esoOperatorgroup.yaml
+          - path: optional/external-secrets/esoSubscription.yaml
+          - path: optional/external-secrets/esoExternalSecretsConfig.yaml
+          - path: optional/external-secrets/esoClusterSecretStore.yaml
+            config:
+              ignore-unspecified-fields: true
+          - path: optional/external-secrets/esoNetworkPolicy.yaml
+            config:
+              ignore-unspecified-fields: true
+          - path: optional/external-secrets/esoClusterTemplates.yaml
+            config:
+              ignore-unspecified-fields: true
+          - path: optional/external-secrets/esoNodeTemplates.yaml
+            config:
+              ignore-unspecified-fields: true
   - name: optional-storage
     components:
       - name: local-storage-operator

--- a/telco-hub/configuration/reference-crs-kube-compare/optional/external-secrets/esoClusterSecretStore.yaml
+++ b/telco-hub/configuration/reference-crs-kube-compare/optional/external-secrets/esoClusterSecretStore.yaml
@@ -1,0 +1,23 @@
+---
+apiVersion: external-secrets.io/v1
+kind: ClusterSecretStore
+metadata:
+  annotations:
+    argocd.argoproj.io/sync-wave: "-30"
+  name: ztp-secret-provider
+spec:
+  conditions:
+    - namespaceSelector:
+        matchExpressions:
+          - key: cluster.open-cluster-management.io/managedCluster
+            operator: Exists
+  provider:
+    vault:
+      server: {{ .spec.provider.vault.server | quote }}
+      path: {{ .spec.provider.vault.path | quote }}
+      version: {{ .spec.provider.vault.version | quote }}
+      auth:
+        tokenSecretRef:
+          name: {{ .spec.provider.vault.auth.tokenSecretRef.name }}
+          key: {{ .spec.provider.vault.auth.tokenSecretRef.key }}
+          namespace: {{ .spec.provider.vault.auth.tokenSecretRef.namespace }}

--- a/telco-hub/configuration/reference-crs-kube-compare/optional/external-secrets/esoClusterTemplates.yaml
+++ b/telco-hub/configuration/reference-crs-kube-compare/optional/external-secrets/esoClusterTemplates.yaml
@@ -1,0 +1,31 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: eso-cluster-templates-v1
+  namespace: open-cluster-management
+  annotations:
+    argocd.argoproj.io/sync-wave: "-30"
+data:
+  PullSecretExternalSecret: |-
+    apiVersion: external-secrets.io/v1
+    kind: ExternalSecret
+    metadata:
+      name: "{{ "{{ .Spec.PullSecretRef.Name }}" }}"
+      namespace: "{{ "{{ .Spec.ClusterName }}" }}"
+      annotations:
+        siteconfig.open-cluster-management.io/sync-wave: "1"
+    spec:
+      refreshPolicy: OnChange
+      secretStoreRef:
+        name: ztp-secret-provider
+        kind: ClusterSecretStore
+      target:
+        name: "{{ "{{ .Spec.PullSecretRef.Name }}" }}"
+        creationPolicy: Owner
+        template:
+          type: kubernetes.io/dockerconfigjson
+      data:
+        - secretKey: .dockerconfigjson
+          remoteRef:
+            key: clusters/{{ "{{ .Spec.ClusterName }}" }}/pull-secret
+            property: .dockerconfigjson

--- a/telco-hub/configuration/reference-crs-kube-compare/optional/external-secrets/esoExternalSecretsConfig.yaml
+++ b/telco-hub/configuration/reference-crs-kube-compare/optional/external-secrets/esoExternalSecretsConfig.yaml
@@ -1,0 +1,8 @@
+---
+apiVersion: operator.openshift.io/v1alpha1
+kind: ExternalSecretsConfig
+metadata:
+  annotations:
+    argocd.argoproj.io/sync-wave: "-30"
+  name: cluster
+spec: {}

--- a/telco-hub/configuration/reference-crs-kube-compare/optional/external-secrets/esoNS.yaml
+++ b/telco-hub/configuration/reference-crs-kube-compare/optional/external-secrets/esoNS.yaml
@@ -1,0 +1,8 @@
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+  annotations:
+    argocd.argoproj.io/sync-wave: "-45"
+    workload.openshift.io/allowed: management
+  name: external-secrets-operator

--- a/telco-hub/configuration/reference-crs-kube-compare/optional/external-secrets/esoNetworkPolicy.yaml
+++ b/telco-hub/configuration/reference-crs-kube-compare/optional/external-secrets/esoNetworkPolicy.yaml
@@ -1,0 +1,22 @@
+---
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: allow-secret-store-egress
+  namespace: external-secrets
+  annotations:
+    argocd.argoproj.io/sync-wave: "-25"
+spec:
+  podSelector:
+    matchLabels:
+      app.kubernetes.io/name: external-secrets
+  policyTypes:
+    - Egress
+  egress:
+    - to:
+        - namespaceSelector:
+            matchLabels:
+              kubernetes.io/metadata.name: vault
+      ports:
+        - port: 8200
+          protocol: TCP

--- a/telco-hub/configuration/reference-crs-kube-compare/optional/external-secrets/esoNodeTemplates.yaml
+++ b/telco-hub/configuration/reference-crs-kube-compare/optional/external-secrets/esoNodeTemplates.yaml
@@ -1,0 +1,33 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: eso-node-templates-v1
+  namespace: open-cluster-management
+  annotations:
+    argocd.argoproj.io/sync-wave: "-30"
+data:
+  BmcSecretExternalSecret: |-
+    apiVersion: external-secrets.io/v1
+    kind: ExternalSecret
+    metadata:
+      name: "{{ "{{ .SpecialVars.CurrentNode.BmcCredentialsName.Name }}" }}"
+      namespace: "{{ "{{ .Spec.ClusterName }}" }}"
+      annotations:
+        siteconfig.open-cluster-management.io/sync-wave: "1"
+    spec:
+      refreshPolicy: OnChange
+      secretStoreRef:
+        name: ztp-secret-provider
+        kind: ClusterSecretStore
+      target:
+        name: "{{ "{{ .SpecialVars.CurrentNode.BmcCredentialsName.Name }}" }}"
+        creationPolicy: Owner
+      data:
+        - secretKey: username
+          remoteRef:
+            key: clusters/{{ "{{ .Spec.ClusterName }}" }}/bmc/{{ "{{ .SpecialVars.CurrentNode.HostName }}" }}
+            property: username
+        - secretKey: password
+          remoteRef:
+            key: clusters/{{ "{{ .Spec.ClusterName }}" }}/bmc/{{ "{{ .SpecialVars.CurrentNode.HostName }}" }}
+            property: password

--- a/telco-hub/configuration/reference-crs-kube-compare/optional/external-secrets/esoOperatorgroup.yaml
+++ b/telco-hub/configuration/reference-crs-kube-compare/optional/external-secrets/esoOperatorgroup.yaml
@@ -1,0 +1,10 @@
+---
+apiVersion: operators.coreos.com/v1
+kind: OperatorGroup
+metadata:
+  annotations:
+    argocd.argoproj.io/sync-wave: "-40"
+  name: openshift-external-secrets-operator
+  namespace: external-secrets-operator
+spec:
+  upgradeStrategy: Default

--- a/telco-hub/configuration/reference-crs-kube-compare/optional/external-secrets/esoSubscription.yaml
+++ b/telco-hub/configuration/reference-crs-kube-compare/optional/external-secrets/esoSubscription.yaml
@@ -1,0 +1,14 @@
+---
+apiVersion: operators.coreos.com/v1alpha1
+kind: Subscription
+metadata:
+  annotations:
+    argocd.argoproj.io/sync-wave: "-40"
+  name: openshift-external-secrets-operator
+  namespace: external-secrets-operator
+spec:
+  channel: stable-v1
+  name: openshift-external-secrets-operator
+  source: {{ .spec.source }}
+  sourceNamespace: openshift-marketplace
+  installPlanApproval: Automatic

--- a/telco-hub/configuration/reference-crs/kustomization.yaml
+++ b/telco-hub/configuration/reference-crs/kustomization.yaml
@@ -5,6 +5,7 @@ resources:
   # comment the optional components when not using them
   - optional/lso/
   - optional/odf-internal/
+  - optional/external-secrets/
   # - optional/cert-manager/
   # everything under required is mandatory
   - required/gitops/

--- a/telco-hub/configuration/reference-crs/optional/external-secrets/README.md
+++ b/telco-hub/configuration/reference-crs/optional/external-secrets/README.md
@@ -1,0 +1,140 @@
+# External Secrets Operator
+
+ESO is the default reference implementation for secret management in the
+telco-hub RDS. Partners may substitute alternative secret management solutions
+as long as secrets are not stored in git.
+
+## Installation
+
+1. Create `esoNS.yaml`, `esoOperatorgroup.yaml`, `esoSubscription.yaml`.
+2. Wait for the operator to be ready.
+3. Create `esoExternalSecretsConfig.yaml` to deploy the operand.
+4. Inject the vault access secret into the cluster (see below).
+5. Create `esoNetworkPolicy.yaml` to allow ESO to reach the secret store.
+6. Create `esoClusterSecretStore.yaml`.
+7. Create `esoClusterTemplates.yaml` and `esoNodeTemplates.yaml`.
+
+## Vault access secret
+
+The `vault-token` secret referenced by `esoClusterSecretStore.yaml` must be
+created by the user after the Hub is configured. It must never be stored in
+git.
+
+```bash
+oc create secret generic vault-token \
+  --from-literal=token='<your-vault-token>' \
+  -n external-secrets-operator
+```
+
+## ClusterInstance templates
+
+Two template ConfigMaps provide automatic secret provisioning when a
+ClusterInstance is created:
+
+- `esoClusterTemplates.yaml` deploys a ConfigMap (`eso-cluster-templates-v1`)
+  containing a template for a pull secret ExternalSecret.
+- `esoNodeTemplates.yaml` deploys a ConfigMap (`eso-node-templates-v1`)
+  containing a template for a BMC credentials ExternalSecret.
+
+When the siteconfig-operator renders a ClusterInstance that references these
+templates, it creates ExternalSecret CRs in the cluster namespace. ESO then
+fetches the actual secret values from the configured secret store.
+
+### Vault structure contract
+
+**IMPORTANT**: The ExternalSecret templates define a binding contract between the
+Hub RDS and your secret store. The paths and property names below MUST be followed
+exactly in your Vault (or alternative secret store) deployment.
+
+The templates use the following vault key paths:
+
+- **Pull secret**: `clusters/<cluster-name>/pull-secret`
+  - Required property: `.dockerconfigjson` (string containing the full docker config JSON)
+  
+- **BMC credentials**: `clusters/<cluster-name>/bmc/<hostname>`
+  - Required properties:
+    - `username` (string)
+    - `password` (string)
+
+Where:
+- `<cluster-name>` is the value from `ClusterInstance.spec.clusterName`
+- `<hostname>` is the value from `ClusterInstance.spec.nodes[].hostName`
+
+**Example Vault structure** for a cluster named "sno-site-1" with one node:
+
+```
+secret/data/clusters/sno-site-1/pull-secret
+  .dockerconfigjson = '{"auths":{"registry.example.com":{"auth":"..."}}}'
+
+secret/data/clusters/sno-site-1/bmc/node1.sno-site-1.example.com
+  username = "admin"
+  password = "secretpassword"
+```
+
+This contract is documented in the telco-hub RDS. Any deviation from these
+paths or property names will cause cluster provisioning to fail.
+
+### Adding templateRefs to a ClusterInstance
+
+Add the ESO template ConfigMaps alongside the existing siteconfig templates
+in your ClusterInstance spec:
+
+```yaml
+spec:
+  templateRefs:
+    - name: ai-cluster-templates-v1
+      namespace: open-cluster-management
+    - name: eso-cluster-templates-v1
+      namespace: open-cluster-management
+  nodes:
+    - hostName: "node1.example.com"
+      templateRefs:
+        - name: ai-node-templates-v1
+          namespace: open-cluster-management
+        - name: eso-node-templates-v1
+          namespace: open-cluster-management
+```
+
+## Security considerations
+
+### Namespace restriction
+
+The ClusterSecretStore includes a `conditions` field with a `namespaceSelector`
+that restricts usage to namespaces labeled with
+`cluster.open-cluster-management.io/managedCluster`. This ensures only
+RHACM-managed cluster namespaces can create ExternalSecrets referencing
+`ztp-secret-provider`. ExternalSecrets in unlabeled namespaces are rejected.
+
+### Vault token scoping
+
+The `vault-token` secret should use a least-privilege Vault policy that limits
+access to only the paths required by the ZTP templates. Example Vault policy:
+
+```hcl
+path "secret/data/clusters/*" {
+  capabilities = ["read"]
+}
+```
+
+This restricts the token to read-only access under `clusters/`, matching the
+path convention used by the ClusterInstance templates. Avoid granting broader
+access (e.g., `secret/*`) even if convenient during initial setup.
+
+## Network policy
+
+The ESO operator deploys a `deny-all-traffic` NetworkPolicy in the `external-secrets`
+operand namespace. `esoNetworkPolicy.yaml` adds an egress rule allowing the ESO
+controller to reach the secret store. Update the target namespace label and port
+in the overlay patch to match your environment.
+
+## Customization required
+
+- Update `esoClusterSecretStore.yaml` with your secret store address, path,
+  and authentication method. The Vault example is illustrative; any provider
+  supported by ESO may be used.
+- Update `esoNetworkPolicy.yaml` target namespace and port to match your
+  secret store deployment (defaults to namespace `vault`, port 8200).
+- Adjust the vault key paths in `esoClusterTemplates.yaml` and
+  `esoNodeTemplates.yaml` if your secret store uses a different path layout.
+
+Back to [Hub Cluster Setup](../../../../README.md).

--- a/telco-hub/configuration/reference-crs/optional/external-secrets/esoClusterSecretStore.yaml
+++ b/telco-hub/configuration/reference-crs/optional/external-secrets/esoClusterSecretStore.yaml
@@ -1,0 +1,23 @@
+---
+apiVersion: external-secrets.io/v1
+kind: ClusterSecretStore
+metadata:
+  annotations:
+    argocd.argoproj.io/sync-wave: "-30"
+  name: ztp-secret-provider
+spec:
+  conditions:
+    - namespaceSelector:
+        matchExpressions:
+          - key: cluster.open-cluster-management.io/managedCluster
+            operator: Exists
+  provider:
+    vault:
+      server: "https://vault.example.com:8200"
+      path: "secret"
+      version: "v2"
+      auth:
+        tokenSecretRef:
+          name: vault-token
+          key: token
+          namespace: external-secrets-operator

--- a/telco-hub/configuration/reference-crs/optional/external-secrets/esoClusterTemplates.yaml
+++ b/telco-hub/configuration/reference-crs/optional/external-secrets/esoClusterTemplates.yaml
@@ -1,0 +1,55 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: eso-cluster-templates-v1
+  namespace: open-cluster-management
+  annotations:
+    argocd.argoproj.io/sync-wave: "-30"
+data:
+  PullSecretExternalSecret: |-
+    apiVersion: external-secrets.io/v1
+    kind: ExternalSecret
+    metadata:
+      name: "{{ .Spec.PullSecretRef.Name }}"
+      namespace: "{{ .Spec.ClusterName }}"
+      annotations:
+        siteconfig.open-cluster-management.io/sync-wave: "1"
+    spec:
+      # refreshPolicy: OnChange updates the Secret only when THIS ExternalSecret CR changes.
+      # IMPORTANT: OnChange does NOT respond to changes in Vault data. If you rotate
+      # credentials in Vault, the Secret will NOT automatically update.
+      #
+      # To refresh after rotating credentials in Vault, manually trigger sync:
+      #   oc annotate externalsecret <name> -n <namespace> force-sync=$(date +%s) --overwrite
+      #
+      # This policy minimizes Vault load by avoiding periodic polling while still allowing
+      # on-demand refresh when needed. For automatic freshness, use refreshPolicy: Periodic.
+      #
+      # When a ClusterInstance is deleted, ACM removes the ExternalSecret CR,
+      # which triggers deletion of the owned Secret via ownerReference.
+      refreshPolicy: OnChange
+      secretStoreRef:
+        name: ztp-secret-provider
+        kind: ClusterSecretStore
+      target:
+        name: "{{ .Spec.PullSecretRef.Name }}"
+        creationPolicy: Owner
+        template:
+          type: kubernetes.io/dockerconfigjson
+      data:
+        # VAULT STRUCTURE CONTRACT:
+        # This defines the required path and property structure in Vault (or alternative secret store).
+        # The secret store MUST conform to this structure:
+        #   Path: clusters/<ClusterName>/pull-secret
+        #   Required property: ".dockerconfigjson" (full docker config JSON as string)
+        #
+        # Example for cluster "sno-site-1":
+        #   secret/data/clusters/sno-site-1/pull-secret
+        #     .dockerconfigjson = '{"auths":{"registry.example.com":{"auth":"..."}}}'
+        #
+        # Any deviation from this contract will cause image pull authentication to fail.
+        # This contract is documented in the telco-hub RDS.
+        - secretKey: .dockerconfigjson
+          remoteRef:
+            key: clusters/{{ .Spec.ClusterName }}/pull-secret
+            property: .dockerconfigjson

--- a/telco-hub/configuration/reference-crs/optional/external-secrets/esoExternalSecretsConfig.yaml
+++ b/telco-hub/configuration/reference-crs/optional/external-secrets/esoExternalSecretsConfig.yaml
@@ -1,0 +1,8 @@
+---
+apiVersion: operator.openshift.io/v1alpha1
+kind: ExternalSecretsConfig
+metadata:
+  annotations:
+    argocd.argoproj.io/sync-wave: "-30"
+  name: cluster
+spec: {}

--- a/telco-hub/configuration/reference-crs/optional/external-secrets/esoNS.yaml
+++ b/telco-hub/configuration/reference-crs/optional/external-secrets/esoNS.yaml
@@ -1,0 +1,8 @@
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+  annotations:
+    argocd.argoproj.io/sync-wave: "-45"
+    workload.openshift.io/allowed: management
+  name: external-secrets-operator

--- a/telco-hub/configuration/reference-crs/optional/external-secrets/esoNetworkPolicy.yaml
+++ b/telco-hub/configuration/reference-crs/optional/external-secrets/esoNetworkPolicy.yaml
@@ -1,0 +1,31 @@
+---
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: allow-secret-store-egress
+  namespace: external-secrets
+  annotations:
+    argocd.argoproj.io/sync-wave: "-25"
+spec:
+  podSelector:
+    matchLabels:
+      app.kubernetes.io/name: external-secrets
+  policyTypes:
+    - Egress
+  egress:
+    - to:
+        - namespaceSelector:
+            matchLabels:
+              kubernetes.io/metadata.name: vault
+      ports:
+        - port: 8200
+          protocol: TCP
+    - to:
+        - namespaceSelector:
+            matchLabels:
+              kubernetes.io/metadata.name: openshift-dns
+      ports:
+        - port: 53
+          protocol: UDP
+        - port: 53
+          protocol: TCP

--- a/telco-hub/configuration/reference-crs/optional/external-secrets/esoNodeTemplates.yaml
+++ b/telco-hub/configuration/reference-crs/optional/external-secrets/esoNodeTemplates.yaml
@@ -1,0 +1,58 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: eso-node-templates-v1
+  namespace: open-cluster-management
+  annotations:
+    argocd.argoproj.io/sync-wave: "-30"
+data:
+  BmcSecretExternalSecret: |-
+    apiVersion: external-secrets.io/v1
+    kind: ExternalSecret
+    metadata:
+      name: "{{ .SpecialVars.CurrentNode.BmcCredentialsName.Name }}"
+      namespace: "{{ .Spec.ClusterName }}"
+      annotations:
+        siteconfig.open-cluster-management.io/sync-wave: "1"
+    spec:
+      # refreshPolicy: OnChange updates the Secret only when THIS ExternalSecret CR changes.
+      # IMPORTANT: OnChange does NOT respond to changes in Vault data. If you rotate
+      # BMC credentials in Vault, the Secret will NOT automatically update.
+      #
+      # To refresh after rotating credentials in Vault, manually trigger sync:
+      #   oc annotate externalsecret <name> -n <namespace> force-sync=$(date +%s) --overwrite
+      #
+      # This policy minimizes Vault load by avoiding periodic polling while still allowing
+      # on-demand refresh when needed. For automatic freshness, use refreshPolicy: Periodic.
+      #
+      # When a BareMetalHost is deleted, ACM's ClusterInstance controller removes
+      # the ExternalSecret CR, which triggers deletion of the owned Secret via ownerReference.
+      refreshPolicy: OnChange
+      secretStoreRef:
+        name: ztp-secret-provider
+        kind: ClusterSecretStore
+      target:
+        name: "{{ .SpecialVars.CurrentNode.BmcCredentialsName.Name }}"
+        creationPolicy: Owner
+      data:
+        # VAULT STRUCTURE CONTRACT:
+        # This defines the required path and property structure in Vault (or alternative secret store).
+        # The secret store MUST conform to this structure:
+        #   Path: clusters/<ClusterName>/bmc/<HostName>
+        #   Required properties: "username", "password"
+        #
+        # Example for cluster "sno-site-1" with node "node1.sno-site-1.example.com":
+        #   secret/data/clusters/sno-site-1/bmc/node1.sno-site-1.example.com
+        #     username = "admin"
+        #     password = "secretpassword"
+        #
+        # Any deviation from this contract will cause BMC authentication to fail.
+        # This contract is documented in the telco-hub RDS.
+        - secretKey: username
+          remoteRef:
+            key: clusters/{{ .Spec.ClusterName }}/bmc/{{ .SpecialVars.CurrentNode.HostName }}
+            property: username
+        - secretKey: password
+          remoteRef:
+            key: clusters/{{ .Spec.ClusterName }}/bmc/{{ .SpecialVars.CurrentNode.HostName }}
+            property: password

--- a/telco-hub/configuration/reference-crs/optional/external-secrets/esoOperatorgroup.yaml
+++ b/telco-hub/configuration/reference-crs/optional/external-secrets/esoOperatorgroup.yaml
@@ -1,0 +1,11 @@
+---
+apiVersion: operators.coreos.com/v1
+kind: OperatorGroup
+metadata:
+  annotations:
+    argocd.argoproj.io/sync-wave: "-40"
+    operatorframework.io/bundle-unpack-min-retry-interval: 10m
+  name: openshift-external-secrets-operator
+  namespace: external-secrets-operator
+spec:
+  upgradeStrategy: Default

--- a/telco-hub/configuration/reference-crs/optional/external-secrets/esoSubscription.yaml
+++ b/telco-hub/configuration/reference-crs/optional/external-secrets/esoSubscription.yaml
@@ -1,0 +1,15 @@
+---
+apiVersion: operators.coreos.com/v1alpha1
+kind: Subscription
+metadata:
+  annotations:
+    argocd.argoproj.io/sync-wave: "-40"
+  name: openshift-external-secrets-operator
+  namespace: external-secrets-operator
+spec:
+  channel: stable-v1
+  name: openshift-external-secrets-operator
+  source: redhat-operators-disconnected
+  sourceNamespace: openshift-marketplace
+  # Automatic: hub operator upgrades are managed by ArgoCD
+  installPlanApproval: Automatic

--- a/telco-hub/configuration/reference-crs/optional/external-secrets/kustomization.yaml
+++ b/telco-hub/configuration/reference-crs/optional/external-secrets/kustomization.yaml
@@ -1,0 +1,12 @@
+---
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - esoNS.yaml
+  - esoOperatorgroup.yaml
+  - esoSubscription.yaml
+  - esoExternalSecretsConfig.yaml
+  - esoClusterSecretStore.yaml
+  - esoNetworkPolicy.yaml
+  - esoClusterTemplates.yaml
+  - esoNodeTemplates.yaml


### PR DESCRIPTION
Add ESO as an optional operator for the telco-hub and telco-core RDS, providing secure secret management via external stores (Vault example).

Hub configuration includes:
- Namespace, OperatorGroup, Subscription, ExternalSecretsConfig, ClusterSecretStore (ztp-secret-provider)
- ClusterInstance template ConfigMaps for pull secret and BMC credentials ExternalSecrets
- kube-compare metadata (allOrNoneOf, optional)
- example-overlays-config with ClusterSecretStore patch
- README documenting usage, vault path conventions, and templateRefs integration

Core configuration includes ESO in the PolicyGenerator baseline (included by default, not commented out).

Co-authored-by: Claude