### PR TITLE
CNF-22624: RAN Hardening (5.0) - API Encryption (M10)

### DIFF
--- a/telco-ran/configuration/hardening/api-server/75-api-server-encryption.yaml
+++ b/telco-ran/configuration/hardening/api-server/75-api-server-encryption.yaml
@@ -1,0 +1,7 @@
+apiVersion: config.openshift.io/v1
+kind: APIServer
+metadata:
+  name: cluster
+spec:
+  encryption:
+    type: aescbc


### PR DESCRIPTION
## Summary
- MEDIUM severity finding from the [ACSC Essential Eight](https://static.open-scap.org/ssg-guides/ssg-rhcos4-guide-e8.html) compliance profile — enables AES-CBC encryption at rest for etcd (Secrets, ConfigMaps, Routes, OAuth tokens)
- APIServer CRD patch (not a MachineConfig, no node reboots)

## Remediation Group
- [M10: API Encryption](https://sebrandon1.github.io/compliance-scripts/versions/5.0/groups/M10.html)

## Jira
- [CNF-22624](https://redhat.atlassian.net/browse/CNF-22624)
- Epic: [CNF-22573](https://redhat.atlassian.net/browse/CNF-22573) — RAN Hardening for 5.0

## Test plan
- [ ] Apply APIServer CRD to OCP 5.0 cluster
- [ ] Verify `encryption.type: aescbc` set
- [ ] Encryption in progress for etcd resources

Supersedes #678 — migrated from `compliance/4.22/*` to `compliance/5.0/*` branch naming.

<details>
<summary>OCP 5.0 Verification (2026-06-22)</summary>

**Cluster:** cnfdt16 — OCP 5.0.0-0.nightly-2026-06-18-000016, RHCOS 10.2

**Finding:** Hardening still needed. OCP 5.0 does not enable etcd encryption at rest by default.

```
$ oc get apiserver cluster -o jsonpath='{.spec.encryption}'
{}   # (empty on fresh install — defaults to identity/no encryption)
```

The `aescbc` encryption on cnfdt16 was manually applied (`generation: 2`, `kubectl-client-side-apply` in managedFields). A fresh 5.0 install still requires this remediation.

</details>

<details>
<summary>Encryption key storage and threat model</summary>

With the default `aescbc` configuration, the encryption keys are stored on the same control plane nodes where etcd runs, specifically in `/etc/kubernetes/static-pod-resources/kube-apiserver-pod-<revision>/secrets/encryption-config/encryption-config`. The openshift-apiserver-operator [rotates these keys every 7 days](https://docs.redhat.com/en/documentation/openshift_container_platform/4.22/html/etcd/enabling-etcd-encryption), preserving up to 10 historical keys for backup decryption.

Keys and data are co-located. The threat model is narrow:
- **Defends against**: etcd backup theft (keys are not inside the backup snapshot), cold disk forensics on decommissioned drives
- **Does not defend against**: control plane node root compromise (attacker reads the key file directly)

For genuine key separation, KMS integration (AWS KMS, Azure Key Vault, HashiCorp Vault) keeps the master key external to the cluster, but that is a deployment-specific choice outside the scope of the RDS reference config.

This configuration satisfies the ACSC Essential Eight / NIST [SC-28](https://redhat.atlassian.net/browse/SC-28) compliance requirement, which mandates demonstrating encryption at rest as defense-in-depth.

</details>