### PR TITLE
CNF-20380: Add balance-xor support to bond NAD kube-compare validation

### DIFF
--- a/telco-core/configuration/reference-crs-kube-compare/optional/networking/networkAttachmentDefinition.yaml
+++ b/telco-core/configuration/reference-crs-kube-compare/optional/networking/networkAttachmentDefinition.yaml
@@ -12,8 +12,16 @@ spec:
   {{- if kindIs "string" .spec.config }}
     {{- $config := fromJson .spec.config }}
     {{- if and (eq $config.type "bond") }}
-      {{- if ne $config.mode "active-backup" }}
-        {{- $configWarnings = append $configWarnings (printf "Invalid mode: when type is 'bond', mode must be 'active-backup', but got '%s'" $config.mode) }}
+      {{- $validModes := list "active-backup" "balance-xor" }}
+      {{- if not (has $config.mode $validModes) }}
+        {{- $configWarnings = append $configWarnings (printf "Invalid mode: when type is 'bond', mode must be one of [active-backup, balance-xor], but got '%s'" $config.mode) }}
+      {{- end }}
+      {{- if eq $config.mode "balance-xor" }}
+        {{- $configWarnings = append $configWarnings "Note: balance-xor mode requires switch-side configuration (e.g. static LAG). All networking on the bond interfaces must use the same configuration (e.g. macvlan on the PF)" }}
+        {{- $validPolicies := list "layer2+3" "layer3+4" }}
+        {{- if not (has $config.xmitHashPolicy $validPolicies) }}
+          {{- $configWarnings = append $configWarnings (printf "Invalid xmitHashPolicy: when mode is 'balance-xor', xmitHashPolicy must be one of [layer2+3, layer3+4], but got '%s'" $config.xmitHashPolicy) }}
+        {{- end }}
       {{- end }}
       {{- if ne (int $config.linksInContainer) 1 }}
         {{- $configWarnings = append $configWarnings (printf "Invalid linksInContainer: when type is 'bond', linksInContainer must be '1', but got '%s'" $config.linksInContainer) }}


### PR DESCRIPTION
Bond member VFs should come from different PFs to provide redundancy.
Bonding VFs from the same PF offers no fault tolerance since a PF
failure takes down all its VFs.

balance-xor with layer3+4 xmitHashPolicy is recommended as it provides
per-flow deterministic distribution. LAG MUST be configured on the
switch ports where the PFs connect.

LACP bonds are not recommended because the PF on the host might already
be part of a LACP bond itself.

Bond-cni is only tested on top of SR-IOV VFs, other configurations
(e.g. macvlan) are not tested or supported.

Only when PFs are secondary node interfaces the setup is supported.

Testing:
- Validate balance-xor with Layer 2, Layer 2+3, and Layer 3+4 Hash
- Validate TX load balancing distributes traffic across VFs/PFs
- Validate HA by taking down one PF and verifying zero packet loss

Relates to: https://redhat.atlassian.net/browse/CNF-25539