### PR TITLE
CNF-22163: Enable kubelet GracefulNodeShutdown in RAN DU 

### DIFF
--- a/telco-ran/configuration/kube-compare-reference/functions/unordered_list.tmpl
+++ b/telco-ran/configuration/kube-compare-reference/functions/unordered_list.tmpl
@@ -70,13 +70,27 @@
 {{- $systemReservedMemory = printf "\"%s\"" $inputSystemReserved.memory }}
 {{- end }}
 {{- end }}
+{{- $shutdownGracePeriod := "" }}
+{{- if hasKey $config "shutdownGracePeriod" }}
+{{- $shutdownGracePeriod = $config.shutdownGracePeriod }}
+{{- end }}
+{{- $shutdownGracePeriodCriticalPods := "" }}
+{{- if hasKey $config "shutdownGracePeriodCriticalPods" }}
+{{- $shutdownGracePeriodCriticalPods = $config.shutdownGracePeriodCriticalPods }}
+{{- end }}
     kubeletconfig.experimental: |
       {
        {{- if $result }}
        "allowedUnsafeSysctls":{{ $result | toJson }},
        {{- end }}
        {{- if $systemReservedMemory }}
-       "systemReserved":{"memory":{{ $systemReservedMemory }}}
+       "systemReserved":{"memory":{{ $systemReservedMemory }}},
+       {{- end }}
+       {{- if $shutdownGracePeriod }}
+       "shutdownGracePeriod":"{{ $shutdownGracePeriod }}",
+       {{- end }}
+       {{- if $shutdownGracePeriodCriticalPods }}
+       "shutdownGracePeriodCriticalPods":"{{ $shutdownGracePeriodCriticalPods }}"
        {{- end }}
       }
 {{- end }}

--- a/telco-ran/configuration/kube-compare-reference/hack/arch/aarch64.yaml
+++ b/telco-ran/configuration/kube-compare-reference/hack/arch/aarch64.yaml
@@ -3,7 +3,9 @@ node_tuning_operator_PerformanceProfile:
       annotations:
         kubeletconfig.experimental: |
           {
-            "systemReserved":{"memory":"11Gi"}
+            "systemReserved":{"memory":"11Gi"},
+            "shutdownGracePeriod":"30s",
+            "shutdownGracePeriodCriticalPods":"10s"
           }
     spec:
       additionalKernelArgs:

--- a/telco-ran/configuration/kube-compare-reference/hack/arch/x86_64.yaml
+++ b/telco-ran/configuration/kube-compare-reference/hack/arch/x86_64.yaml
@@ -3,7 +3,9 @@ node_tuning_operator_PerformanceProfile:
       annotations:
         kubeletconfig.experimental: |
           {
-            "systemReserved":{"memory":"11Gi"}
+            "systemReserved":{"memory":"11Gi"},
+            "shutdownGracePeriod":"30s",
+            "shutdownGracePeriodCriticalPods":"10s"
           }
     spec:
       additionalKernelArgs:

--- a/telco-ran/configuration/source-crs/node-tuning-operator/aarch64/PerformanceProfile-SetSelector.yaml
+++ b/telco-ran/configuration/source-crs/node-tuning-operator/aarch64/PerformanceProfile-SetSelector.yaml
@@ -10,9 +10,13 @@ metadata:
     ran.openshift.io/ztp-deploy-wave: "10"
     ran.openshift.io/reference-configuration: "ran-du.redhat.com"
     # systemReserved: when used, it should be tailored for each environment.
+    # shutdownGracePeriod: enables kubelet GracefulNodeShutdown to reduce
+    # IBU upgrade downtime. Non-critical pods get 20s, critical pods get 10s.
     kubeletconfig.experimental: |
       {
-       "systemReserved":{"memory":"11Gi"}
+       "systemReserved":{"memory":"11Gi"},
+       "shutdownGracePeriod":"30s",
+       "shutdownGracePeriodCriticalPods":"10s"
       }
 spec:
   # Note: The defaults here are for Grace Hopper systems. Other systems may alternative PCI or iommu settings such as:

--- a/telco-ran/configuration/source-crs/node-tuning-operator/aarch64/PerformanceProfile.yaml
+++ b/telco-ran/configuration/source-crs/node-tuning-operator/aarch64/PerformanceProfile.yaml
@@ -10,9 +10,13 @@ metadata:
     ran.openshift.io/ztp-deploy-wave: "10"
     ran.openshift.io/reference-configuration: "ran-du.redhat.com"
     # systemReserved: when used, it should be tailored for each environment.
+    # shutdownGracePeriod: enables kubelet GracefulNodeShutdown to reduce
+    # IBU upgrade downtime. Non-critical pods get 20s, critical pods get 10s.
     kubeletconfig.experimental: |
       {
-       "systemReserved":{"memory":"11Gi"}
+       "systemReserved":{"memory":"11Gi"},
+       "shutdownGracePeriod":"30s",
+       "shutdownGracePeriodCriticalPods":"10s"
       }
 spec:
   # Note: The defaults here are for Grace Hopper systems. Other systems may alternative PCI or iommu settings such as:

--- a/telco-ran/configuration/source-crs/node-tuning-operator/x86_64/PerformanceProfile-SetSelector.yaml
+++ b/telco-ran/configuration/source-crs/node-tuning-operator/x86_64/PerformanceProfile-SetSelector.yaml
@@ -10,9 +10,13 @@ metadata:
     ran.openshift.io/ztp-deploy-wave: "10"
     ran.openshift.io/reference-configuration: "ran-du.redhat.com"
     # systemReserved: when used, it should be tailored for each environment.
+    # shutdownGracePeriod: enables kubelet GracefulNodeShutdown to reduce
+    # IBU upgrade downtime. Non-critical pods get 20s, critical pods get 10s.
     kubeletconfig.experimental: |
       {
-       "systemReserved":{"memory":"11Gi"}
+       "systemReserved":{"memory":"11Gi"},
+       "shutdownGracePeriod":"30s",
+       "shutdownGracePeriodCriticalPods":"10s"
       }
 spec:
   # Optional kernel arguments:

--- a/telco-ran/configuration/source-crs/node-tuning-operator/x86_64/PerformanceProfile.yaml
+++ b/telco-ran/configuration/source-crs/node-tuning-operator/x86_64/PerformanceProfile.yaml
@@ -10,9 +10,13 @@ metadata:
     ran.openshift.io/ztp-deploy-wave: "10"
     ran.openshift.io/reference-configuration: "ran-du.redhat.com"
     # systemReserved: when used, it should be tailored for each environment.
+    # shutdownGracePeriod: enables kubelet GracefulNodeShutdown to reduce
+    # IBU upgrade downtime. Non-critical pods get 20s, critical pods get 10s.
     kubeletconfig.experimental: |
       {
-       "systemReserved":{"memory":"11Gi"}
+       "systemReserved":{"memory":"11Gi"},
+       "shutdownGracePeriod":"30s",
+       "shutdownGracePeriodCriticalPods":"10s"
       }
 spec:
   # Optional kernel arguments:


### PR DESCRIPTION
Add `shutdownGracePeriod` and `shutdownGracePeriodCriticalPods` to the `kubeletconfig.experimental`annotation in all PerformanceProfile source CRs (x86_64 and aarch64). This enables the kubelet's native GracefulNodeShutdown feature, which reduces IBU upgrade downtime by allowing pods to terminate gracefully before node shutdown.

The kube-compare template and hack arch values are updated to validate and render the new fields with defaults of 30s total (20s non-critical, 10s critical).