### PR TITLE
OCPBUGS-97831: Fix duplicate module_blacklist kernel parameter

### DIFF
--- a/telco-ran/configuration/kube-compare-reference/node-tuning-operator/PerformanceProfile.yaml
+++ b/telco-ran/configuration/kube-compare-reference/node-tuning-operator/PerformanceProfile.yaml
@@ -82,9 +82,6 @@ spec:
       "earlycon"
     }}
     {{- if eq $arch "x86_64" }}
-      {{- $requiredArgs = concat $requiredArgs ( list
-        "module_blacklist=irdma"
-      ) }}
       {{- $optionalArgs = concat $optionalArgs ( list 
         "vfio_pci.disable_idle_d3=1"
         "vfio_pci.enable_sriov=1"

--- a/telco-ran/configuration/kube-compare-reference/node-tuning-operator/TunedPerformancePatch.yaml
+++ b/telco-ran/configuration/kube-compare-reference/node-tuning-operator/TunedPerformancePatch.yaml
@@ -39,7 +39,7 @@ spec:
         group.ice-gnss=0:f:10:*:ice-gnss.*
         group.ice-dplls=0:f:10:*:ice-dplls.*
         [bootloader]
-        cmdline_x86_blacklist=module_blacklist=mgag200
+        cmdline_x86_blacklist=module_blacklist=irdma,mgag200
   recommend:
   {{- range .spec.recommend }}
     - machineConfigLabels:

--- a/telco-ran/configuration/source-crs/node-tuning-operator/TunedPerformancePatch.yaml
+++ b/telco-ran/configuration/source-crs/node-tuning-operator/TunedPerformancePatch.yaml
@@ -39,7 +39,7 @@ spec:
         group.ice-gnss=0:f:10:*:ice-gnss.*
         group.ice-dplls=0:f:10:*:ice-dplls.*
         [bootloader]
-        cmdline_x86_blacklist=module_blacklist=mgag200
+        cmdline_x86_blacklist=module_blacklist=irdma,mgag200
   recommend:
     - machineConfigLabels:
         machineconfiguration.openshift.io/role: $mcp

--- a/telco-ran/configuration/source-crs/node-tuning-operator/x86_64/PerformanceProfile-SetSelector.yaml
+++ b/telco-ran/configuration/source-crs/node-tuning-operator/x86_64/PerformanceProfile-SetSelector.yaml
@@ -15,7 +15,6 @@ spec:
     - efi=runtime
     - vfio_pci.enable_sriov=1
     - vfio_pci.disable_idle_d3=1
-    - module_blacklist=irdma
   cpu:
   #    isolated: $isolated
   #    reserved: $reserved

--- a/telco-ran/configuration/source-crs/node-tuning-operator/x86_64/PerformanceProfile.yaml
+++ b/telco-ran/configuration/source-crs/node-tuning-operator/x86_64/PerformanceProfile.yaml
@@ -15,7 +15,6 @@ spec:
     - efi=runtime
     - vfio_pci.enable_sriov=1
     - vfio_pci.disable_idle_d3=1
-    - module_blacklist=irdma
   cpu:
     isolated: $isolated
     reserved: $reserved


### PR DESCRIPTION
The mgag200 blacklist was added as a separate module_blacklist entry, causing two module_blacklist parameters in the kernel cmdline. This PR combines both modules into a single comma-separated parameter in Tuned (and removes the duplicate in perf profile patch)