### PR TITLE
telco-ran: Add PtpConfigDualTrTBC dual-Rx T-BC WPC PTP profile

### DIFF
--- a/telco-ran/configuration/kube-compare-reference/hack/default_value.yaml
+++ b/telco-ran/configuration/kube-compare-reference/hack/default_value.yaml
@@ -713,6 +713,59 @@ ptp_operator_configuration_PtpConfigThreeCardTBCWpc:
               [ens3f3]
               masterOnly 1
               # ...
+ptp_operator_configuration_PtpConfigDualTrTBC:
+  - spec:
+      profile:
+        - name: "tbc-tr"
+          plugins:
+            e810:
+              interconnections:
+                - gnssInput: false
+                  id: $iface_FirstPort
+                  part: E810-XXVDA4T
+                  phaseOutputConnectors:
+                    - SMA1
+                  upstreamPort: $iface_timeRx_FirstPort, $iface_timeRx_SecondPort
+              settings:
+                LocalMaxHoldoverOffSet: 1500
+                LocalHoldoverTimeout: 14400
+                MaxInSpecOffset: 100
+              pins:
+                $iface_FirstPort:
+                  SMA1: 2 1
+                  SMA2: 2 2
+                  U.FL1: 0 1
+                  U.FL2: 0 2
+          ptpSettings:
+            clockType: "T-BC"
+            inSyncConditionThreshold: "10"
+            inSyncConditionTimes: "12"
+            logReduce: "false"
+            leadingInterface: $iface_FirstPort
+            upstreamPort: $iface_timeRx_FirstPort, $iface_timeRx_SecondPort
+        - name: "tbc-tt"
+          ptpSettings:
+            controllingProfile: tbc-tr
+            logReduce: "false"
+      recommend:
+        - profile: "tbc-tr"
+          match:
+            - nodeLabel: "node-role.kubernetes.io/master"
+        - profile: "tbc-tt"
+          match:
+            - nodeLabel: "node-role.kubernetes.io/master"
+    captureGroup_defaults:
+      priority2: 128
+      domainNumber: 24
+      domainNumberTt: 25
+      pi_proportional_const: "0.60"
+      pi_integral_const: "0.0003"
+      iface_timeRx_FirstPort: $iface_timeRx_FirstPort
+      iface_timeRx_SecondPort: $iface_timeRx_SecondPort
+      iface_FirstPort: $iface_FirstPort
+      masterPorts: |-
+              [$iface_timeTx_N]
+                    masterOnly 1
 ptp_operator_configuration_PtpConfigTTSCWpc:
   - spec:
       profile:

--- a/telco-ran/configuration/kube-compare-reference/metadata.yaml
+++ b/telco-ran/configuration/kube-compare-reference/metadata.yaml
@@ -410,6 +410,17 @@ parts:
                   inlineDiffFunc: capturegroups
                 - pathToKey: spec.profile.1.ptp4lConf
                   inlineDiffFunc: capturegroups
+          - path: ptp-operator/configuration/PtpConfigDualTrTBC.yaml
+            config:
+              perField:
+                - pathToKey: spec.profile.0.phc2sysOpts
+                  inlineDiffFunc: capturegroups
+                - pathToKey: spec.profile.0.ts2phcConf
+                  inlineDiffFunc: capturegroups
+                - pathToKey: spec.profile.0.ptp4lConf
+                  inlineDiffFunc: capturegroups
+                - pathToKey: spec.profile.1.ptp4lConf
+                  inlineDiffFunc: capturegroups
           - path: ptp-operator/configuration/PtpConfigTTSCWpc.yaml
             config:
               perField:

