### PR TITLE
CNF-23514: RAN Hardening (5.0) - Auditd Configuration (M9)

### DIFF
--- a/telco-ran/configuration/kube-compare-reference/informational/hardening/75-auditd-configuration-master.yaml
+++ b/telco-ran/configuration/kube-compare-reference/informational/hardening/75-auditd-configuration-master.yaml
@@ -1,0 +1,17 @@
+apiVersion: machineconfiguration.openshift.io/v1
+kind: MachineConfig
+metadata:
+  name: 75-auditd-configuration-master
+  labels:
+    machineconfiguration.openshift.io/role: master
+spec:
+  config:
+    ignition:
+      version: 3.5.0
+    storage:
+      files:
+      - path: /etc/audit/auditd.conf
+        mode: 416
+        overwrite: true
+        contents:
+          source: "data:,%23%0A%23%20This%20file%20controls%20the%20configuration%20of%20the%20audit%20daemon%0A%23%0A%0Alocal_events%20=%20yes%0Awrite_logs%20=%20yes%0Alog_file%20=%20%2Fvar%2Flog%2Faudit%2Faudit.log%0Alog_group%20=%20root%0Alog_format%20=%20ENRICHED%0Aflush%20=%20incremental_async%0Afreq%20=%2050%0Amax_log_file%20=%206%0Anum_logs%20=%205%0Apriority_boost%20=%204%0Aname_format%20=%20hostname%0A%23%23name%20=%20mydomain%0Amax_log_file_action%20=%20rotate%0Aspace_left%20=%20100%0Aspace_left_action%20=%20syslog%0Averify_email%20=%20yes%0Aaction_mail_acct%20=%20root%0Aadmin_space_left%20=%2050%0Aadmin_space_left_action%20=%20syslog%0Adisk_full_action%20=%20syslog%0Adisk_error_action%20=%20syslog%0Ause_libwrap%20=%20yes%0A%23%23tcp_listen_port%20=%2060%0Atcp_listen_queue%20=%205%0Atcp_max_per_addr%20=%201%0A%23%23tcp_client_ports%20=%201024-65535%0Atcp_client_max_idle%20=%200%0Atransport%20=%20TCP%0Akrb5_principal%20=%20auditd%0A%23%23krb5_key_file%20=%20%2Fetc%2Faudit%2Faudit.key%0Adistribute_network%20=%20no%0Aq_depth%20=%20400%0Aoverflow_action%20=%20syslog%0Amax_restarts%20=%2010%0Aplugin_dir%20=%20%2Fetc%2Faudit%2Fplugins.d"

--- a/telco-ran/configuration/kube-compare-reference/informational/hardening/75-auditd-configuration-worker.yaml
+++ b/telco-ran/configuration/kube-compare-reference/informational/hardening/75-auditd-configuration-worker.yaml
@@ -1,0 +1,17 @@
+apiVersion: machineconfiguration.openshift.io/v1
+kind: MachineConfig
+metadata:
+  name: 75-auditd-configuration-worker
+  labels:
+    machineconfiguration.openshift.io/role: worker
+spec:
+  config:
+    ignition:
+      version: 3.5.0
+    storage:
+      files:
+      - path: /etc/audit/auditd.conf
+        mode: 416
+        overwrite: true
+        contents:
+          source: "data:,%23%0A%23%20This%20file%20controls%20the%20configuration%20of%20the%20audit%20daemon%0A%23%0A%0Alocal_events%20=%20yes%0Awrite_logs%20=%20yes%0Alog_file%20=%20%2Fvar%2Flog%2Faudit%2Faudit.log%0Alog_group%20=%20root%0Alog_format%20=%20ENRICHED%0Aflush%20=%20incremental_async%0Afreq%20=%2050%0Amax_log_file%20=%206%0Anum_logs%20=%205%0Apriority_boost%20=%204%0Aname_format%20=%20hostname%0A%23%23name%20=%20mydomain%0Amax_log_file_action%20=%20rotate%0Aspace_left%20=%20100%0Aspace_left_action%20=%20syslog%0Averify_email%20=%20yes%0Aaction_mail_acct%20=%20root%0Aadmin_space_left%20=%2050%0Aadmin_space_left_action%20=%20syslog%0Adisk_full_action%20=%20syslog%0Adisk_error_action%20=%20syslog%0Ause_libwrap%20=%20yes%0A%23%23tcp_listen_port%20=%2060%0Atcp_listen_queue%20=%205%0Atcp_max_per_addr%20=%201%0A%23%23tcp_client_ports%20=%201024-65535%0Atcp_client_max_idle%20=%200%0Atransport%20=%20TCP%0Akrb5_principal%20=%20auditd%0A%23%23krb5_key_file%20=%20%2Fetc%2Faudit%2Faudit.key%0Adistribute_network%20=%20no%0Aq_depth%20=%20400%0Aoverflow_action%20=%20syslog%0Amax_restarts%20=%2010%0Aplugin_dir%20=%20%2Fetc%2Faudit%2Fplugins.d"


### PR DESCRIPTION
## Summary

Adds MachineConfig to deploy hardened auditd configuration on both master and worker nodes.

This addresses MEDIUM severity findings from the [ACSC Essential Eight](https://static.open-scap.org/ssg-guides/ssg-rhcos4-guide-e8.html) compliance profile — hardening the auditd service configuration to ensure proper audit logging settings (hostname identification, disk-full behavior, queue depth).

## Remediation Group
- [M9: Auditd Configuration](https://sebrandon1.github.io/compliance-scripts/versions/5.0/groups/M9.html)

## Files

- `75-auditd-configuration-master.yaml`
- `75-auditd-configuration-worker.yaml`

## Verification

After applying to a cluster, verify with:
```bash
oc debug node/<node> -- chroot /host cat /etc/audit/auditd.conf
# Expected: hardened auditd configuration
```

## Jira

- Epic: [CNF-22573](https://redhat.atlassian.net/browse/CNF-22573) (RAN Hardening for 5.0)

<details>
<summary>OCP 5.0 Verification (2026-06-22)</summary>

**Cluster:** cnfdt16 — OCP 5.0.0-0.nightly-2026-06-18-000016, RHCOS 10.2

**Finding:** Hardening still needed. Stock RHCOS 10 auditd.conf has several compliance-relevant differences.

| Setting | RHCOS 10 Default | Hardened (M9) | Impact |
|---------|-----------------|---------------|--------|
| `name_format` | `NONE` | `hostname` | Identify audit source in centralized logs |
| `space_left` | `75` | `100` | Earlier warning when disk space low |
| `admin_space_left_action` | `SUSPEND` | `syslog` | Keep logging vs silently stop |
| `disk_full_action` | `SUSPEND` | `syslog` | Keep logging vs silently stop |
| `disk_error_action` | `SUSPEND` | `syslog` | Keep logging vs silently stop |
| `q_depth` | `2000` | `400` | Compliance-recommended queue depth |
| `max_log_file` | `8` | `6` | Compliance-recommended max log size (MB) |

The critical change is the `*_action` settings: RHCOS 10 defaults to `SUSPEND` which silently stops audit logging when disk issues occur. The hardened config changes these to `syslog` so audit events are still captured via syslog.

</details>