### PR TITLE
OCPBUGS-105558: fix phc2sys -w flag for T-GM and T-BC profiles

### DIFF
--- a/telco-ran/configuration/kube-compare-reference/ptp-operator/configuration/PtpConfigDualCardTBCWpc.yaml
+++ b/telco-ran/configuration/kube-compare-reference/ptp-operator/configuration/PtpConfigDualCardTBCWpc.yaml
@@ -18,7 +18,7 @@ spec:
   {{- range .spec.profile }}
   {{- if eq .name "tbc-dual-card-tr" }}
   - name: tbc-dual-card-tr
-    phc2sysOpts: -r -n (?<domainNumber>[0-9]+) -N 8 -R 16 -u 0 -m -s (?<iface_timeRx>[[:alnum:]]+)
+    phc2sysOpts: -r -n (?<domainNumber>[0-9]+) -N 8 -R 16 -u 0 -m -w -s (?<iface_timeRx>[[:alnum:]]+)
     plugins:
       e810:
         enableDefaultConfig: false

--- a/telco-ran/configuration/kube-compare-reference/ptp-operator/configuration/PtpConfigDualTrTBC.yaml
+++ b/telco-ran/configuration/kube-compare-reference/ptp-operator/configuration/PtpConfigDualTrTBC.yaml
@@ -16,7 +16,7 @@ spec:
   {{- range .spec.profile }}
   {{- if eq .name "tbc-tr" }}
   - name: tbc-tr
-    phc2sysOpts: -r -n (?<domainNumber>[0-9]+) -N 8 -R 16 -u 0 -m -s (?<iface_timeRx_FirstPort>[[:alnum:]]+)
+    phc2sysOpts: -r -n (?<domainNumber>[0-9]+) -N 8 -R 16 -u 0 -m -w -s (?<iface_timeRx_FirstPort>[[:alnum:]]+)
     plugins:
       e810:
         enableDefaultConfig: false

--- a/telco-ran/configuration/kube-compare-reference/ptp-operator/configuration/PtpConfigGnrdBcNoHoldover.yaml
+++ b/telco-ran/configuration/kube-compare-reference/ptp-operator/configuration/PtpConfigGnrdBcNoHoldover.yaml
@@ -138,7 +138,7 @@ spec:
   {{- end }}
   {{- if eq .name "01-bc-tr" }}
     - name: 01-bc-tr
-      phc2sysOpts: -r -n (?<domainNumber>[0-9]+) -N 8 -R 16 -u 0 -m -s (?<upstreamInterface>[[:alnum:]]+)
+      phc2sysOpts: -r -n (?<domainNumber>[0-9]+) -N 8 -R 16 -u 0 -m -w -s (?<upstreamInterface>[[:alnum:]]+)
       ptp4lConf: |
         [(?<upstreamInterface>[[:alnum:]]+)]
         masterOnly 0

--- a/telco-ran/configuration/kube-compare-reference/ptp-operator/configuration/PtpConfigGnrdTGM.yaml
+++ b/telco-ran/configuration/kube-compare-reference/ptp-operator/configuration/PtpConfigGnrdTGM.yaml
@@ -14,7 +14,7 @@ spec:
   {{- range .spec.profile }}
     - name: "grandmaster"
       ptp4lOpts: "-2 --summary_interval -4"
-      phc2sysOpts: -r -u 0 -m -w -N 8 -R 16 -n (?<domainNumber>[0-9]+) -s (?<leadingInterface>[[:alnum:]]+)
+      phc2sysOpts: -r -u 0 -m -N 8 -R 16 -n (?<domainNumber>[0-9]+) -s (?<leadingInterface>[[:alnum:]]+)
       ptpSchedulingPolicy: SCHED_FIFO
       ptpSchedulingPriority: 10
       ptpSettings:

--- a/telco-ran/configuration/kube-compare-reference/ptp-operator/configuration/PtpConfigTBCWpc.yaml
+++ b/telco-ran/configuration/kube-compare-reference/ptp-operator/configuration/PtpConfigTBCWpc.yaml
@@ -16,7 +16,7 @@ spec:
   {{- range .spec.profile }}
   {{- if eq .name "tbc-tr" }}
   - name: tbc-tr
-    phc2sysOpts: -r -n (?<domainNumber>[0-9]+) -N 8 -R 16 -u 0 -m -s (?<iface_timeRx>[[:alnum:]]+)
+    phc2sysOpts: -r -n (?<domainNumber>[0-9]+) -N 8 -R 16 -u 0 -m -w -s (?<iface_timeRx>[[:alnum:]]+)
     plugins:
       e810:
         enableDefaultConfig: false

--- a/telco-ran/configuration/kube-compare-reference/ptp-operator/configuration/PtpConfigThreeCardTBCWpc.yaml
+++ b/telco-ran/configuration/kube-compare-reference/ptp-operator/configuration/PtpConfigThreeCardTBCWpc.yaml
@@ -20,7 +20,7 @@ spec:
   {{- range .spec.profile }}
   {{- if eq .name "tbc-3-card-tr" }}
   - name: tbc-3-card-tr
