### PR TITLE
CNF-26586: Update registry path from openshift4 to openshift5

### DIFF
--- a/.tekton/build-pipeline-telco-core-rds.yaml
+++ b/.tekton/build-pipeline-telco-core-rds.yaml
@@ -257,7 +257,7 @@ spec:
       - description=Telco Core RDS manifests
       - distribution-scope=public
       - io.k8s.description=Telco Core RDS manifests
-      - name=openshift4/openshift-telco-core-rds-rhel9
+      - name=openshift5/openshift-telco-core-rds-rhel9
       - release=4.22
       - url=https://github.com/openshift-kni/telco-reference
       - vendor=Red Hat, Inc.

--- a/.tekton/build-pipeline-telco-hub-rds.yaml
+++ b/.tekton/build-pipeline-telco-hub-rds.yaml
@@ -250,7 +250,7 @@ spec:
       - description=Telco Hub RDS manifests
       - distribution-scope=public
       - io.k8s.description=Telco Hub RDS manifests
-      - name=openshift4/openshift-telco-hub-rds-rhel9
+      - name=openshift5/openshift-telco-hub-rds-rhel9
       - release=4.22
       - url=https://github.com/openshift-kni/telco-reference
       - vendor=Red Hat, Inc.

--- a/telco-core/Dockerfile.telco-core
+++ b/telco-core/Dockerfile.telco-core
@@ -10,7 +10,7 @@ ENTRYPOINT ["/bin/bash"]
 CMD ["-c", "tar -cf - --directory /usr/share telco-core-rds | base64 -w0"]
 
 LABEL com.redhat.component="openshift-telco-core-rds-container" \
-    name="openshift4/openshift-telco-core-rds-rhel9" \
+    name="openshift5/openshift-telco-core-rds-rhel9" \
     cpe="cpe:/a:redhat:openshift:5.0::el9" \
     summary="Telco Core RDS manifests" \
     io.openshift.expose-services="" \

--- a/telco-core/configuration/core-baseline.yaml
+++ b/telco-core/configuration/core-baseline.yaml
@@ -110,4 +110,4 @@ policies:
       - path: reference-crs/required/scheduling/sched.yaml
         patches:
         - spec:
-            imageSpec: registry.example.com/openshift4/noderesourcetopology-scheduler-rhel9:v4.22.0
+            imageSpec: registry.example.com/openshift5/noderesourcetopology-scheduler-rhel9:v5.0.0

--- a/telco-core/configuration/reference-crs/required/scheduling/sched.yaml
+++ b/telco-core/configuration/reference-crs/required/scheduling/sched.yaml
@@ -8,6 +8,6 @@ metadata:
 spec:
   # cacheResyncPeriod: "0"
   # Image spec should be the latest for the release
-  imageSpec: "registry.redhat.io/openshift4/noderesourcetopology-scheduler-rhel9:v4.22.0"
+  imageSpec: "registry.redhat.io/openshift5/noderesourcetopology-scheduler-rhel9:v5.0.0"
   # logLevel: "Trace"
   schedulerName: topo-aware-scheduler

--- a/telco-hub/Dockerfile.telco-hub
+++ b/telco-hub/Dockerfile.telco-hub
@@ -10,7 +10,7 @@ ENTRYPOINT ["/bin/bash"]
 CMD ["-c", "tar -cf - --directory /usr/share telco-hub-rds | base64 -w0"]
 
 LABEL com.redhat.component="openshift-telco-hub-rds-container" \
-    name="openshift4/openshift-telco-hub-rds-rhel9" \
+    name="openshift5/openshift-telco-hub-rds-rhel9" \
     cpe="cpe:/a:redhat:openshift:5.0::el9" \
     summary="Telco Hub RDS manifests" \
     io.openshift.expose-services="" \

--- a/telco-hub/configuration/example-overlays-config/acm/acmMirrorRegistryCM-patch.yaml
+++ b/telco-hub/configuration/example-overlays-config/acm/acmMirrorRegistryCM-patch.yaml
@@ -46,10 +46,10 @@
 
     [[registry]]
       prefix = ""
-      location = "registry.redhat.io/openshift4"
+      location = "registry.redhat.io/openshift5"
 
       [[registry.mirror]]
