### PR TITLE
CNF-23448: RAN Hardening (5.0) - Audit Kernel Modules (M5)

### DIFF
--- a/telco-ran/configuration/kube-compare-reference/informational/hardening/75-audit-kernel-modules-master.yaml
+++ b/telco-ran/configuration/kube-compare-reference/informational/hardening/75-audit-kernel-modules-master.yaml
@@ -1,0 +1,17 @@
+apiVersion: machineconfiguration.openshift.io/v1
+kind: MachineConfig
+metadata:
+  name: 75-audit-kernel-modules-master
+  labels:
+    machineconfiguration.openshift.io/role: master
+spec:
+  config:
+    ignition:
+      version: 3.2.0
+    storage:
+      files:
+      - path: /etc/audit/rules.d/75-kernel-modules.rules
+        mode: 420
+        overwrite: true
+        contents:
+          source: data:text/plain,%23%20M5%3A%20Audit%20Kernel%20Module%20Loading%20%28E8%20Compliance%29%0A%23%20Documentation%3A%20https%3A%2F%2Fsebrandon1.github.io%2Fcompliance-scripts%2Fversions%2F5.0%2Fgroups%2FM5.html%0A%0A%23%20Module%20loading%0A-a%20always%2Cexit%20-F%20arch%3Db64%20-S%20init_module%20-S%20finit_module%20-k%20module_load%0A-a%20always%2Cexit%20-F%20arch%3Db32%20-S%20init_module%20-S%20finit_module%20-k%20module_load%0A%0A%23%20Module%20unloading%0A-a%20always%2Cexit%20-F%20arch%3Db64%20-S%20delete_module%20-k%20module_unload%0A-a%20always%2Cexit%20-F%20arch%3Db32%20-S%20delete_module%20-k%20module_unload%0A

--- a/telco-ran/configuration/kube-compare-reference/informational/hardening/75-audit-kernel-modules-worker.yaml
+++ b/telco-ran/configuration/kube-compare-reference/informational/hardening/75-audit-kernel-modules-worker.yaml
@@ -1,0 +1,17 @@
+apiVersion: machineconfiguration.openshift.io/v1
+kind: MachineConfig
+metadata:
+  name: 75-audit-kernel-modules-worker
+  labels:
+    machineconfiguration.openshift.io/role: worker
+spec:
+  config:
+    ignition:
+      version: 3.2.0
+    storage:
+      files:
+      - path: /etc/audit/rules.d/75-kernel-modules.rules
+        mode: 420
+        overwrite: true
+        contents:
+          source: data:text/plain,%23%20M5%3A%20Audit%20Kernel%20Module%20Loading%20%28E8%20Compliance%29%0A%23%20Documentation%3A%20https%3A%2F%2Fsebrandon1.github.io%2Fcompliance-scripts%2Fversions%2F5.0%2Fgroups%2FM5.html%0A%0A%23%20Module%20loading%0A-a%20always%2Cexit%20-F%20arch%3Db64%20-S%20init_module%20-S%20finit_module%20-k%20module_load%0A-a%20always%2Cexit%20-F%20arch%3Db32%20-S%20init_module%20-S%20finit_module%20-k%20module_load%0A%0A%23%20Module%20unloading%0A-a%20always%2Cexit%20-F%20arch%3Db64%20-S%20delete_module%20-k%20module_unload%0A-a%20always%2Cexit%20-F%20arch%3Db32%20-S%20delete_module%20-k%20module_unload%0A


### PR DESCRIPTION
## Summary

Adds MachineConfig to deploy audit rules for kernel module loading and unloading events on both master and worker nodes.

This addresses MEDIUM severity findings from the [ACSC Essential Eight](https://static.open-scap.org/ssg-guides/ssg-rhcos4-guide-e8.html) compliance profile — auditing `init_module`, `finit_module`, and `delete_module` syscalls to ensure all kernel module operations are recorded.

## Remediation Group
- [M5: Audit Kernel Modules](https://sebrandon1.github.io/compliance-scripts/versions/5.0/groups/M5.html)

## Files

- `75-audit-kernel-modules-master.yaml`
- `75-audit-kernel-modules-worker.yaml`

## Verification

After applying to a cluster, verify with:
```bash
oc debug node/<node> -- chroot /host auditctl -l | grep -E "init_module|delete_module"
# Expected: audit rules for module syscalls
```

## Jira

- Story: [CNF-23448](https://redhat.atlassian.net/browse/CNF-23448)
- Epic: [CNF-22573](https://redhat.atlassian.net/browse/CNF-22573) (RAN Hardening for 5.0)

Supersedes #738 — migrated from `compliance/4.22/*` to `compliance/5.0/*` branch naming.

<details>
<summary>OCP 5.0 Verification (2026-06-22)</summary>

**Cluster:** cnfdt16 — OCP 5.0.0-0.nightly-2026-06-18-000016, RHCOS 10.2

**Finding:** Hardening still needed. Stock RHCOS 10 ships no kernel module audit rules.

```
$ cat /etc/audit/rules.d/audit.rules
## First rule - delete all
-D
## Increase the buffers to survive stress events.
-b 8192
## This determine how long to wait in burst of events
--backlog_wait_time 60000
## Set failure mode to syslog
-f 1
```

The default `audit.rules` only has basic buffer/backlog setup. No rules for `init_module`, `finit_module`, or `delete_module` syscalls exist by default. The only other rules file is `mco-audit-quiet-containers.rules` (NETFILTER_CFG and ANOM_PROMISCUOUS suppressions).

</details>