--- a/telco-ran/configuration/kube-compare-reference/ptp-operator/configuration/PtpConfigDualTrTBC.yaml
+++ b/telco-ran/configuration/kube-compare-reference/ptp-operator/configuration/PtpConfigDualTrTBC.yaml
@@ -1,0 +1,301 @@
+# T-BC (Telecom Boundary Clock) with WPC (Westport Channel) configuration
+# This profile receives PTP time from an upstream source and redistributes it
+# Interface variables:
+#   - $iface_timeRx: Receives (Rx) PTP time from upstream source
+#   - $iface_FirstPort: First port on the card (used for WPC timing)
+#   - $iface_timeTx_N: Transmits (Tx) PTP time to downstream devices (N = 0-2)
+apiVersion: ptp.openshift.io/v1
+kind: PtpConfig
+metadata:
+  name: t-bc
+  namespace: openshift-ptp
+  annotations:
+    ran.openshift.io/ztp-deploy-wave: "10"
+spec:
+  profile:
+  {{- range .spec.profile }}
+  {{- if eq .name "tbc-tr" }}
+  - name: tbc-tr
+    phc2sysOpts: -r -n (?<domainNumber>[0-9]+) -N 8 -R 16 -u 0 -m -s (?<iface_timeRx_FirstPort>[[:alnum:]]+)
+    plugins:
+      e810:
+        enableDefaultConfig: false
+        interconnections:
+          {{- .plugins.e810.interconnections | toYaml | nindent 10 }}
+        settings:
+          {{- .plugins.e810.settings | toYaml | nindent 10 }}
+        pins:
+          # Syntax guide:
+          # - The 1st number in each pair must be one of:
+          #    0 - Disabled
+          #    1 - RX
+          #    2 - TX
+          # - The 2nd number in each pair must match the channel number
+          {{- .plugins.e810.pins | toYaml | nindent 10 }}
+    ptp4lConf: |
+      # The interface name is hardware-specific
+      [(?<iface_timeRx_FirstPort>[[:alnum:]]+)]
+      masterOnly 0
+      [(?<iface_timeRx_SecondPort>[[:alnum:]]+)]
+      masterOnly 0
+      [global]
+      #
+      # Default Data Set
+      #
+      twoStepFlag 1
+      slaveOnly 1
+      priority1 128
+      priority2 (?<priority2>[0-9]+)
+      domainNumber (?<domainNumber>[0-9]+)
+      clockClass 248
+      clockAccuracy 0xFE
+      offsetScaledLogVariance 0xFFFF
+      free_running 0
+      freq_est_interval 1
+      dscp_event 0
+      dscp_general 0
+      dataset_comparison G.8275.x
+      G.8275.defaultDS.localPriority 128
+      #
+      # Port Data Set
+      #
+      logAnnounceInterval -3
+      logSyncInterval -4
+      logMinDelayReqInterval -4
+      logMinPdelayReqInterval -4
+      announceReceiptTimeout 3
+      syncReceiptTimeout 0
+      delayAsymmetry 0
+      fault_reset_interval -4
+      neighborPropDelayThresh 20000000
+      masterOnly 0
+      G.8275.portDS.localPriority 128
+      #
+      # Run time options
+      #
+      assume_two_step 0
+      logging_level 6
+      path_trace_enabled 0
+      follow_up_info 0
+      hybrid_e2e 0
+      inhibit_multicast_service 0
+      net_sync_monitor 0
+      tc_spanning_tree 0
+      tx_timestamp_timeout 50
+      unicast_listen 0
+      unicast_master_table 0
+      unicast_req_duration 3600
+      use_syslog 1
+      verbose 0
+      summary_interval 0
+      kernel_leap 1
+      check_fup_sync 0
+      clock_class_threshold 135
+      #
+      # Servo Options
+      #
+      pi_proportional_const (?<pi_proportional_const>[0-9.]+)
+      pi_integral_const (?<pi_integral_const>[0-9.]+)
+      pi_proportional_scale 0.0
+      pi_proportional_exponent -0.3
+      pi_proportional_norm_max 0.7
+      pi_integral_scale 0.0
+      pi_integral_exponent 0.4
+      pi_integral_norm_max 0.3
+      step_threshold 2.0
+      first_step_threshold 0.00002
+      max_frequency 900000000
+      clock_servo pi
+      sanity_freq_limit 200000000
+      ntpshm_segment 0
+      #
+      # Transport options
+      #
+      transportSpecific 0x0
+      ptp_dst_mac 01:1B:19:00:00:00
+      p2p_dst_mac 01:80:C2:00:00:0E
+      udp_ttl 1
+      udp6_scope 0x0E
+      uds_address /var/run/ptp4l
+      #
+      # Default interface options
+      #
+      clock_type OC
+      network_transport L2
+      delay_mechanism E2E
+      time_stamping hardware
+      tsproc_mode filter
+      delay_filter moving_median
+      delay_filter_length 10
+      egressLatency 0
+      ingressLatency 0
+      # $iface_timeRx_FirstPort and $iface_timeRx_SecondPort share the same PHC (same NIC, disciplined via $iface_FirstPort's
+      # DPLL). boundary_clock_jbod must stay 0 (default): setting it to 1 makes
+      # ptp4l tear down and recreate the clock servo (fresh PI state, count=0)
+      boundary_clock_jbod 0
+      #
+      # Clock description
+      #
+      productDescription ;;
+      revisionData ;;
+      manufacturerIdentity 00:00:00
+      userDescription ;
+      timeSource 0xA0
+    ptp4lOpts: -2 --summary_interval -4
+    ptpSchedulingPolicy: SCHED_FIFO
+    ptpSchedulingPriority: 10
+    ptpSettings:
+      clockType: "T-BC"
+      inSyncConditionThreshold: "10"
+      inSyncConditionTimes: "12"
+      logReduce: "false"
+      leadingInterface: {{ .ptpSettings.leadingInterface }}
+      upstreamPort: {{ .ptpSettings.upstreamPort }}
+    ts2phcConf: |
+      [global]
+      use_syslog  0
+      verbose 1
+      logging_level 7
+      ts2phc.pulsewidth 100000000
+      leapfile  /usr/share/zoneinfo/leap-seconds.list
+      domainNumber (?<domainNumber>[0-9]+)
+      uds_address /var/run/ptp4l.0.socket
+      [(?<iface_FirstPort>[[:alnum:]]+)]
+      ts2phc.extts_polarity rising
+      ts2phc.pin_index 1
+      ts2phc.extts_correction -10
+      ts2phc.master 0
+    ts2phcOpts: -s generic -a --ts2phc.rh_external_pps 1
+  {{- end }}
+  {{- if eq .name "tbc-tt" }}
+  - name: tbc-tt
+    ptp4lConf: |
+      (?<masterPorts>((\[[[:alnum:]]+\]
+      masterOnly 1| *#.*| *)(\n|$))+)
+      [global]
+      #
+      # Default Data Set
+      #
+      twoStepFlag 1
+      slaveOnly 0
+      priority1 128
+      priority2 (?<priority2>[0-9]+)
+      domainNumber (?<domainNumberTt>[0-9]+)
+      clockClass 248
+      clockAccuracy 0xFE
+      offsetScaledLogVariance 0xFFFF
+      free_running 0
+      freq_est_interval 1
+      dscp_event 0
+      dscp_general 0
+      dataset_comparison G.8275.x
+      G.8275.defaultDS.localPriority 128
+      #
+      # Port Data Set
+      #
+      logAnnounceInterval -3
+      logSyncInterval -4
+      logMinDelayReqInterval -4
+      logMinPdelayReqInterval -4
+      announceReceiptTimeout 3
+      syncReceiptTimeout 0
+      delayAsymmetry 0
+      fault_reset_interval -4
+      neighborPropDelayThresh 20000000
+      masterOnly 0
+      G.8275.portDS.localPriority 128
+      #
+      # Run time options
+      #
+      assume_two_step 0
+      logging_level 6
+      path_trace_enabled 0
+      follow_up_info 0
+      hybrid_e2e 0
+      inhibit_multicast_service 0
+      net_sync_monitor 0
+      tc_spanning_tree 0
+      tx_timestamp_timeout 50
+      unicast_listen 0
+      unicast_master_table 0
+      unicast_req_duration 3600
+      use_syslog 1
+      verbose 0
+      summary_interval 0
+      kernel_leap 1
+      check_fup_sync 0
+      clock_class_threshold 135
+      #
+      # Servo Options
+      #
+      pi_proportional_const (?<pi_proportional_const>[0-9.]+)
+      pi_integral_const (?<pi_integral_const>[0-9.]+)
+      pi_proportional_scale 0.0
+      pi_proportional_exponent -0.3
+      pi_proportional_norm_max 0.7
+      pi_integral_scale 0.0
+      pi_integral_exponent 0.4
+      pi_integral_norm_max 0.3
+      step_threshold 2.0
+      first_step_threshold 0.00002
+      max_frequency 900000000
+      clock_servo pi
+      sanity_freq_limit 200000000
+      ntpshm_segment 0
+      #
+      # Transport options
+      #
+      transportSpecific 0x0
+      ptp_dst_mac 01:1B:19:00:00:00
+      p2p_dst_mac 01:80:C2:00:00:0E
+      udp_ttl 1
+      udp6_scope 0x0E
+      uds_address /var/run/ptp4l
+      #
+      # Default interface options
+      #
+      clock_type OC
+      network_transport L2
+      delay_mechanism E2E
+      time_stamping hardware
+      tsproc_mode filter
+      delay_filter moving_median
+      delay_filter_length 10
+      egressLatency 0
+      ingressLatency 0
+      boundary_clock_jbod 0
+      #
+      # Clock description
+      #
+      productDescription ;;
+      revisionData ;;
+      manufacturerIdentity 00:00:00
+      userDescription ;
+      timeSource 0xA0
+    ptp4lOpts: -2 --summary_interval -4
+    ptpSchedulingPolicy: SCHED_FIFO
+    ptpSchedulingPriority: 10
+    ptpSettings:
+      controllingProfile: tbc-tr
+      logReduce: "false"
+  {{- end }}
+  {{- end }}
+  recommend:
+  {{- range .spec.recommend }}
+  {{- if eq .profile "tbc-tt" }}
+  - match:
+    {{- range .match }}
+    - nodeLabel: {{ template "matchNodeSelectorValue" (list .nodeLabel "node-role.kubernetes.io" ) }}
+    {{- end }}
+    priority: 4
+    profile: tbc-tt
+  {{- end }}
+  {{- if eq .profile "tbc-tr" }}
+  - match:
+    {{- range .match }}
+    - nodeLabel: {{ template "matchNodeSelectorValue" (list .nodeLabel "node-role.kubernetes.io" ) }}
+    {{- end }}
+    priority: 4
+    profile: tbc-tr
+  {{- end }}
+  {{- end }}

--- a/telco-ran/configuration/source-crs/ptp-operator/configuration/PtpConfigDualTrTBC.yaml
+++ b/telco-ran/configuration/source-crs/ptp-operator/configuration/PtpConfigDualTrTBC.yaml
@@ -1,0 +1,296 @@
+# T-BC (Telecom Boundary Clock) with WPC (Westport Channel) configuration
+# This profile receives PTP time from an upstream source and redistributes it
+# Interface variables:
+#   - $iface_timeRx: Receives (Rx) PTP time from upstream source
+#   - $iface_FirstPort: First port on the card (used for WPC timing)
+#   - $iface_timeTx_N: Transmits (Tx) PTP time to downstream devices (N = 0-2)
+apiVersion: ptp.openshift.io/v1
+kind: PtpConfig
+metadata:
+  name: t-bc
+  namespace: openshift-ptp
+  annotations:
+    ran.openshift.io/ztp-deploy-wave: "10"
+spec:
+  profile:
+  - name: tbc-tr
+    phc2sysOpts: -r -n 24 -N 8 -R 16 -u 0 -m -s $iface_timeRx_FirstPort
+    plugins:
+      e810:
+        enableDefaultConfig: false
+        interconnections:
+          - gnssInput: false
+            id: $iface_FirstPort
+            part: E810-XXVDA4T
+            phaseOutputConnectors:
+            - SMA1
+            upstreamPort: $iface_timeRx_FirstPort, $iface_timeRx_SecondPort
+        settings:
+          LocalHoldoverTimeout: 14400
+          LocalMaxHoldoverOffSet: 1500
+          MaxInSpecOffset: 100
+        pins:
+          # Syntax guide:
+          # - The 1st number in each pair must be one of:
+          #    0 - Disabled
+          #    1 - RX
+          #    2 - TX
+          # - The 2nd number in each pair must match the channel number
+          $iface_FirstPort:
+            SMA1: 2 1
+            SMA2: 2 2
+            U.FL1: 0 1
+            U.FL2: 0 2
+    ptp4lConf: |
+      # The interface name is hardware-specific
+      [$iface_timeRx_FirstPort]
+      masterOnly 0
+      [$iface_timeRx_SecondPort]
+      masterOnly 0
+      [global]
+      #
+      # Default Data Set
+      #
+      twoStepFlag 1
+      slaveOnly 1
+      priority1 128
+      priority2 128
+      domainNumber 24
+      clockClass 248
+      clockAccuracy 0xFE
+      offsetScaledLogVariance 0xFFFF
+      free_running 0
+      freq_est_interval 1
+      dscp_event 0
+      dscp_general 0
+      dataset_comparison G.8275.x
+      G.8275.defaultDS.localPriority 128
+      #
+      # Port Data Set
+      #
+      logAnnounceInterval -3
+      logSyncInterval -4
+      logMinDelayReqInterval -4
+      logMinPdelayReqInterval -4
+      announceReceiptTimeout 3
+      syncReceiptTimeout 0
+      delayAsymmetry 0
+      fault_reset_interval -4
+      neighborPropDelayThresh 20000000
+      masterOnly 0
+      G.8275.portDS.localPriority 128
+      #
+      # Run time options
+      #
+      assume_two_step 0
+      logging_level 6
+      path_trace_enabled 0
+      follow_up_info 0
+      hybrid_e2e 0
+      inhibit_multicast_service 0
+      net_sync_monitor 0
+      tc_spanning_tree 0
+      tx_timestamp_timeout 50
+      unicast_listen 0
+      unicast_master_table 0
+      unicast_req_duration 3600
+      use_syslog 1
+      verbose 0
+      summary_interval 0
+      kernel_leap 1
+      check_fup_sync 0
+      clock_class_threshold 135
+      #
+      # Servo Options
+      #
+      pi_proportional_const 0.60
+      pi_integral_const 0.0003
+      pi_proportional_scale 0.0
+      pi_proportional_exponent -0.3
+      pi_proportional_norm_max 0.7
+      pi_integral_scale 0.0
+      pi_integral_exponent 0.4
+      pi_integral_norm_max 0.3
+      step_threshold 2.0
+      first_step_threshold 0.00002
+      max_frequency 900000000
+      clock_servo pi
+      sanity_freq_limit 200000000
+      ntpshm_segment 0
+      #
+      # Transport options
+      #
+      transportSpecific 0x0
+      ptp_dst_mac 01:1B:19:00:00:00
+      p2p_dst_mac 01:80:C2:00:00:0E
+      udp_ttl 1
+      udp6_scope 0x0E
+      uds_address /var/run/ptp4l
+      #
+      # Default interface options
+      #
+      clock_type OC
+      network_transport L2
+      delay_mechanism E2E
+      time_stamping hardware
+      tsproc_mode filter
+      delay_filter moving_median
+      delay_filter_length 10
+      egressLatency 0
+      ingressLatency 0
+      # $iface_timeRx_FirstPort and $iface_timeRx_SecondPort share the same PHC (same NIC, disciplined via $iface_FirstPort's
+      # DPLL). boundary_clock_jbod must stay 0 (default): setting it to 1 makes
+      # ptp4l tear down and recreate the clock servo (fresh PI state, count=0)
+      boundary_clock_jbod 0
+      #
+      # Clock description
+      #
+      productDescription ;;
+      revisionData ;;
+      manufacturerIdentity 00:00:00
+      userDescription ;
+      timeSource 0xA0
+    ptp4lOpts: -2 --summary_interval -4
+    ptpSchedulingPolicy: SCHED_FIFO
+    ptpSchedulingPriority: 10
+    ptpSettings:
+      clockType: "T-BC"
+      inSyncConditionThreshold: "10"
+      inSyncConditionTimes: "12"
+      logReduce: "false"
+      leadingInterface: $iface_FirstPort
+      upstreamPort: $iface_timeRx_FirstPort, $iface_timeRx_SecondPort
+    ts2phcConf: |
+      [global]
+      use_syslog  0
+      verbose 1
+      logging_level 7
+      ts2phc.pulsewidth 100000000
+      leapfile  /usr/share/zoneinfo/leap-seconds.list
+      domainNumber 24
+      uds_address /var/run/ptp4l.0.socket
+      [$iface_FirstPort]
+      ts2phc.extts_polarity rising
+      ts2phc.pin_index 1
+      ts2phc.extts_correction -10
+      ts2phc.master 0
+    ts2phcOpts: -s generic -a --ts2phc.rh_external_pps 1
+  - name: tbc-tt
+    ptp4lConf: |
+      [$iface_timeTx_N]
+      masterOnly 1
+      [global]
+      #
+      # Default Data Set
+      #
+      twoStepFlag 1
+      slaveOnly 0
+      priority1 128
+      priority2 128
+      domainNumber 25
+      clockClass 248
+      clockAccuracy 0xFE
+      offsetScaledLogVariance 0xFFFF
+      free_running 0
+      freq_est_interval 1
+      dscp_event 0
+      dscp_general 0
+      dataset_comparison G.8275.x
+      G.8275.defaultDS.localPriority 128
+      #
+      # Port Data Set
+      #
+      logAnnounceInterval -3
+      logSyncInterval -4
+      logMinDelayReqInterval -4
+      logMinPdelayReqInterval -4
+      announceReceiptTimeout 3
+      syncReceiptTimeout 0
+      delayAsymmetry 0
+      fault_reset_interval -4
+      neighborPropDelayThresh 20000000
+      masterOnly 0
+      G.8275.portDS.localPriority 128
+      #
+      # Run time options
+      #
+      assume_two_step 0
+      logging_level 6
+      path_trace_enabled 0
+      follow_up_info 0
+      hybrid_e2e 0
+      inhibit_multicast_service 0
+      net_sync_monitor 0
+      tc_spanning_tree 0
+      tx_timestamp_timeout 50
+      unicast_listen 0
+      unicast_master_table 0
+      unicast_req_duration 3600
+      use_syslog 1
+      verbose 0
+      summary_interval 0
+      kernel_leap 1
+      check_fup_sync 0
+      clock_class_threshold 135
+      #
+      # Servo Options
+      #
+      pi_proportional_const 0.60
+      pi_integral_const 0.0003
+      pi_proportional_scale 0.0
+      pi_proportional_exponent -0.3
+      pi_proportional_norm_max 0.7
+      pi_integral_scale 0.0
+      pi_integral_exponent 0.4
+      pi_integral_norm_max 0.3
+      step_threshold 2.0
+      first_step_threshold 0.00002
+      max_frequency 900000000
+      clock_servo pi
+      sanity_freq_limit 200000000
+      ntpshm_segment 0
+      #
+      # Transport options
+      #
+      transportSpecific 0x0
+      ptp_dst_mac 01:1B:19:00:00:00
+      p2p_dst_mac 01:80:C2:00:00:0E
+      udp_ttl 1
+      udp6_scope 0x0E
+      uds_address /var/run/ptp4l
+      #
+      # Default interface options
+      #
+      clock_type OC
+      network_transport L2
+      delay_mechanism E2E
+      time_stamping hardware
+      tsproc_mode filter
+      delay_filter moving_median
+      delay_filter_length 10
+      egressLatency 0
+      ingressLatency 0
+      boundary_clock_jbod 0
+      #
+      # Clock description
+      #
+      productDescription ;;
+      revisionData ;;
+      manufacturerIdentity 00:00:00
+      userDescription ;
+      timeSource 0xA0
+    ptp4lOpts: -2 --summary_interval -4
+    ptpSchedulingPolicy: SCHED_FIFO
+    ptpSchedulingPriority: 10
+    ptpSettings:
+      controllingProfile: tbc-tr
+      logReduce: "false"
+  recommend:
+  - match:
+    - nodeLabel: node-role.kubernetes.io/master
+    priority: 4
+    profile: tbc-tr
+  - match:
+    - nodeLabel: node-role.kubernetes.io/master
+    priority: 4
+    profile: tbc-tt


### PR DESCRIPTION
## Summary 
Add a new T-BC (Telecom Boundary Clock) WPC PTP profile variant that receives time on two separate Rx interfaces sharing one PHC/DPLL, for use in RAN deployments needing this dual-uplink boundary-clock topology. Includes the source-crs example CR alongside its kube-compare-reference template counterpart (with distinct capture groups for each Rx interface and per-profile domain numbers), registered as a new oneOf alternative in metadata.yaml. Verified with make check/make compare — template renders and matches source-crs with zero diffs.