-        location = "<registry.example.com:8443>/openshift4"
+        location = "<registry.example.com:8443>/openshift5"
         pull-from-mirror = "digest-only"
 
     [[registry]]

--- a/telco-hub/configuration/example-overlays-config/acm/acmMirrorRegistryCM-patch.yaml
+++ b/telco-hub/configuration/example-overlays-config/acm/acmMirrorRegistryCM-patch.yaml
@@ -46,6 +46,14 @@
 
     [[registry]]
       prefix = ""
+      location = "registry.redhat.io/openshift4"
+
+      [[registry.mirror]]
+        location = "<registry.example.com:8443>/openshift4"
+        pull-from-mirror = "digest-only"
+
+    [[registry]]
+      prefix = ""
       location = "registry.redhat.io/openshift5"
 
       [[registry.mirror]]

--- a/telco-hub/configuration/example-overlays-config/registry/idms-operator-mirrors-patch.yaml
+++ b/telco-hub/configuration/example-overlays-config/registry/idms-operator-mirrors-patch.yaml
@@ -30,8 +30,8 @@
     - <registry.example.com:8443>/rhacm2
     source: registry.redhat.io/rhacm2
   - mirrors:
-    - <registry.example.com:8443>/openshift4
-    source: registry.redhat.io/openshift4
+    - <registry.example.com:8443>/openshift5
+    source: registry.redhat.io/openshift5
   - mirrors:
     - <registry.example.com:8443>/multicluster-engine/assisted-installer-agent-rhel9
     source: registry.redhat.io/multicluster-engine/assisted-installer-agent-rhel9

--- a/telco-hub/configuration/example-overlays-config/registry/idms-operator-mirrors-patch.yaml
+++ b/telco-hub/configuration/example-overlays-config/registry/idms-operator-mirrors-patch.yaml
@@ -30,6 +30,9 @@
     - <registry.example.com:8443>/rhacm2
     source: registry.redhat.io/rhacm2
   - mirrors:
+    - <registry.example.com:8443>/openshift4
+    source: registry.redhat.io/openshift4
+  - mirrors:
     - <registry.example.com:8443>/openshift5
     source: registry.redhat.io/openshift5
   - mirrors:

--- a/telco-hub/configuration/example-overlays-config/registry/idms-operator-mirrors-patch.yaml
+++ b/telco-hub/configuration/example-overlays-config/registry/idms-operator-mirrors-patch.yaml
@@ -30,9 +30,6 @@
     - <registry.example.com:8443>/rhacm2
     source: registry.redhat.io/rhacm2
   - mirrors:
-    - <registry.example.com:8443>/openshift4
-    source: registry.redhat.io/openshift4
-  - mirrors:
     - <registry.example.com:8443>/openshift5
     source: registry.redhat.io/openshift5
   - mirrors:

--- a/telco-hub/configuration/example-overlays-config/registry/itms-generic-mirrors-patch.yaml
+++ b/telco-hub/configuration/example-overlays-config/registry/itms-generic-mirrors-patch.yaml
@@ -6,8 +6,8 @@
     - <registry.example.com:8443>/ubi8
     source: registry.redhat.io/ubi8
   - mirrors:
-    - <registry.example.com:8443>/openshift4
-    source: registry.redhat.io/openshift4
+    - <registry.example.com:8443>/openshift5
+    source: registry.redhat.io/openshift5
   - mirrors:
     - <registry.example.com:8443>/rhel8
     source: registry.redhat.io/rhel8

--- a/telco-hub/configuration/example-overlays-config/registry/itms-generic-mirrors-patch.yaml
+++ b/telco-hub/configuration/example-overlays-config/registry/itms-generic-mirrors-patch.yaml
@@ -6,6 +6,9 @@
     - <registry.example.com:8443>/ubi8
     source: registry.redhat.io/ubi8
   - mirrors:
+    - <registry.example.com:8443>/openshift4
+    source: registry.redhat.io/openshift4
+  - mirrors:
     - <registry.example.com:8443>/openshift5
     source: registry.redhat.io/openshift5
   - mirrors:

--- a/telco-hub/configuration/example-overlays-config/registry/itms-generic-mirrors-patch.yaml
+++ b/telco-hub/configuration/example-overlays-config/registry/itms-generic-mirrors-patch.yaml
@@ -6,9 +6,6 @@
     - <registry.example.com:8443>/ubi8
     source: registry.redhat.io/ubi8
   - mirrors:
