### PR TITLE
Update defaultChannel and channels for multicluster-engine

### DIFF
--- a/telco-hub/install/mirror-registry/imageset-config.yaml
+++ b/telco-hub/install/mirror-registry/imageset-config.yaml
@@ -21,9 +21,9 @@ mirror:
       channels:
       - name: release-2.17
     - name: multicluster-engine
-      defaultChannel: stable-2.12
+      defaultChannel: stable-2.17
       channels:
-      - name: stable-2.12
+      - name: stable-2.17
     - name: openshift-gitops-operator
       defaultChannel: gitops-1.20
       channels:


### PR DESCRIPTION
For OpenShift 4.22 version the RHACM 2.17 matches with MCE 2.17: 

RHACM version 2.17 is released with MCE version 2.17 for cluster management. Note: multicluster engine for Kubernetes operator 2.11 was the immediate previous release. The current version is changed to better reflect MCE's alignment within RHACM 2.17.


Rerefence: https://access.redhat.com/articles/7142376