-    phc2sysOpts: -r -n (?<domainNumber>[0-9]+) -N 8 -R 16 -u 0 -m -s (?<iface_timeRx>[[:alnum:]]+)
+    phc2sysOpts: -r -n (?<domainNumber>[0-9]+) -N 8 -R 16 -u 0 -m -w -s (?<iface_timeRx>[[:alnum:]]+)
     plugins:
       e810:
         enableDefaultConfig: false

--- a/telco-ran/configuration/source-crs/ptp-operator/configuration/PtpConfigDualCardTBCWpc.yaml
+++ b/telco-ran/configuration/source-crs/ptp-operator/configuration/PtpConfigDualCardTBCWpc.yaml
@@ -16,7 +16,7 @@ metadata:
 spec:
   profile:
   - name: tbc-dual-card-tr
-    phc2sysOpts: -r -n 24 -N 8 -R 16 -u 0 -m -s $iface_timeRx
+    phc2sysOpts: -r -n 24 -N 8 -R 16 -u 0 -m -w -s $iface_timeRx
     plugins:
       e810:
         enableDefaultConfig: false

--- a/telco-ran/configuration/source-crs/ptp-operator/configuration/PtpConfigDualTrTBC.yaml
+++ b/telco-ran/configuration/source-crs/ptp-operator/configuration/PtpConfigDualTrTBC.yaml
@@ -14,7 +14,7 @@ metadata:
 spec:
   profile:
   - name: tbc-tr
-    phc2sysOpts: -r -n 24 -N 8 -R 16 -u 0 -m -s $iface_timeRx_FirstPort
+    phc2sysOpts: -r -n 24 -N 8 -R 16 -u 0 -m -w -s $iface_timeRx_FirstPort
     plugins:
       e810:
         enableDefaultConfig: false

--- a/telco-ran/configuration/source-crs/ptp-operator/configuration/PtpConfigGnrdBcNoHoldover.yaml
+++ b/telco-ran/configuration/source-crs/ptp-operator/configuration/PtpConfigGnrdBcNoHoldover.yaml
@@ -181,7 +181,7 @@ spec:
         controllingProfile: 01-bc-tr
         logReduce: "true"
     - name: 01-bc-tr
-      phc2sysOpts: -r -n 24 -N 8 -R 16 -u 0 -m -s $upstreamInterface
+      phc2sysOpts: -r -n 24 -N 8 -R 16 -u 0 -m -w -s $upstreamInterface
       ptp4lConf: |
         [$upstreamInterface]
         masterOnly 0

--- a/telco-ran/configuration/source-crs/ptp-operator/configuration/PtpConfigGnrdTGM.yaml
+++ b/telco-ran/configuration/source-crs/ptp-operator/configuration/PtpConfigGnrdTGM.yaml
@@ -13,7 +13,7 @@ spec:
   profile:
     - name: "grandmaster"
       ptp4lOpts: "-2 --summary_interval -4"
-      phc2sysOpts: -r -u 0 -m -w -N 8 -R 16 -n 24 -s eno8703
+      phc2sysOpts: -r -u 0 -m -N 8 -R 16 -n 24 -s eno8703
       ptpSchedulingPolicy: SCHED_FIFO
       ptpSchedulingPriority: 10
       ptpSettings:

--- a/telco-ran/configuration/source-crs/ptp-operator/configuration/PtpConfigTBCWpc.yaml
+++ b/telco-ran/configuration/source-crs/ptp-operator/configuration/PtpConfigTBCWpc.yaml
@@ -14,7 +14,7 @@ metadata:
 spec:
   profile:
   - name: tbc-tr
-    phc2sysOpts: -r -n 24 -N 8 -R 16 -u 0 -m -s $iface_timeRx
+    phc2sysOpts: -r -n 24 -N 8 -R 16 -u 0 -m -w -s $iface_timeRx
     plugins:
       e810:
         enableDefaultConfig: false

--- a/telco-ran/configuration/source-crs/ptp-operator/configuration/PtpConfigThreeCardTBCWpc.yaml
+++ b/telco-ran/configuration/source-crs/ptp-operator/configuration/PtpConfigThreeCardTBCWpc.yaml
@@ -18,7 +18,7 @@ metadata:
 spec:
   profile:
   - name: tbc-3-card-tr
-    phc2sysOpts: -r -n 24 -N 8 -R 16 -u 0 -m -s $iface_timeRx
+    phc2sysOpts: -r -n 24 -N 8 -R 16 -u 0 -m -w -s $iface_timeRx
     plugins:
       e810:
         enableDefaultConfig: false


### PR DESCRIPTION
Remove -w from T-GM profile (PtpConfigGnrdTGM) and add -w to all T-BC profiles (PtpConfigGnrdBcNoHoldover, PtpConfigDualTrTBC, PtpConfigThreeCardTBCWpc, PtpConfigTBCWpc, PtpConfigDualCardTBCWpc).
/cc @lack 