-    - <registry.example.com:8443>/openshift4
-    source: registry.redhat.io/openshift4
-  - mirrors:
     - <registry.example.com:8443>/openshift5
     source: registry.redhat.io/openshift5
   - mirrors:

--- a/telco-hub/configuration/reference-crs-kube-compare/default_value.yaml
+++ b/telco-hub/configuration/reference-crs-kube-compare/default_value.yaml
@@ -235,9 +235,9 @@ required_acm_acmMirrorRegistryCM:
           pull-from-mirror = "digest-only"
       [[registry]]
         prefix = ""
-        location = "registry.redhat.io/openshift4"
+        location = "registry.redhat.io/openshift5"
         [[registry.mirror]]
-          location = "<registry.example.com:8443>/openshift4"
+          location = "<registry.example.com:8443>/openshift5"
           pull-from-mirror = "digest-only"
       [[registry]]
         prefix = ""
@@ -385,8 +385,8 @@ required_registry_idms_operator:
         - <registry.example.com:8443>/rhacm2
         source: registry.redhat.io/rhacm2
       - mirrors:
-        - <registry.example.com:8443>/openshift4
-        source: registry.redhat.io/openshift4
+        - <registry.example.com:8443>/openshift5
+        source: registry.redhat.io/openshift5
       - mirrors:
         - <registry.example.com:8443>/multicluster-engine/assisted-installer-agent-rhel9
         source: registry.redhat.io/multicluster-engine/assisted-installer-agent-rhel9
@@ -421,8 +421,8 @@ required_registry_itms_generic:
         - <registry.example.com:8443>/ubi8
         source: registry.redhat.io/ubi8
       - mirrors:
-        - <registry.example.com:8443>/openshift4
-        source: registry.redhat.io/openshift4
+        - <registry.example.com:8443>/openshift5
+        source: registry.redhat.io/openshift5
       - mirrors:
         - <registry.example.com:8443>/rhel8
         source: registry.redhat.io/rhel8

--- a/telco-hub/configuration/reference-crs-kube-compare/default_value.yaml
+++ b/telco-hub/configuration/reference-crs-kube-compare/default_value.yaml
@@ -235,6 +235,12 @@ required_acm_acmMirrorRegistryCM:
           pull-from-mirror = "digest-only"
       [[registry]]
         prefix = ""
+        location = "registry.redhat.io/openshift4"
+        [[registry.mirror]]
+          location = "<registry.example.com:8443>/openshift4"
+          pull-from-mirror = "digest-only"
+      [[registry]]
+        prefix = ""
         location = "registry.redhat.io/openshift5"
         [[registry.mirror]]
           location = "<registry.example.com:8443>/openshift5"
@@ -385,6 +391,9 @@ required_registry_idms_operator:
         - <registry.example.com:8443>/rhacm2
         source: registry.redhat.io/rhacm2
       - mirrors:
+        - <registry.example.com:8443>/openshift4
+        source: registry.redhat.io/openshift4
+      - mirrors:
         - <registry.example.com:8443>/openshift5
         source: registry.redhat.io/openshift5
       - mirrors:
@@ -420,6 +429,9 @@ required_registry_itms_generic:
       - mirrors:
         - <registry.example.com:8443>/ubi8
         source: registry.redhat.io/ubi8
+      - mirrors:
+        - <registry.example.com:8443>/openshift4
+        source: registry.redhat.io/openshift4
       - mirrors:
         - <registry.example.com:8443>/openshift5
         source: registry.redhat.io/openshift5

--- a/telco-hub/configuration/reference-crs-kube-compare/default_value.yaml
+++ b/telco-hub/configuration/reference-crs-kube-compare/default_value.yaml
@@ -391,9 +391,6 @@ required_registry_idms_operator:
         - <registry.example.com:8443>/rhacm2
         source: registry.redhat.io/rhacm2
       - mirrors:
-        - <registry.example.com:8443>/openshift4
-        source: registry.redhat.io/openshift4
-      - mirrors:
         - <registry.example.com:8443>/openshift5
         source: registry.redhat.io/openshift5
       - mirrors:
@@ -429,9 +426,6 @@ required_registry_itms_generic:
       - mirrors:
         - <registry.example.com:8443>/ubi8
         source: registry.redhat.io/ubi8
-      - mirrors:
-        - <registry.example.com:8443>/openshift4
-        source: registry.redhat.io/openshift4
       - mirrors:
         - <registry.example.com:8443>/openshift5
         source: registry.redhat.io/openshift5

--- a/telco-hub/configuration/reference-crs/required/acm/acmMirrorRegistryCM.yaml
+++ b/telco-hub/configuration/reference-crs/required/acm/acmMirrorRegistryCM.yaml
@@ -53,6 +53,12 @@ data:
         pull-from-mirror = "digest-only"
     [[registry]]
       prefix = ""
+      location = "registry.redhat.io/openshift4"
+      [[registry.mirror]]
+        location = "<registry.example.com:8443>/openshift4"
+        pull-from-mirror = "digest-only"
+    [[registry]]
+      prefix = ""
       location = "registry.redhat.io/openshift5"
       [[registry.mirror]]
         location = "<registry.example.com:8443>/openshift5"

--- a/telco-hub/configuration/reference-crs/required/acm/acmMirrorRegistryCM.yaml
+++ b/telco-hub/configuration/reference-crs/required/acm/acmMirrorRegistryCM.yaml
@@ -53,9 +53,9 @@ data:
         pull-from-mirror = "digest-only"
     [[registry]]
       prefix = ""
-      location = "registry.redhat.io/openshift4"
+      location = "registry.redhat.io/openshift5"
       [[registry.mirror]]
-        location = "<registry.example.com:8443>/openshift4"
+        location = "<registry.example.com:8443>/openshift5"
         pull-from-mirror = "digest-only"
     [[registry]]
       prefix = ""

--- a/telco-hub/configuration/reference-crs/required/gitops/addPluginsPolicy.yaml
+++ b/telco-hub/configuration/reference-crs/required/gitops/addPluginsPolicy.yaml
@@ -75,7 +75,7 @@ spec:
                             mountPath: "/.config"
                         terminationMessagePolicy: "File"
                         terminationMessagePath: "/dev/termination-log"
-                        image: "registry.redhat.io/openshift4/ztp-site-generate-rhel8:v4.22"
+                        image: "registry.redhat.io/openshift5/ztp-site-generate-rhel8:v5.0"
                       - name: "policy-generator-install"
                         image: "registry.redhat.io/rhacm2/multicluster-operators-subscription-rhel9:v2.17"
                         imagePullPolicy: "Always"

--- a/telco-hub/configuration/reference-crs/required/gitops/get_ztp_installation.sh
+++ b/telco-hub/configuration/reference-crs/required/gitops/get_ztp_installation.sh
@@ -11,7 +11,7 @@ fi
 
 #CURRENT_OCP_VERSION=4.18
 #ZTP_SITE_GENERATE_IMAGE=ztp-site-generate-rhel8:v${CURRENT_OCP_VERSION}
-#podman run --log-driver=none --rm registry.redhat.io/openshift5/${ZTP_SITE_GENERATE_IMAGE=ztp-site-generate-rhel8} extract /home/ztp/argocd/deployment --tar | tar x -C "ztp-installation"
+#podman run --log-driver=none --rm registry.redhat.io/openshift4/${ZTP_SITE_GENERATE_IMAGE=ztp-site-generate-rhel8} extract /home/ztp/argocd/deployment --tar | tar x -C "ztp-installation"
 
 rm ztp-installation/*
 cp ../../../../../telco-ran/configuration/argocd/deployment/* ztp-installation/
@@ -27,7 +27,7 @@ find ./ztp-installation/ -name "*.yaml" -exec yq -i eval '.metadata.annotations.
 
 # patch the ztp-site-generate version
 echo " - Patch ztp-site-generate version"
-sedi 's|quay.io/openshift-kni/ztp-site-generator:latest|registry.redhat.io/openshift5/ztp-site-generate-rhel8:v4.21|g' ztp-installation/argocd-openshift-gitops-patch.json
+sedi 's|quay.io/openshift-kni/ztp-site-generator:latest|registry.redhat.io/openshift4/ztp-site-generate-rhel8:v4.21|g' ztp-installation/argocd-openshift-gitops-patch.json
 
 echo  " - Adding elements to the whitelist"
 yq '.spec.namespaceResourceWhitelist += {"group": "'metal3.io'", "kind": "DataImage"}' ztp-installation/app-project.yaml

--- a/telco-hub/configuration/reference-crs/required/gitops/get_ztp_installation.sh
+++ b/telco-hub/configuration/reference-crs/required/gitops/get_ztp_installation.sh
@@ -11,7 +11,7 @@ fi
 
 #CURRENT_OCP_VERSION=4.18
 #ZTP_SITE_GENERATE_IMAGE=ztp-site-generate-rhel8:v${CURRENT_OCP_VERSION}
-#podman run --log-driver=none --rm registry.redhat.io/openshift4/${ZTP_SITE_GENERATE_IMAGE=ztp-site-generate-rhel8} extract /home/ztp/argocd/deployment --tar | tar x -C "ztp-installation"
+#podman run --log-driver=none --rm registry.redhat.io/openshift5/${ZTP_SITE_GENERATE_IMAGE=ztp-site-generate-rhel8} extract /home/ztp/argocd/deployment --tar | tar x -C "ztp-installation"
 
 rm ztp-installation/*
 cp ../../../../../telco-ran/configuration/argocd/deployment/* ztp-installation/
@@ -27,7 +27,7 @@ find ./ztp-installation/ -name "*.yaml" -exec yq -i eval '.metadata.annotations.
 
 # patch the ztp-site-generate version
 echo " - Patch ztp-site-generate version"
-sedi 's|quay.io/openshift-kni/ztp-site-generator:latest|registry.redhat.io/openshift4/ztp-site-generate-rhel8:v4.21|g' ztp-installation/argocd-openshift-gitops-patch.json
+sedi 's|quay.io/openshift-kni/ztp-site-generator:latest|registry.redhat.io/openshift5/ztp-site-generate-rhel8:v4.21|g' ztp-installation/argocd-openshift-gitops-patch.json
 
 echo  " - Adding elements to the whitelist"
 yq '.spec.namespaceResourceWhitelist += {"group": "'metal3.io'", "kind": "DataImage"}' ztp-installation/app-project.yaml

--- a/telco-hub/configuration/reference-crs/required/registry/idms-operator.yaml
+++ b/telco-hub/configuration/reference-crs/required/registry/idms-operator.yaml
@@ -39,8 +39,8 @@ spec:
     - <registry.example.com:8443>/rhacm2
     source: registry.redhat.io/rhacm2
   - mirrors:
-    - <registry.example.com:8443>/openshift4
-    source: registry.redhat.io/openshift4
+    - <registry.example.com:8443>/openshift5
+    source: registry.redhat.io/openshift5
   - mirrors:
     - <registry.example.com:8443>/multicluster-engine/assisted-installer-agent-rhel9
     source: registry.redhat.io/multicluster-engine/assisted-installer-agent-rhel9

--- a/telco-hub/configuration/reference-crs/required/registry/idms-operator.yaml
+++ b/telco-hub/configuration/reference-crs/required/registry/idms-operator.yaml
@@ -39,9 +39,6 @@ spec:
     - <registry.example.com:8443>/rhacm2
     source: registry.redhat.io/rhacm2
   - mirrors:
-    - <registry.example.com:8443>/openshift4
-    source: registry.redhat.io/openshift4
-  - mirrors:
     - <registry.example.com:8443>/openshift5
     source: registry.redhat.io/openshift5
   - mirrors:

--- a/telco-hub/configuration/reference-crs/required/registry/idms-operator.yaml
+++ b/telco-hub/configuration/reference-crs/required/registry/idms-operator.yaml
@@ -39,6 +39,9 @@ spec:
     - <registry.example.com:8443>/rhacm2
     source: registry.redhat.io/rhacm2
   - mirrors:
+    - <registry.example.com:8443>/openshift4
+    source: registry.redhat.io/openshift4
+  - mirrors:
     - <registry.example.com:8443>/openshift5
     source: registry.redhat.io/openshift5
   - mirrors:

--- a/telco-hub/configuration/reference-crs/required/registry/itms-generic.yaml
+++ b/telco-hub/configuration/reference-crs/required/registry/itms-generic.yaml
@@ -15,6 +15,9 @@ spec:
     - <registry.example.com:8443>/ubi8
     source: registry.redhat.io/ubi8
   - mirrors:
+    - <registry.example.com:8443>/openshift4
+    source: registry.redhat.io/openshift4
+  - mirrors:
     - <registry.example.com:8443>/openshift5
     source: registry.redhat.io/openshift5
   - mirrors:

--- a/telco-hub/configuration/reference-crs/required/registry/itms-generic.yaml
+++ b/telco-hub/configuration/reference-crs/required/registry/itms-generic.yaml
@@ -15,9 +15,6 @@ spec:
     - <registry.example.com:8443>/ubi8
     source: registry.redhat.io/ubi8
   - mirrors:
-    - <registry.example.com:8443>/openshift4
-    source: registry.redhat.io/openshift4
-  - mirrors:
     - <registry.example.com:8443>/openshift5
     source: registry.redhat.io/openshift5
   - mirrors:

--- a/telco-hub/configuration/reference-crs/required/registry/itms-generic.yaml
+++ b/telco-hub/configuration/reference-crs/required/registry/itms-generic.yaml
@@ -15,8 +15,8 @@ spec:
     - <registry.example.com:8443>/ubi8
     source: registry.redhat.io/ubi8
   - mirrors:
-    - <registry.example.com:8443>/openshift4
-    source: registry.redhat.io/openshift4
+    - <registry.example.com:8443>/openshift5
+    source: registry.redhat.io/openshift5
   - mirrors:
     - <registry.example.com:8443>/rhel8
     source: registry.redhat.io/rhel8

--- a/telco-hub/install/mirror-registry/imageset-config.yaml
+++ b/telco-hub/install/mirror-registry/imageset-config.yaml
@@ -103,7 +103,7 @@ mirror:
       - name: stable-v1
   additionalImages:
   - name: registry.redhat.io/ubi8/ubi:latest
-  - name: registry.redhat.io/openshift5/ztp-site-generate-rhel9:v5.0
+  - name: registry.redhat.io/openshift5/ztp-site-generate-rhel8:v5.0
   - name: registry.redhat.io/rhel8/support-tools:latest
   - name: registry.redhat.io/rhacm2/multicluster-operators-subscription-rhel9:v2.17.0-1
   helm: {}

--- a/telco-hub/install/mirror-registry/imageset-config.yaml
+++ b/telco-hub/install/mirror-registry/imageset-config.yaml
@@ -103,7 +103,7 @@ mirror:
       - name: stable-v1
   additionalImages:
   - name: registry.redhat.io/ubi8/ubi:latest
-  - name: registry.redhat.io/openshift5/ztp-site-generate-rhel8:v5.0
+  - name: registry.redhat.io/openshift5/ztp-site-generate-rhel9:v5.0
   - name: registry.redhat.io/rhel8/support-tools:latest
   - name: registry.redhat.io/rhacm2/multicluster-operators-subscription-rhel9:v2.17.0-1
   helm: {}

--- a/telco-hub/install/mirror-registry/imageset-config.yaml
+++ b/telco-hub/install/mirror-registry/imageset-config.yaml
@@ -103,7 +103,7 @@ mirror:
       - name: stable-v1
   additionalImages:
   - name: registry.redhat.io/ubi8/ubi:latest
-  - name: registry.redhat.io/openshift4/ztp-site-generate-rhel8:v4.22
+  - name: registry.redhat.io/openshift5/ztp-site-generate-rhel8:v5.0
   - name: registry.redhat.io/rhel8/support-tools:latest
   - name: registry.redhat.io/rhacm2/multicluster-operators-subscription-rhel9:v2.17.0-1
   helm: {}


### PR DESCRIPTION
## Summary
- Replace all occurrences of the `openshift4` registry namespace with `openshift5` across telco-hub, telco-core, and tekton build pipelines (16 files, 28 replacements).
- Covers mirror registry configs (IDMS, ITMS, ACM), scheduling image references, Dockerfiles, kube-compare default values, ZTP site-generate image refs, and imageset-config.

## Test plan
- [ ] Verify no remaining `openshift4` references in the repository (excluding submodules)
- [ ] Validate mirror registry configurations resolve correctly with the new `openshift5` path
- [ ] Confirm tekton build pipelines reference the correct image names

Resolves: https://redhat.atlassian.net/browse/CNF-26586


Made with [Cursor](https://cursor.com)