### PR TITLE
Fix yamllint warnings in telco-core and telco-ran manifests

### DIFF
--- a/telco-core/configuration/hack/cluster-default-crs/node.config.yaml
+++ b/telco-core/configuration/hack/cluster-default-crs/node.config.yaml
@@ -1,3 +1,4 @@
+---
 apiVersion: config.openshift.io/v1
 kind: Node
 metadata:

--- a/telco-core/configuration/reference-crs/required/performance/PerformanceProfile-control-plane.yaml
+++ b/telco-core/configuration/reference-crs/required/performance/PerformanceProfile-control-plane.yaml
@@ -27,7 +27,7 @@ spec:
   # default value of globallyDisableIrqLoadBalancing is false
   globallyDisableIrqLoadBalancing: false
   # Hugepages may be configured as needed when using schedulable control planes
-  #hugepages:
+  # hugepages:
   #  defaultHugepagesSize: 1G
   #  pages:
   #  - count: 64

--- a/telco-core/install/extra-manifests/clusterimagepolicy-telco-core-operators.yaml
+++ b/telco-core/install/extra-manifests/clusterimagepolicy-telco-core-operators.yaml
@@ -1,3 +1,4 @@
+---
 apiVersion: config.openshift.io/v1
 kind: ClusterImagePolicy
 metadata:

--- a/telco-ran/configuration/acmpolicygenerator/image-based-upgrades/acm-pg-ran-ibu-upgrade.yaml
+++ b/telco-ran/configuration/acmpolicygenerator/image-based-upgrades/acm-pg-ran-ibu-upgrade.yaml
@@ -1,3 +1,4 @@
+---
 apiVersion: policy.open-cluster-management.io/v1
 kind: PolicyGenerator
 metadata:

--- a/telco-ran/configuration/acmpolicygenerator/image-based-upgrades/kustomization.yaml
+++ b/telco-ran/configuration/acmpolicygenerator/image-based-upgrades/kustomization.yaml
@@ -1,3 +1,4 @@
+---
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 

--- a/telco-ran/configuration/acmpolicygenerator/image-based-upgrades/pgt-ibu-upgrade.yaml
+++ b/telco-ran/configuration/acmpolicygenerator/image-based-upgrades/pgt-ibu-upgrade.yaml
@@ -1,3 +1,4 @@
+---
 apiVersion: ran.openshift.io/v1
 kind: PolicyGenTemplate
 metadata:

--- a/telco-ran/configuration/acmpolicygenerator/kustomization.yaml
+++ b/telco-ran/configuration/acmpolicygenerator/kustomization.yaml
@@ -1,3 +1,4 @@
+---
 generators:
 # Common policies for all SNO RAN deployments
 - ran-common.yaml

--- a/telco-ran/configuration/acmpolicygenerator/ns.yaml
+++ b/telco-ran/configuration/acmpolicygenerator/ns.yaml
@@ -1,3 +1,4 @@
+---
 apiVersion: v1
 kind: Namespace
 metadata:

--- a/telco-ran/configuration/acmpolicygenerator/ran-common.yaml
+++ b/telco-ran/configuration/acmpolicygenerator/ran-common.yaml
@@ -1,3 +1,4 @@
+---
 apiVersion: policy.open-cluster-management.io/v1
 kind: PolicyGenerator
 metadata:
@@ -6,7 +7,7 @@ placementBindingDefaults:
   name: common-placement-binding
 policyDefaults:
   # categories: []
-  #controls:
+  # controls:
   #  - PR.DS-1 Data-at-rest
   namespace: ztp-common
   # Use an existing placement rule so that placement bindings can be consolidated

--- a/telco-ran/configuration/acmpolicygenerator/ran-example-reboot.yaml
+++ b/telco-ran/configuration/acmpolicygenerator/ran-example-reboot.yaml
@@ -1,3 +1,4 @@
+---
 apiVersion: policy.open-cluster-management.io/v1
 kind: PolicyGenerator
 metadata:
@@ -32,9 +33,9 @@ policies:
           storage:
             files:
             - contents:
-              # content of file should change to trigger a reboot
-              # append a message for the reboot to the content of the file
-              # example: $ echo "$(date): applying tuned config" | base64
+                # content of file should change to trigger a reboot
+                # append a message for the reboot to the content of the file
+                # example: $ echo "$(date): applying tuned config" | base64
                 source: data:text/plain;charset=utf-8;base64,bWVzc2FnZQo=
               mode: 420
               path: "/etc/kubernetes/mcp-reboot-flag"

--- a/telco-ran/configuration/acmpolicygenerator/ran-group-du-3node-templated.yaml
+++ b/telco-ran/configuration/acmpolicygenerator/ran-group-du-3node-templated.yaml
@@ -3,6 +3,7 @@
 #   hardware-type: hw-type-platform-1
 # ConfigMaps used:
 #   group-hardware-types-configmap.yaml: group-hardware-types-configmap
+---
 apiVersion: policy.open-cluster-management.io/v1
 kind: PolicyGenerator
 metadata:

--- a/telco-ran/configuration/acmpolicygenerator/ran-group-du-3node-validator.yaml
+++ b/telco-ran/configuration/acmpolicygenerator/ran-group-du-3node-validator.yaml
@@ -1,3 +1,4 @@
+---
 apiVersion: policy.open-cluster-management.io/v1
 kind: PolicyGenerator
 metadata:
@@ -6,7 +7,7 @@ placementBindingDefaults:
   name: group-du-3node-placement-binding
 policyDefaults:
   # categories: []
-  #controls:
+  # controls:
   #  - PR.DS-1 Data-at-rest
   namespace: ztp-group
   # Use an existing placement rule so that placement bindings can be consolidated
@@ -29,8 +30,8 @@ policyDefaults:
     include:
       - '*'
   evaluationInterval:
-   # This low setting is only valid if the validation policy is disconnected from the cluster at steady-state
-   # using a bindingExcludeRules entry with ztp-done
+    # This low setting is only valid if the validation policy is disconnected from the cluster at steady-state
+    # using a bindingExcludeRules entry with ztp-done
     compliant: 5s
     noncompliant: 10s
 policies:

--- a/telco-ran/configuration/acmpolicygenerator/ran-group-du-sno-templated.yaml
+++ b/telco-ran/configuration/acmpolicygenerator/ran-group-du-sno-templated.yaml
@@ -5,6 +5,7 @@
 #   group-hardware-types-configmap.yaml: group-hardware-types-configmap
 #   group-zones-configmap.yaml:          group-zones-configmap
 #   site-data-configmap.yaml:            site-data-configmap
+---
 apiVersion: policy.open-cluster-management.io/v1
 kind: PolicyGenerator
 metadata:
@@ -12,8 +13,8 @@ metadata:
 placementBindingDefaults:
   name: group-du-sno-pb
 policyDefaults:
-  #categories: []
-  #controls:
+  # categories: []
+  # controls:
   #  - PR.DS-1 Data-at-rest
   namespace: ztp-group
   # Use an existing placement rule so that placement bindings can be consolidated.
@@ -62,12 +63,12 @@ policies:
     ## attempt to change the daemonsetNodeSelector will result in ptp daemon
     ## restart and time synchronization loss.
     ## After complying with the policy, complianceType can be set to a safer "musthave"
-#    - path: source-crs/ptp-operator/PtpOperatorConfigForEvent.yaml
-#      complianceType: "mustonlyhave"
-#      patches:
-#      - spec:
-#          daemonNodeSelector:
-#            node-role.kubernetes.io/worker: ""
+    #    - path: source-crs/ptp-operator/PtpOperatorConfigForEvent.yaml
+    #      complianceType: "mustonlyhave"
+    #      patches:
+    #      - spec:
+    #          daemonNodeSelector:
+    #            node-role.kubernetes.io/worker: ""
     - path: source-crs/ptp-operator/configuration/PtpConfigSlave.yaml
       patches:
         - metadata:
@@ -102,14 +103,14 @@ policies:
             volumeMode: Filesystem
             fsType: xfs
             devicePaths: '{{hub fromConfigMap "" "group-hardware-types-configmap" (printf "%s-storagelv-devicepaths-2" (index .ManagedClusterLabels "hardware-type")) | toLiteral hub}}'
-       ## This is required if PTP and BMER operators use HTTP transport.
-       ## The disk labels are created by ignitionConfigOverride in siteConfig.
-       ## - storageClassName: "storage-class-http-events"
-       ##   volumeMode: Filesystem
-       ##   fsType: xfs
-       ##   devicePaths:
-       ##   - /dev/disk/by-partlabel/httpevent1
-       ##   - /dev/disk/by-partlabel/httpevent2
+    ## This is required if PTP and BMER operators use HTTP transport.
+    ## The disk labels are created by ignitionConfigOverride in siteConfig.
+    ## - storageClassName: "storage-class-http-events"
+    ##   volumeMode: Filesystem
+    ##   fsType: xfs
+    ##   devicePaths:
+    ##   - /dev/disk/by-partlabel/httpevent1
+    ##   - /dev/disk/by-partlabel/httpevent2
     - path: source-crs/cluster-tuning/disabling-network-diagnostics/DisableSnoNetworkDiag.yaml
     # PerformanceProfile.yaml is architecture-specific.  Replace x86_64 with aarch64 for ARM deployments
     - path: source-crs/node-tuning-operator/x86_64/PerformanceProfile-SetSelector.yaml
@@ -137,7 +138,7 @@ policies:
             pools.operator.machineconfiguration.openshift.io/master: ""
           nodeSelector:
             node-role.kubernetes.io/master: ''
-    - path: source-crs/node-tuning-operator/TunedPerformancePatch.yaml # wave 10
+    - path: source-crs/node-tuning-operator/TunedPerformancePatch.yaml  # wave 10
       patches:
       - spec:
           recommend:
@@ -145,30 +146,30 @@ policies:
               machineconfiguration.openshift.io/role: "master"
             priority: 18
             profile: ran-du-performance
-#    - path: source-crs/storage-lso/StorageClass.yaml
-#      patches:
-#      - metadata:
-#          name: image-registry-sc # FIXED
-#    - path: source-crs/storage-lso/StoragePVC.yaml # wave 10
-#      patches:
-#      - metadata:
-#          name: image-registry-pvc # FIXED
-#          namespace: openshift-image-registry
-#        spec:
-#          accessModes:
-#            - ReadWriteMany
-#          resources:
-#            requests:
-#              storage: '{{hub fromConfigMap "" "group-zones-configmap" (printf "%s-storagepvc-storage" (index .ManagedClusterLabels "group-du-sno-zone")) hub}}'
-#          storageClassName: image-registry-sc # FIXED
-#          volumeMode: Filesystem # FIXED
-#    - path: source-crs/image-registry/ImageRegistryPV.yaml
-#    - path: source-crs/image-registry/ImageRegistryConfig.yaml
-#      patches:
-#      - spec:
-#          storage:
-#            pvc:
-#              claim: "image-registry-pvc" # FIXED
+    #    - path: source-crs/storage-lso/StorageClass.yaml
+    #      patches:
+    #      - metadata:
+    #          name: image-registry-sc # FIXED
+    #    - path: source-crs/storage-lso/StoragePVC.yaml # wave 10
+    #      patches:
+    #      - metadata:
+    #          name: image-registry-pvc # FIXED
+    #          namespace: openshift-image-registry
+    #        spec:
+    #          accessModes:
+    #            - ReadWriteMany
+    #          resources:
+    #            requests:
+    #              storage: '{{hub fromConfigMap "" "group-zones-configmap" (printf "%s-storagepvc-storage" (index .ManagedClusterLabels "group-du-sno-zone")) hub}}'
+    #          storageClassName: image-registry-sc # FIXED
+    #          volumeMode: Filesystem # FIXED
+    #    - path: source-crs/image-registry/ImageRegistryPV.yaml
+    #    - path: source-crs/image-registry/ImageRegistryConfig.yaml
+    #      patches:
+    #      - spec:
+    #          storage:
+    #            pvc:
+    #              claim: "image-registry-pvc" # FIXED
     - path: source-crs/sriov-fec-operator/SriovFecClusterConfig.yaml
       patches:
       - metadata:
@@ -189,19 +190,19 @@ policies:
   policyAnnotations:
     ran.openshift.io/ztp-deploy-wave: "10"
   manifests:
-    - path: source-crs/sriov-operator/SriovNetwork.yaml # wave 100
+    - path: source-crs/sriov-operator/SriovNetwork.yaml  # wave 100
       patches:
       - metadata:
-          name: sriov-nw-du-fh # FIXED
+          name: sriov-nw-du-fh  # FIXED
         spec:
-          resourceName: du_fh # FIXED
+          resourceName: du_fh  # FIXED
           vlan: '{{hub fromConfigMap "" "site-data-configmap" (printf "%s-sriov-network-vlan-1" .ManagedClusterName) | toInt hub}}'
-    - path: source-crs/sriov-operator/SriovNetworkNodePolicy-SetSelector.yaml # wave 100
+    - path: source-crs/sriov-operator/SriovNetworkNodePolicy-SetSelector.yaml  # wave 100
       patches:
       - metadata:
           name: sriov-nnp-du-fh
         spec:
-          deviceType: netdevice # FIXED
+          deviceType: netdevice  # FIXED
           isRdma: false
           nicSelector:
             pfNames: '{{hub fromConfigMap "" "group-hardware-types-configmap" (printf "%s-sriov-node-policy-pfNames-1" (index .ManagedClusterLabels "hardware-type")) | toLiteral hub}}'
@@ -210,19 +211,19 @@ policies:
           resourceName: du_fh
           nodeSelector:
             node-role.kubernetes.io/master: ""
-    - path: source-crs/sriov-operator/SriovNetwork.yaml # wave 100
+    - path: source-crs/sriov-operator/SriovNetwork.yaml  # wave 100
       patches:
       - metadata:
-          name: sriov-nw-du-mh # FIXED
+          name: sriov-nw-du-mh  # FIXED
         spec:
-          resourceName: du_mh # FIXED
+          resourceName: du_mh  # FIXED
           vlan: '{{hub fromConfigMap "" "site-data-configmap" (printf "%s-sriov-network-vlan-2" .ManagedClusterName) | toInt hub}}'
-    - path: source-crs/sriov-operator/SriovNetworkNodePolicy-SetSelector.yaml # wave 100
+    - path: source-crs/sriov-operator/SriovNetworkNodePolicy-SetSelector.yaml  # wave 100
       patches:
       - metadata:
           name: sriov-nw-du-fh
         spec:
-          deviceType: netdevice # FIXED
+          deviceType: netdevice  # FIXED
           isRdma: false
           nicSelector:
             pfNames: '{{hub fromConfigMap "" "group-hardware-types-configmap" (printf "%s-sriov-node-policy-pfNames-2" (index .ManagedClusterLabels "hardware-type")) | toLiteral hub}}'

--- a/telco-ran/configuration/acmpolicygenerator/ran-group-du-sno-validator.yaml
+++ b/telco-ran/configuration/acmpolicygenerator/ran-group-du-sno-validator.yaml
@@ -1,3 +1,4 @@
+---
 apiVersion: policy.open-cluster-management.io/v1
 kind: PolicyGenerator
 metadata:
@@ -6,7 +7,7 @@ placementBindingDefaults:
   name: group-du-sno-placement-binding
 policyDefaults:
   # categories: []
-  #controls:
+  # controls:
   #  - PR.DS-1 Data-at-rest
   namespace: ztp-group
   # Use an existing placement rule so that placement bindings can be consolidated
@@ -29,8 +30,8 @@ policyDefaults:
     include:
       - '*'
   evaluationInterval:
-   # This low setting is only valid if the validation policy is disconnected from the cluster at steady-state
-   # using a bindingExcludeRules entry with ztp-done
+    # This low setting is only valid if the validation policy is disconnected from the cluster at steady-state
+    # using a bindingExcludeRules entry with ztp-done
     compliant: 5s
     noncompliant: 10s
 policies:

--- a/telco-ran/configuration/acmpolicygenerator/ran-group-du-standard-templated.yaml
+++ b/telco-ran/configuration/acmpolicygenerator/ran-group-du-standard-templated.yaml
@@ -3,6 +3,7 @@
 #   hardware-type: hw-type-platform-1
 # ConfigMaps used:
 #   group-hardware-types-configmap.yaml: group-hardware-types-configmap
+---
 apiVersion: policy.open-cluster-management.io/v1
 kind: PolicyGenerator
 metadata:
@@ -10,8 +11,8 @@ metadata:
 placementBindingDefaults:
   name: group-du-standard-pb
 policyDefaults:
-  #categories: []
-  #controls:
+  # categories: []
+  # controls:
   #  - PR.DS-1 Data-at-rest
   namespace: ztp-group
   # Use an existing placement rule so that placement bindings can be consolidated

--- a/telco-ran/configuration/acmpolicygenerator/ran-group-du-standard-validator.yaml
+++ b/telco-ran/configuration/acmpolicygenerator/ran-group-du-standard-validator.yaml
@@ -1,3 +1,4 @@
+---
 apiVersion: policy.open-cluster-management.io/v1
 kind: PolicyGenerator
 metadata:
@@ -6,7 +7,7 @@ placementBindingDefaults:
   name: group-du-standard-placement-binding
 policyDefaults:
   # categories: []
-  #controls:
+  # controls:
   #  - PR.DS-1 Data-at-rest
   namespace: ztp-group
   # Use an existing placement rule so that placement bindings can be consolidated
@@ -29,8 +30,8 @@ policyDefaults:
     include:
       - '*'
   evaluationInterval:
-   # This low setting is only valid if the validation policy is disconnected from the cluster at steady-state
-   # using a bindingExcludeRules entry with ztp-done
+    # This low setting is only valid if the validation policy is disconnected from the cluster at steady-state
+    # using a bindingExcludeRules entry with ztp-done
     compliant: 5s
     noncompliant: 10s
 policies:

--- a/telco-ran/configuration/argocd/deployment/app-project.yaml
+++ b/telco-ran/configuration/argocd/deployment/app-project.yaml
@@ -1,3 +1,4 @@
+---
 apiVersion: argoproj.io/v1alpha1
 kind: AppProject
 metadata:

--- a/telco-ran/configuration/argocd/deployment/clusters-app.yaml
+++ b/telco-ran/configuration/argocd/deployment/clusters-app.yaml
@@ -1,3 +1,4 @@
+---
 apiVersion: v1
 kind: Namespace
 metadata:
@@ -22,18 +23,18 @@ spec:
     repoURL: https://github.com/openshift-kni/cnf-features-deploy
     targetRevision: master
     # uncomment the below plugin if you will be adding the plugin binaries in the same repo->dir where
-    # the sitconfig.yaml exist AND use the ../../hack/patch-argocd-dev.sh script to re-patch the deployment-repo-server
-#    plugin:
-#      name: kustomize-with-local-plugins
-  ignoreDifferences: # recommended way to allow ACM controller to manage its fields. alternative approach documented below (1)
+  # the sitconfig.yaml exist AND use the ../../hack/patch-argocd-dev.sh script to re-patch the deployment-repo-server
+  #    plugin:
+  #      name: kustomize-with-local-plugins
+  ignoreDifferences:  # recommended way to allow ACM controller to manage its fields. alternative approach documented below (1)
     - group: cluster.open-cluster-management.io
       kind: ManagedCluster
       managedFieldsManagers:
         - controller
-# (1) alternatively you can choose to ignore a specific path like so (replace managedFieldsManagers with jsonPointers)
-#      jsonPointers:
-#        - /metadata/labels/cloud
-#        - /metadata/labels/vendor
+  # (1) alternatively you can choose to ignore a specific path like so (replace managedFieldsManagers with jsonPointers)
+  #      jsonPointers:
+  #        - /metadata/labels/cloud
+  #        - /metadata/labels/vendor
   syncPolicy:
     automated:
       prune: true

--- a/telco-ran/configuration/argocd/deployment/openshift-gitops-operator.yaml
+++ b/telco-ran/configuration/argocd/deployment/openshift-gitops-operator.yaml
@@ -1,3 +1,4 @@
+---
 apiVersion: v1
 kind: Namespace
 metadata:

--- a/telco-ran/configuration/argocd/deployment/policies-app.yaml
+++ b/telco-ran/configuration/argocd/deployment/policies-app.yaml
@@ -1,3 +1,4 @@
+---
 apiVersion: v1
 kind: Namespace
 metadata:

--- a/telco-ran/configuration/argocd/example/optional-extra-manifest/ipsec/enable-ipsec.yaml
+++ b/telco-ran/configuration/argocd/example/optional-extra-manifest/ipsec/enable-ipsec.yaml
@@ -1,3 +1,4 @@
+---
 apiVersion: operator.openshift.io/v1
 kind: Network
 metadata:

--- a/telco-ran/configuration/argocd/example/optional-extra-manifest/ipsec/ipsec-config-policy.yaml
+++ b/telco-ran/configuration/argocd/example/optional-extra-manifest/ipsec/ipsec-config-policy.yaml
@@ -1,3 +1,4 @@
+---
 apiVersion: policy.open-cluster-management.io/v1
 kind: ConfigurationPolicy
 metadata:

--- a/telco-ran/configuration/argocd/example/optional-extra-manifest/ipsec/ipsec-endpoint-config.yml
+++ b/telco-ran/configuration/argocd/example/optional-extra-manifest/ipsec/ipsec-endpoint-config.yml
@@ -1,3 +1,4 @@
+---
 interfaces:
 - name: hosta_conn
   type: ipsec

--- a/telco-ran/configuration/policygentemplates/common-mno-ranGen.yaml
+++ b/telco-ran/configuration/policygentemplates/common-mno-ranGen.yaml
@@ -12,6 +12,6 @@ spec:
     common: "true"
     du-profile: "latest"
   sourceFiles:
-      # Create operators policies that will be installed in all clusters
+    # Create operators policies that will be installed in all clusters
     - fileName: cluster-tuning/operator-hub/OperatorHub.yaml
       policyName: "config-policy"

--- a/telco-ran/configuration/policygentemplates/example-reboot.yaml
+++ b/telco-ran/configuration/policygentemplates/example-reboot.yaml
@@ -19,9 +19,9 @@ spec:
           storage:
             files:
             - contents:
-              # content of file should change to trigger a reboot
-              # append a message for the reboot to the content of the file
-              # example: $ echo "$(date): applying tuned config" | base64
+                # content of file should change to trigger a reboot
+                # append a message for the reboot to the content of the file
+                # example: $ echo "$(date): applying tuned config" | base64
                 source: data:text/plain;charset=utf-8;base64,bWVzc2FnZQo=
               mode: 420
               path: "/etc/kubernetes/mcp-reboot-flag"

--- a/telco-ran/configuration/policygentemplates/group-du-3node-ranGen-templated.yaml
+++ b/telco-ran/configuration/policygentemplates/group-du-3node-ranGen-templated.yaml
@@ -33,11 +33,11 @@ spec:
           ptp4lOpts: "-2 -s --summary_interval -4"
           phc2sysOpts: "-a -r -n 24"
     ###
-    - fileName: sriov-operator/SriovOperatorConfig.yaml # wave 10
+    - fileName: sriov-operator/SriovOperatorConfig.yaml  # wave 10
       policyName: "group-du-3nc-cfg-pc"
     ###
     # PerformanceProfile.yaml is architecture-specific.  Replace x86_64 with aarch64 for ARM deployments
-    - fileName: node-tuning-operator/x86_64/PerformanceProfile.yaml # wave 10
+    - fileName: node-tuning-operator/x86_64/PerformanceProfile.yaml  # wave 10
       policyName: "group-du-3nc-cfg-pc"
       spec:
         cpu:
@@ -50,5 +50,5 @@ spec:
             - size: '{{hub fromConfigMap "" "group-hardware-types-configmap" (printf "%s-hugepages-size" (index .ManagedClusterLabels "hardware-type")) hub}}'
               count: '{{hub fromConfigMap "" "group-hardware-types-configmap" (printf "%s-hugepages-count" (index .ManagedClusterLabels "hardware-type")) | toInt hub}}'
     ###
-    - fileName: node-tuning-operator/TunedPerformancePatch.yaml # wave 10
+    - fileName: node-tuning-operator/TunedPerformancePatch.yaml  # wave 10
       policyName: "group-du-3nc-cfg-pc"

--- a/telco-ran/configuration/policygentemplates/group-du-3node-validator-ranGen.yaml
+++ b/telco-ran/configuration/policygentemplates/group-du-3node-validator-ranGen.yaml
@@ -1,3 +1,4 @@
+---
 apiVersion: ran.openshift.io/v1
 kind: PolicyGenTemplate
 metadata:

--- a/telco-ran/configuration/policygentemplates/group-du-sno-ranGen-templated.yaml
+++ b/telco-ran/configuration/policygentemplates/group-du-sno-ranGen-templated.yaml
@@ -22,7 +22,7 @@ spec:
     ##############################
     # gr-du-sno-cfg-pc-templated #
     ##############################
-    - fileName: cluster-logging/ClusterLogForwarder.yaml # wave 10
+    - fileName: cluster-logging/ClusterLogForwarder.yaml  # wave 10
       policyName: "gr-du-sno-cfg-pc-templated"
       spec:
         filters:
@@ -32,7 +32,7 @@ spec:
               # below url is an example
               url: '{{hub fromConfigMap "" "group-zones-configmap" (printf "%s-cluster-log-fwd-outputs-url" (index .ManagedClusterLabels "group-du-sno-zone")) | toLiteral hub}}'
     ###
-    - fileName: cluster-tuning/DisableOLMPprof.yaml # wave 10
+    - fileName: cluster-tuning/DisableOLMPprof.yaml  # wave 10
       policyName: "gr-du-sno-cfg-pc-templated"
       complianceType: mustnothave
     ###
@@ -48,7 +48,7 @@ spec:
           ptp4lOpts: "-2 -s --summary_interval -4"
           phc2sysOpts: "-a -r -n 24"
     ###
-    - fileName: sriov-operator/SriovOperatorConfig.yaml # wave 10
+    - fileName: sriov-operator/SriovOperatorConfig.yaml  # wave 10
       policyName: "gr-du-sno-cfg-pc-templated"
       # For existing clusters with node selector set as "master",
       # change the complianceType to "mustonlyhave".
@@ -59,7 +59,7 @@ spec:
         configDaemonNodeSelector:
           node-role.kubernetes.io/worker: ""
     ###
-    - fileName: storage/StorageLV.yaml # wave 10
+    - fileName: storage/StorageLV.yaml  # wave 10
       policyName: "gr-du-sno-cfg-pc-templated"
       spec:
         storageClassDevices:
@@ -72,11 +72,11 @@ spec:
           fsType: xfs
           devicePaths: '{{hub fromConfigMap "" "group-hardware-types-configmap" (printf "%s-storagelv-devicepaths-2" (index .ManagedClusterLabels "hardware-type")) | toLiteral hub}}'
     ###
-    - fileName: cluster-tuning/disabling-network-diagnostics/DisableSnoNetworkDiag.yaml # wave 10
+    - fileName: cluster-tuning/disabling-network-diagnostics/DisableSnoNetworkDiag.yaml  # wave 10
       policyName: "gr-du-sno-cfg-pc-templated"
     ###
     # PerformanceProfile.yaml is architecture-specific.  Replace x86_64 with aarch64 for ARM deployments
-    - fileName: node-tuning-operator/x86_64/PerformanceProfile.yaml # wave 10
+    - fileName: node-tuning-operator/x86_64/PerformanceProfile.yaml  # wave 10
       policyName: "gr-du-sno-cfg-pc-templated"
       metadata:
         name: openshift-node-performance-profile
@@ -97,27 +97,27 @@ spec:
         realTimeKernel:
           enabled: true
     ###
-    - fileName: node-tuning-operator/TunedPerformancePatch.yaml # wave 10
+    - fileName: node-tuning-operator/TunedPerformancePatch.yaml  # wave 10
       policyName: "gr-du-sno-cfg-pc-templated"
     ###
-#    # ---- START OF source CRs needed for image registry
-#    - fileName: storage-lso/StorageClass.yaml # wave 10
-#      policyName: "gr-du-sno-cfg-pc-templated"
-#      metadata:
-#        name: image-registry-sc # FIXED
-#    - fileName: storage-lso/StoragePVC.yaml # wave 10
-#      policyName: "gr-du-sno-cfg-pc-templated"
-#      metadata:
-#        name: image-registry-pvc # FIXED
-#        namespace: openshift-image-registry
-#      spec:
-#        accessModes:
-#          - ReadWriteMany
-#        resources:
-#          requests:
-#            storage: '{{hub fromConfigMap "" "group-zones-configmap" (printf "%s-storagepvc-storage" (index .ManagedClusterLabels "group-du-sno-zone")) hub}}'
-#        storageClassName: image-registry-sc # FIXED
-#        volumeMode: Filesystem # FIXED
+    #    # ---- START OF source CRs needed for image registry
+    #    - fileName: storage-lso/StorageClass.yaml # wave 10
+    #      policyName: "gr-du-sno-cfg-pc-templated"
+    #      metadata:
+    #        name: image-registry-sc # FIXED
+    #    - fileName: storage-lso/StoragePVC.yaml # wave 10
+    #      policyName: "gr-du-sno-cfg-pc-templated"
+    #      metadata:
+    #        name: image-registry-pvc # FIXED
+    #        namespace: openshift-image-registry
+    #      spec:
+    #        accessModes:
+    #          - ReadWriteMany
+    #        resources:
+    #          requests:
+    #            storage: '{{hub fromConfigMap "" "group-zones-configmap" (printf "%s-storagepvc-storage" (index .ManagedClusterLabels "group-du-sno-zone")) hub}}'
+    #        storageClassName: image-registry-sc # FIXED
+    #        volumeMode: Filesystem # FIXED
     - fileName: sriov-fec-operator/SriovFecClusterConfig.yaml
       policyName: gr-du-sno-cfg-pc-templated
       metadata:
@@ -130,40 +130,40 @@ spec:
           pfDriver: '{{hub fromConfigMap "" "group-hardware-types-configmap" (printf "%s-sriov-fec-pfDriver" (index .ManagedClusterLabels "hardware-type")) hub}}'
           vfDriver: '{{hub fromConfigMap "" "group-hardware-types-configmap" (printf "%s-sriov-fec-vfDriver" (index .ManagedClusterLabels "hardware-type")) hub}}'
           vfAmount: 16
-#    #############
-#    # pv-policy #
-#    #############
-#    # The following usage of image-registry/ImageRegistryPV.yaml is assuming that mount_point is set to `/var/imageregistry` in SiteConfig
-#    # using StorageClass `image-registry-sc` (see the first sc-file)
-#    - fileName: image-registry/ImageRegistryPV.yaml  # wave 2
-#      policyName: "pv-policy"
-#    #############
-#    # irc-policy #
-#    #############
-#    - fileName: image-registry/ImageRegistryConfig.yaml # wave 11
-#      policyName: "irc-policy"
-#      spec:
-#        storage:
-#          pvc:
-#            claim: "image-registry-pvc" # FIXED
-#    # ---- END OF source CRs needed for image registry (check ImageRegistry.md for more details) ----
+    #    #############
+    #    # pv-policy #
+    #    #############
+    #    # The following usage of image-registry/ImageRegistryPV.yaml is assuming that mount_point is set to `/var/imageregistry` in SiteConfig
+    #    # using StorageClass `image-registry-sc` (see the first sc-file)
+    #    - fileName: image-registry/ImageRegistryPV.yaml  # wave 2
+    #      policyName: "pv-policy"
+    #    #############
+    #    # irc-policy #
+    #    #############
+    #    - fileName: image-registry/ImageRegistryConfig.yaml # wave 11
+    #      policyName: "irc-policy"
+    #      spec:
+    #        storage:
+    #          pvc:
+    #            claim: "image-registry-pvc" # FIXED
+    #    # ---- END OF source CRs needed for image registry (check ImageRegistry.md for more details) ----
     ################################
     # gr-du-sno-sriov-pc-templated #
     ################################
-    - fileName: sriov-operator/SriovNetwork.yaml # wave 100
+    - fileName: sriov-operator/SriovNetwork.yaml  # wave 100
       policyName: "gr-du-sno-sriov-pc-templated"
       metadata:
-        name: sriov-nw-du-fh # FIXED
+        name: sriov-nw-du-fh  # FIXED
       spec:
-        resourceName: du_fh # FIXED
+        resourceName: du_fh  # FIXED
         vlan: '{{hub fromConfigMap "" "site-data-configmap" (printf "%s-sriov-network-vlan-1" .ManagedClusterName) | toInt hub}}'
     ###
-    - fileName: sriov-operator/SriovNetworkNodePolicy.yaml # wave 100
+    - fileName: sriov-operator/SriovNetworkNodePolicy.yaml  # wave 100
       policyName: "gr-du-sno-sriov-pc-templated"
       metadata:
         name: sriov-nnp-du-fh
       spec:
-        deviceType: netdevice # FIXED
+        deviceType: netdevice  # FIXED
         isRdma: false
         nicSelector:
           pfNames: '{{hub fromConfigMap "" "group-hardware-types-configmap" (printf "%s-sriov-node-policy-pfNames-1" (index .ManagedClusterLabels "hardware-type")) | toLiteral hub}}'
@@ -171,20 +171,20 @@ spec:
         priority: 10
         resourceName: du_fh
     ###
-    - fileName: sriov-operator/SriovNetwork.yaml # wave 100
+    - fileName: sriov-operator/SriovNetwork.yaml  # wave 100
       policyName: "gr-du-sno-sriov-pc-templated"
       metadata:
-        name: sriov-nw-du-mh # FIXED
+        name: sriov-nw-du-mh  # FIXED
       spec:
-        resourceName: du_mh # FIXED
+        resourceName: du_mh  # FIXED
         vlan: '{{hub fromConfigMap "" "site-data-configmap" (printf "%s-sriov-network-vlan-2" .ManagedClusterName) | toInt hub}}'
     ###
-    - fileName: sriov-operator/SriovNetworkNodePolicy.yaml # wave 100
+    - fileName: sriov-operator/SriovNetworkNodePolicy.yaml  # wave 100
       policyName: "gr-du-sno-sriov-pc-templated"
       metadata:
         name: sriov-nw-du-fh
       spec:
-        deviceType: netdevice # FIXED
+        deviceType: netdevice  # FIXED
         isRdma: false
         nicSelector:
           pfNames: '{{hub fromConfigMap "" "group-hardware-types-configmap" (printf "%s-sriov-node-policy-pfNames-2" (index .ManagedClusterLabels "hardware-type")) | toLiteral hub}}'

--- a/telco-ran/configuration/policygentemplates/group-du-sno-validator-ranGen.yaml
+++ b/telco-ran/configuration/policygentemplates/group-du-sno-validator-ranGen.yaml
@@ -1,3 +1,4 @@
+---
 apiVersion: ran.openshift.io/v1
 kind: PolicyGenTemplate
 metadata:

--- a/telco-ran/configuration/policygentemplates/group-du-standard-ranGen-templated.yaml
+++ b/telco-ran/configuration/policygentemplates/group-du-standard-ranGen-templated.yaml
@@ -33,11 +33,11 @@ spec:
           ptp4lOpts: "-2 -s --summary_interval -4"
           phc2sysOpts: "-a -r -n 24"
     ###
-    - fileName: sriov-operator/SriovOperatorConfig.yaml # wave 10
+    - fileName: sriov-operator/SriovOperatorConfig.yaml  # wave 10
       policyName: "group-du-standard-cfg-pc"
     ###
     # PerformanceProfile.yaml is architecture-specific.  Replace x86_64 with aarch64 for ARM deployments
-    - fileName: node-tuning-operator/x86_64/PerformanceProfile.yaml # wave 10
+    - fileName: node-tuning-operator/x86_64/PerformanceProfile.yaml  # wave 10
       policyName: "group-du-standard-cfg-pc"
       spec:
         cpu:
@@ -50,5 +50,5 @@ spec:
             - size: '{{hub fromConfigMap "" "group-hardware-types-configmap" (printf "%s-hugepages-size" (index .ManagedClusterLabels "hardware-type")) hub}}'
               count: '{{hub fromConfigMap "" "group-hardware-types-configmap" (printf "%s-hugepages-count" (index .ManagedClusterLabels "hardware-type")) | toInt hub}}'
     ###
-    - fileName: node-tuning-operator/TunedPerformancePatch.yaml # wave 10
+    - fileName: node-tuning-operator/TunedPerformancePatch.yaml  # wave 10
       policyName: "group-du-standard-cfg-pc"

--- a/telco-ran/configuration/policygentemplates/group-du-standard-validator-ranGen.yaml
+++ b/telco-ran/configuration/policygentemplates/group-du-standard-validator-ranGen.yaml
@@ -1,3 +1,4 @@
+---
 apiVersion: ran.openshift.io/v1
 kind: PolicyGenTemplate
 metadata:

--- a/telco-ran/configuration/policygentemplates/kustomization.yaml
+++ b/telco-ran/configuration/policygentemplates/kustomization.yaml
@@ -2,6 +2,7 @@
 # in ../acmpolicygenerator/ instead. These PGT examples are provided for
 # reference only and will be removed in a future release.
 
+---
 generators:
 # Common policies for all RAN deployments
 - common-ranGen.yaml

--- a/telco-ran/configuration/policygentemplates/ns.yaml
+++ b/telco-ran/configuration/policygentemplates/ns.yaml
@@ -1,3 +1,4 @@
+---
 apiVersion: v1
 kind: Namespace
 metadata:

--- a/telco-ran/configuration/source-crs/cert-manager/apiServerCertificate.yaml
+++ b/telco-ran/configuration/source-crs/cert-manager/apiServerCertificate.yaml
@@ -1,3 +1,4 @@
+---
 apiVersion: cert-manager.io/v1
 kind: Certificate
 metadata:

--- a/telco-ran/configuration/source-crs/cert-manager/apiServerConfig.yaml
+++ b/telco-ran/configuration/source-crs/cert-manager/apiServerConfig.yaml
@@ -1,3 +1,4 @@
+---
 apiVersion: config.openshift.io/v1
 kind: APIServer
 metadata:

--- a/telco-ran/configuration/source-crs/cert-manager/certManagerClusterIssuer.yaml
+++ b/telco-ran/configuration/source-crs/cert-manager/certManagerClusterIssuer.yaml
@@ -1,3 +1,4 @@
+---
 apiVersion: cert-manager.io/v1
 kind: ClusterIssuer
 metadata:

--- a/telco-ran/configuration/source-crs/cert-manager/certManagerNS.yaml
+++ b/telco-ran/configuration/source-crs/cert-manager/certManagerNS.yaml
@@ -1,3 +1,4 @@
+---
 apiVersion: v1
 kind: Namespace
 metadata:

--- a/telco-ran/configuration/source-crs/cert-manager/certManagerOperatorStatus.yaml
+++ b/telco-ran/configuration/source-crs/cert-manager/certManagerOperatorStatus.yaml
@@ -1,4 +1,5 @@
 # This CR verifies the installation/upgrade of the cert-manager Operator
+---
 apiVersion: operators.coreos.com/v1
 kind: Operator
 metadata:

--- a/telco-ran/configuration/source-crs/cert-manager/certManagerOperatorgroup.yaml
+++ b/telco-ran/configuration/source-crs/cert-manager/certManagerOperatorgroup.yaml
@@ -1,3 +1,4 @@
+---
 apiVersion: operators.coreos.com/v1
 kind: OperatorGroup
 metadata:

--- a/telco-ran/configuration/source-crs/cert-manager/certManagerSubscription.yaml
+++ b/telco-ran/configuration/source-crs/cert-manager/certManagerSubscription.yaml
@@ -1,3 +1,4 @@
+---
 apiVersion: operators.coreos.com/v1alpha1
 kind: Subscription
 metadata:

--- a/telco-ran/configuration/source-crs/cert-manager/ingressCertificate.yaml
+++ b/telco-ran/configuration/source-crs/cert-manager/ingressCertificate.yaml
@@ -1,3 +1,4 @@
+---
 apiVersion: cert-manager.io/v1
 kind: Certificate
 metadata:

--- a/telco-ran/configuration/source-crs/cert-manager/ingressControllerConfig.yaml
+++ b/telco-ran/configuration/source-crs/cert-manager/ingressControllerConfig.yaml
@@ -1,3 +1,4 @@
+---
 apiVersion: operator.openshift.io/v1
 kind: IngressController
 metadata:

--- a/telco-ran/configuration/source-crs/cluster-logging/ClusterLogForwarder.yaml
+++ b/telco-ran/configuration/source-crs/cluster-logging/ClusterLogForwarder.yaml
@@ -1,3 +1,4 @@
+---
 apiVersion: observability.openshift.io/v1
 kind: ClusterLogForwarder
 metadata:
@@ -31,9 +32,9 @@ status:
   - type: observability.openshift.io/Valid
     status: "True"
 
-#apiVersion: observability.openshift.io/v1
-#kind: ClusterLogForwarder
-#metadata:
+# apiVersion: observability.openshift.io/v1
+# kind: ClusterLogForwarder
+# metadata:
 #  name: instance
 #  namespace: openshift-logging
 # spec:

--- a/telco-ran/configuration/source-crs/cluster-logging/ClusterLogNS.yaml
+++ b/telco-ran/configuration/source-crs/cluster-logging/ClusterLogNS.yaml
@@ -1,3 +1,4 @@
+---
 apiVersion: v1
 kind: Namespace
 metadata:

--- a/telco-ran/configuration/source-crs/cluster-logging/ClusterLogOperGroup.yaml
+++ b/telco-ran/configuration/source-crs/cluster-logging/ClusterLogOperGroup.yaml
@@ -1,3 +1,4 @@
+---
 apiVersion: operators.coreos.com/v1
 kind: OperatorGroup
 metadata:

--- a/telco-ran/configuration/source-crs/cluster-logging/ClusterLogOperatorStatus.yaml
+++ b/telco-ran/configuration/source-crs/cluster-logging/ClusterLogOperatorStatus.yaml
@@ -1,4 +1,5 @@
 # This CR verifies the installation/upgrade of the Cluster Logging Operator
+---
 apiVersion: operators.coreos.com/v1
 kind: Operator
 metadata:

--- a/telco-ran/configuration/source-crs/cluster-logging/ClusterLogSubscription.yaml
+++ b/telco-ran/configuration/source-crs/cluster-logging/ClusterLogSubscription.yaml
@@ -1,3 +1,4 @@
+---
 apiVersion: operators.coreos.com/v1alpha1
 kind: Subscription
 metadata:

--- a/telco-ran/configuration/source-crs/cluster-tuning/DisableOLMPprof.yaml
+++ b/telco-ran/configuration/source-crs/cluster-tuning/DisableOLMPprof.yaml
@@ -1,3 +1,4 @@
+---
 apiVersion: v1
 kind: ConfigMap
 metadata:

--- a/telco-ran/configuration/source-crs/cluster-tuning/console-disable/ConsoleOperatorDisable.yaml
+++ b/telco-ran/configuration/source-crs/cluster-tuning/console-disable/ConsoleOperatorDisable.yaml
@@ -1,3 +1,4 @@
+---
 apiVersion: operator.openshift.io/v1
 kind: Console
 metadata:

--- a/telco-ran/configuration/source-crs/cluster-tuning/disabling-network-diagnostics/DisableSnoNetworkDiag.yaml
+++ b/telco-ran/configuration/source-crs/cluster-tuning/disabling-network-diagnostics/DisableSnoNetworkDiag.yaml
@@ -1,3 +1,4 @@
+---
 apiVersion: operator.openshift.io/v1
 kind: Network
 metadata:

--- a/telco-ran/configuration/source-crs/cluster-tuning/operator-hub/OperatorHub.yaml
+++ b/telco-ran/configuration/source-crs/cluster-tuning/operator-hub/OperatorHub.yaml
@@ -1,3 +1,4 @@
+---
 apiVersion: config.openshift.io/v1
 kind: OperatorHub
 metadata:

--- a/telco-ran/configuration/source-crs/data-protection/OadpBackupStorageLocationStatus.yaml
+++ b/telco-ran/configuration/source-crs/data-protection/OadpBackupStorageLocationStatus.yaml
@@ -1,4 +1,5 @@
 # This CR verifies the availability of backup storage locations created by OADP
+---
 apiVersion: velero.io/v1
 kind: BackupStorageLocation
 metadata:

--- a/telco-ran/configuration/source-crs/data-protection/OadpDataProtectionApplication.yaml
+++ b/telco-ran/configuration/source-crs/data-protection/OadpDataProtectionApplication.yaml
@@ -1,5 +1,6 @@
 # The configuration CR for OADP operator
 # More information can be found in https://docs.openshift.com/container-platform/4.15/backup_and_restore/application_backup_and_restore/installing/installing-oadp-aws.html
+---
 apiVersion: oadp.openshift.io/v1alpha1
 kind: DataProtectionApplication
 metadata:

--- a/telco-ran/configuration/source-crs/data-protection/OadpOperatorStatus.yaml
+++ b/telco-ran/configuration/source-crs/data-protection/OadpOperatorStatus.yaml
@@ -1,4 +1,5 @@
 # This CR verifies the installation/upgrade of the OADP operator
+---
 apiVersion: operators.coreos.com/v1
 kind: Operator
 metadata:

--- a/telco-ran/configuration/source-crs/data-protection/OadpSecret.yaml
+++ b/telco-ran/configuration/source-crs/data-protection/OadpSecret.yaml
@@ -1,5 +1,6 @@
 # The OADP secret for the s3 storage connection
 # should be referenced in the data-protection/OadpDataProtectionApplication.yaml
+---
 apiVersion: v1
 kind: Secret
 metadata:

--- a/telco-ran/configuration/source-crs/data-protection/OadpSubscription.yaml
+++ b/telco-ran/configuration/source-crs/data-protection/OadpSubscription.yaml
@@ -1,3 +1,4 @@
+---
 apiVersion: operators.coreos.com/v1alpha1
 kind: Subscription
 metadata:

--- a/telco-ran/configuration/source-crs/data-protection/OadpSubscriptionNS.yaml
+++ b/telco-ran/configuration/source-crs/data-protection/OadpSubscriptionNS.yaml
@@ -1,6 +1,7 @@
 # OADP is not intended to be deployed on reserved cores for platform.
 # It is solely used for backing up and restoring application during Image Based Upgrade(IBU).
 # It can be removed after IBU is completed.
+---
 apiVersion: v1
 kind: Namespace
 metadata:

--- a/telco-ran/configuration/source-crs/data-protection/OadpSubscriptionOperGroup.yaml
+++ b/telco-ran/configuration/source-crs/data-protection/OadpSubscriptionOperGroup.yaml
@@ -1,3 +1,4 @@
+---
 apiVersion: operators.coreos.com/v1
 kind: OperatorGroup
 metadata:

--- a/telco-ran/configuration/source-crs/deprecated/AmqOperatorStatus.yaml
+++ b/telco-ran/configuration/source-crs/deprecated/AmqOperatorStatus.yaml
@@ -1,4 +1,5 @@
 # This CR verifies the installation/upgrade of the Amq Operator
+---
 apiVersion: operators.coreos.com/v1
 kind: Operator
 metadata:

--- a/telco-ran/configuration/source-crs/deprecated/AmqSubscriptionOperGroup.yaml
+++ b/telco-ran/configuration/source-crs/deprecated/AmqSubscriptionOperGroup.yaml
@@ -1,3 +1,4 @@
+---
 apiVersion: operators.coreos.com/v1
 kind: OperatorGroup
 metadata:

--- a/telco-ran/configuration/source-crs/deprecated/ClusterLogCatSource.yaml
+++ b/telco-ran/configuration/source-crs/deprecated/ClusterLogCatSource.yaml
@@ -1,3 +1,4 @@
+---
 apiVersion: operators.coreos.com/v1alpha1
 kind: CatalogSource
 metadata:

--- a/telco-ran/configuration/source-crs/deprecated/PaoOperatorStatus.yaml
+++ b/telco-ran/configuration/source-crs/deprecated/PaoOperatorStatus.yaml
@@ -1,4 +1,5 @@
 # This CR verifies the installation/upgrade of the Performance Addon Operator
+---
 apiVersion: operators.coreos.com/v1
 kind: Operator
 metadata:

--- a/telco-ran/configuration/source-crs/deprecated/PaoSubscription.yaml
+++ b/telco-ran/configuration/source-crs/deprecated/PaoSubscription.yaml
@@ -1,3 +1,4 @@
+---
 apiVersion: operators.coreos.com/v1alpha1
 kind: Subscription
 metadata:

--- a/telco-ran/configuration/source-crs/deprecated/PaoSubscriptionCatalogSource.yaml
+++ b/telco-ran/configuration/source-crs/deprecated/PaoSubscriptionCatalogSource.yaml
@@ -1,3 +1,4 @@
+---
 apiVersion: operators.coreos.com/v1alpha1
 kind: CatalogSource
 metadata:
@@ -12,7 +13,7 @@ spec:
   icon:
     base64data: ""
     mediatype: ""
-  #image: quay.io/openshift-kni/performance-addon-operator-index:4.9-snapshot
+  # image: quay.io/openshift-kni/performance-addon-operator-index:4.9-snapshot
   image: $imageUrl
   publisher: Red Hat
   sourceType: grpc

--- a/telco-ran/configuration/source-crs/deprecated/PaoSubscriptionNS.yaml
+++ b/telco-ran/configuration/source-crs/deprecated/PaoSubscriptionNS.yaml
@@ -1,3 +1,4 @@
+---
 apiVersion: v1
 kind: Namespace
 metadata:

--- a/telco-ran/configuration/source-crs/deprecated/PaoSubscriptionOperGroup.yaml
+++ b/telco-ran/configuration/source-crs/deprecated/PaoSubscriptionOperGroup.yaml
@@ -1,3 +1,4 @@
+---
 apiVersion: operators.coreos.com/v1
 kind: OperatorGroup
 metadata:

--- a/telco-ran/configuration/source-crs/deprecated/PtpCatSource.yaml
+++ b/telco-ran/configuration/source-crs/deprecated/PtpCatSource.yaml
@@ -1,3 +1,4 @@
+---
 apiVersion: operators.coreos.com/v1alpha1
 kind: CatalogSource
 metadata:

--- a/telco-ran/configuration/source-crs/deprecated/PtpConfigSlaveCvl.yaml
+++ b/telco-ran/configuration/source-crs/deprecated/PtpConfigSlaveCvl.yaml
@@ -1,4 +1,5 @@
 # This configuration is tailored to ColumbiaVille NIC
+---
 apiVersion: ptp.openshift.io/v1
 kind: PtpConfig
 metadata:

--- a/telco-ran/configuration/source-crs/deprecated/SriovCatSource.yaml
+++ b/telco-ran/configuration/source-crs/deprecated/SriovCatSource.yaml
@@ -1,3 +1,4 @@
+---
 apiVersion: operators.coreos.com/v1alpha1
 kind: CatalogSource
 metadata:

--- a/telco-ran/configuration/source-crs/deprecated/StorageCatSource.yaml
+++ b/telco-ran/configuration/source-crs/deprecated/StorageCatSource.yaml
@@ -1,3 +1,4 @@
+---
 apiVersion: operators.coreos.com/v1alpha1
 kind: CatalogSource
 metadata:

--- a/telco-ran/configuration/source-crs/disconnected-registry/DefaultCatsrc.yaml
+++ b/telco-ran/configuration/source-crs/disconnected-registry/DefaultCatsrc.yaml
@@ -1,3 +1,4 @@
+---
 apiVersion: operators.coreos.com/v1alpha1
 kind: CatalogSource
 metadata:

--- a/telco-ran/configuration/source-crs/disconnected-registry/DisconnectedIDMS.yaml
+++ b/telco-ran/configuration/source-crs/disconnected-registry/DisconnectedIDMS.yaml
@@ -1,9 +1,10 @@
+---
 apiVersion: config.openshift.io/v1
 kind: ImageDigestMirrorSet
 metadata:
   name: fec-disconnected-idms
   annotations:
     ran.openshift.io/ztp-deploy-wave: "1"
+# imageDigestMirrors:
+# - $mirrors
 spec:
-  # imageDigestMirrors:
-  # - $mirrors

--- a/telco-ran/configuration/source-crs/generic/ConfigMapGeneric.yaml
+++ b/telco-ran/configuration/source-crs/generic/ConfigMapGeneric.yaml
@@ -1,3 +1,4 @@
+---
 apiVersion: v1
 kind: ConfigMap
 metadata:

--- a/telco-ran/configuration/source-crs/generic/MachineConfigGeneric.yaml
+++ b/telco-ran/configuration/source-crs/generic/MachineConfigGeneric.yaml
@@ -1,3 +1,4 @@
+---
 apiVersion: machineconfiguration.openshift.io/v1
 kind: MachineConfig
 metadata:
@@ -8,6 +9,6 @@ spec:
   config:
     ignition:
       version: 3.2.0
-    #storage:
-    #  files:
-    #    - contents: ""
+      # storage:
+      #  files:
+      #    - contents: ""

--- a/telco-ran/configuration/source-crs/ibu/ClusterVersion.yaml
+++ b/telco-ran/configuration/source-crs/ibu/ClusterVersion.yaml
@@ -1,3 +1,4 @@
+---
 apiVersion: config.openshift.io/v1
 kind: ClusterVersion
 metadata:
@@ -6,13 +7,13 @@ metadata:
     ran.openshift.io/ztp-deploy-wave: "100"
 spec:
   channel: stable-4.10
-  upstream: https://api.openshift.com/api/upgrades_info/v1/graph # default upstream.
+  upstream: https://api.openshift.com/api/upgrades_info/v1/graph  # default upstream.
 
 # add these changes using PGT overlay to generate the policy to perform and verify platform upgrade.
 #  desiredUpdate:
 #    force: false
 #    version: $version
-#status:
+# status:
 #  history:
 #    -  version: $version
 #       state: "Completed"

--- a/telco-ran/configuration/source-crs/ibu/ImageBasedUpgrade.yaml
+++ b/telco-ran/configuration/source-crs/ibu/ImageBasedUpgrade.yaml
@@ -1,3 +1,4 @@
+---
 apiVersion: lca.openshift.io/v1
 kind: ImageBasedUpgrade
 metadata:

--- a/telco-ran/configuration/source-crs/ibu/ImageBasedUpgradeStatus.yaml
+++ b/telco-ran/configuration/source-crs/ibu/ImageBasedUpgradeStatus.yaml
@@ -1,3 +1,4 @@
+---
 apiVersion: lca.openshift.io/v1
 kind: ImageBasedUpgrade
 metadata:

--- a/telco-ran/configuration/source-crs/ibu/ImageSignature.yaml
+++ b/telco-ran/configuration/source-crs/ibu/ImageSignature.yaml
@@ -1,3 +1,4 @@
+---
 apiVersion: v1
 kind: ConfigMap
 metadata:

--- a/telco-ran/configuration/source-crs/ibu/PlatformBackupRestore.yaml
+++ b/telco-ran/configuration/source-crs/ibu/PlatformBackupRestore.yaml
@@ -1,3 +1,4 @@
+---
 apiVersion: velero.io/v1
 kind: Backup
 metadata:

--- a/telco-ran/configuration/source-crs/ibu/PlatformBackupRestoreWithIBGU.yaml
+++ b/telco-ran/configuration/source-crs/ibu/PlatformBackupRestoreWithIBGU.yaml
@@ -1,3 +1,4 @@
+---
 apiVersion: velero.io/v1
 kind: Backup
 metadata:

--- a/telco-ran/configuration/source-crs/image-registry/ImageRegistryConfig.yaml
+++ b/telco-ran/configuration/source-crs/image-registry/ImageRegistryConfig.yaml
@@ -1,3 +1,4 @@
+---
 apiVersion: imageregistry.operator.openshift.io/v1
 kind: Config
 metadata:
@@ -13,8 +14,8 @@ spec:
   observedConfig:
     {}
   # These fields can be set by the user as desired
-  #operatorLogLevel: Normal
-  #proxy: {}
+  # operatorLogLevel: Normal
+  # proxy: {}
   replicas: 1
   requests:
     read:

--- a/telco-ran/configuration/source-crs/image-registry/ImageRegistryPV.yaml
+++ b/telco-ran/configuration/source-crs/image-registry/ImageRegistryPV.yaml
@@ -1,3 +1,4 @@
+---
 apiVersion: v1
 kind: PersistentVolume
 metadata:

--- a/telco-ran/configuration/source-crs/lca/LcaOperatorStatus.yaml
+++ b/telco-ran/configuration/source-crs/lca/LcaOperatorStatus.yaml
@@ -1,4 +1,5 @@
 # This CR verifies the installation/upgrade of the Lifecycle Agent Operator
+---
 apiVersion: operators.coreos.com/v1
 kind: Operator
 metadata:

--- a/telco-ran/configuration/source-crs/lca/LcaSubscription.yaml
+++ b/telco-ran/configuration/source-crs/lca/LcaSubscription.yaml
@@ -1,3 +1,4 @@
+---
 apiVersion: operators.coreos.com/v1alpha1
 kind: Subscription
 metadata:

--- a/telco-ran/configuration/source-crs/lca/LcaSubscriptionNS.yaml
+++ b/telco-ran/configuration/source-crs/lca/LcaSubscriptionNS.yaml
@@ -1,3 +1,4 @@
+---
 apiVersion: v1
 kind: Namespace
 metadata:

--- a/telco-ran/configuration/source-crs/lca/LcaSubscriptionOperGroup.yaml
+++ b/telco-ran/configuration/source-crs/lca/LcaSubscriptionOperGroup.yaml
@@ -1,3 +1,4 @@
+---
 apiVersion: operators.coreos.com/v1
 kind: OperatorGroup
 metadata:

--- a/telco-ran/configuration/source-crs/machine-config/RebootMachineConfig.yaml
+++ b/telco-ran/configuration/source-crs/machine-config/RebootMachineConfig.yaml
@@ -1,3 +1,4 @@
+---
 apiVersion: machineconfiguration.openshift.io/v1
 kind: MachineConfig
 metadata:

--- a/telco-ran/configuration/source-crs/nmstate/NMState.yaml
+++ b/telco-ran/configuration/source-crs/nmstate/NMState.yaml
@@ -1,3 +1,4 @@
+---
 apiVersion: nmstate.io/v1
 kind: NMState
 metadata:

--- a/telco-ran/configuration/source-crs/nmstate/NMStateOperatorStatus.yaml
+++ b/telco-ran/configuration/source-crs/nmstate/NMStateOperatorStatus.yaml
@@ -1,4 +1,5 @@
 # This CR verifies the installation/upgrade of the Lifecycle Agent Operator
+---
 apiVersion: operators.coreos.com/v1
 kind: Operator
 metadata:

--- a/telco-ran/configuration/source-crs/nmstate/NMStateSubscription.yaml
+++ b/telco-ran/configuration/source-crs/nmstate/NMStateSubscription.yaml
@@ -1,3 +1,4 @@
+---
 apiVersion: operators.coreos.com/v1alpha1
 kind: Subscription
 metadata:

--- a/telco-ran/configuration/source-crs/nmstate/NMStateSubscriptionNS.yaml
+++ b/telco-ran/configuration/source-crs/nmstate/NMStateSubscriptionNS.yaml
@@ -1,3 +1,4 @@
+---
 apiVersion: v1
 kind: Namespace
 metadata:

--- a/telco-ran/configuration/source-crs/nmstate/NMStateSubscriptionOperGroup.yaml
+++ b/telco-ran/configuration/source-crs/nmstate/NMStateSubscriptionOperGroup.yaml
@@ -1,3 +1,4 @@
+---
 apiVersion: operators.coreos.com/v1
 kind: OperatorGroup
 metadata:

--- a/telco-ran/configuration/source-crs/node-tuning-operator/TunedPerformancePatch.yaml
+++ b/telco-ran/configuration/source-crs/node-tuning-operator/TunedPerformancePatch.yaml
@@ -1,3 +1,4 @@
+---
 apiVersion: tuned.openshift.io/v1
 kind: Tuned
 metadata:

--- a/telco-ran/configuration/source-crs/node-tuning-operator/TunedPowerCustom.yaml
+++ b/telco-ran/configuration/source-crs/node-tuning-operator/TunedPowerCustom.yaml
@@ -1,3 +1,4 @@
+---
 apiVersion: tuned.openshift.io/v1
 kind: Tuned
 metadata:

--- a/telco-ran/configuration/source-crs/node-tuning-operator/aarch64/PerformanceProfile-SetSelector.yaml
+++ b/telco-ran/configuration/source-crs/node-tuning-operator/aarch64/PerformanceProfile-SetSelector.yaml
@@ -1,3 +1,4 @@
+---
 apiVersion: performance.openshift.io/v2
 kind: PerformanceProfile
 metadata:
@@ -28,7 +29,7 @@ spec:
   #  isolated: 4-$lastcpu
   #  reserved: 0-3
   # hardwareTuning allows maximum CPU frequencies to be set for reserved and isolated CPUs
-  #hardwareTuning:
+  # hardwareTuning:
   #  isolatedCpuFreq: <max frequency in kHz>
   #  reservedCpuFreq: <max frequency in kHz>
   hugepages:
@@ -57,11 +58,11 @@ spec:
     realTime: true
     highPowerConsumption: false
     perPodPowerManagement: false
-  # Optional: userLevelNetworking reduces NIC queues to the reserved CPU count.
-  # Enabling on a running cluster causes node drain and reboot.
-  # Validate NIC driver compatibility before enabling; silent failures are possible.
-  # When devices is omitted, applies to all network interfaces.
-  #net:
-  #  userLevelNetworking: true
-  #  devices:
-  #  - interfaceName: "eth0"
+    # Optional: userLevelNetworking reduces NIC queues to the reserved CPU count.
+    # Enabling on a running cluster causes node drain and reboot.
+    # Validate NIC driver compatibility before enabling; silent failures are possible.
+    # When devices is omitted, applies to all network interfaces.
+    # net:
+    #  userLevelNetworking: true
+    #  devices:
+    #  - interfaceName: "eth0"

--- a/telco-ran/configuration/source-crs/node-tuning-operator/aarch64/PerformanceProfile.yaml
+++ b/telco-ran/configuration/source-crs/node-tuning-operator/aarch64/PerformanceProfile.yaml
@@ -1,3 +1,4 @@
+---
 apiVersion: performance.openshift.io/v2
 kind: PerformanceProfile
 metadata:
@@ -28,7 +29,7 @@ spec:
     isolated: 4-$lastcpu
     reserved: 0-3
   # hardwareTuning allows maximum CPU frequencies to be set for reserved and isolated CPUs
-  #hardwareTuning:
+  # hardwareTuning:
   #  isolatedCpuFreq: <max frequency in kHz>
   #  reservedCpuFreq: <max frequency in kHz>
   hugepages:
@@ -57,11 +58,11 @@ spec:
     realTime: true
     highPowerConsumption: false
     perPodPowerManagement: false
-  # Optional: userLevelNetworking reduces NIC queues to the reserved CPU count.
-  # Enabling on a running cluster causes node drain and reboot.
-  # Validate NIC driver compatibility before enabling; silent failures are possible.
-  # When devices is omitted, applies to all network interfaces.
-  #net:
-  #  userLevelNetworking: true
-  #  devices:
-  #  - interfaceName: "eth0"
+    # Optional: userLevelNetworking reduces NIC queues to the reserved CPU count.
+    # Enabling on a running cluster causes node drain and reboot.
+    # Validate NIC driver compatibility before enabling; silent failures are possible.
+    # When devices is omitted, applies to all network interfaces.
+    # net:
+    #  userLevelNetworking: true
+    #  devices:
+    #  - interfaceName: "eth0"

--- a/telco-ran/configuration/source-crs/node-tuning-operator/x86_64/PerformanceProfile-SetSelector.yaml
+++ b/telco-ran/configuration/source-crs/node-tuning-operator/x86_64/PerformanceProfile-SetSelector.yaml
@@ -1,3 +1,4 @@
+---
 apiVersion: performance.openshift.io/v2
 kind: PerformanceProfile
 metadata:
@@ -25,7 +26,7 @@ spec:
   #    isolated: $isolated
   #    reserved: $reserved
   # hardwareTuning allows maximum CPU frequencies to be set for reserved and isolated CPUs
-  #hardwareTuning:
+  # hardwareTuning:
   #  isolatedCpuFreq: <max frequency in kHz>
   #  reservedCpuFreq: <max frequency in kHz>
   hugepages:
@@ -52,11 +53,11 @@ spec:
     realTime: true
     highPowerConsumption: false
     perPodPowerManagement: false
-  # Optional: userLevelNetworking reduces NIC queues to the reserved CPU count.
-  # Enabling on a running cluster causes node drain and reboot.
-  # Validate NIC driver compatibility before enabling; silent failures are possible.
-  # When devices is omitted, applies to all network interfaces.
-  #net:
-  #  userLevelNetworking: true
-  #  devices:
-  #  - interfaceName: "eth0"
+    # Optional: userLevelNetworking reduces NIC queues to the reserved CPU count.
+    # Enabling on a running cluster causes node drain and reboot.
+    # Validate NIC driver compatibility before enabling; silent failures are possible.
+    # When devices is omitted, applies to all network interfaces.
+    # net:
+    #  userLevelNetworking: true
+    #  devices:
+    #  - interfaceName: "eth0"

--- a/telco-ran/configuration/source-crs/node-tuning-operator/x86_64/PerformanceProfile.yaml
+++ b/telco-ran/configuration/source-crs/node-tuning-operator/x86_64/PerformanceProfile.yaml
@@ -1,3 +1,4 @@
+---
 apiVersion: performance.openshift.io/v2
 kind: PerformanceProfile
 metadata:
@@ -25,7 +26,7 @@ spec:
     isolated: $isolated
     reserved: $reserved
   # hardwareTuning allows maximum CPU frequencies to be set for reserved and isolated CPUs
-  #hardwareTuning:
+  # hardwareTuning:
   #  isolatedCpuFreq: <max frequency in kHz>
   #  reservedCpuFreq: <max frequency in kHz>
   hugepages:
@@ -52,11 +53,11 @@ spec:
     realTime: true
     highPowerConsumption: false
     perPodPowerManagement: false
-  # Optional: userLevelNetworking reduces NIC queues to the reserved CPU count.
-  # Enabling on a running cluster causes node drain and reboot.
-  # Validate NIC driver compatibility before enabling; silent failures are possible.
-  # When devices is omitted, applies to all network interfaces.
-  #net:
-  #  userLevelNetworking: true
-  #  devices:
-  #  - interfaceName: "eth0"
+    # Optional: userLevelNetworking reduces NIC queues to the reserved CPU count.
+    # Enabling on a running cluster causes node drain and reboot.
+    # Validate NIC driver compatibility before enabling; silent failures are possible.
+    # When devices is omitted, applies to all network interfaces.
+    # net:
+    #  userLevelNetworking: true
+    #  devices:
+    #  - interfaceName: "eth0"

--- a/telco-ran/configuration/source-crs/ptp-operator/PtpOperatorConfig-SetSelector.yaml
+++ b/telco-ran/configuration/source-crs/ptp-operator/PtpOperatorConfig-SetSelector.yaml
@@ -1,3 +1,4 @@
+---
 apiVersion: ptp.openshift.io/v1
 kind: PtpOperatorConfig
 metadata:

--- a/telco-ran/configuration/source-crs/ptp-operator/PtpOperatorConfig.yaml
+++ b/telco-ran/configuration/source-crs/ptp-operator/PtpOperatorConfig.yaml
@@ -1,3 +1,4 @@
+---
 apiVersion: ptp.openshift.io/v1
 kind: PtpOperatorConfig
 metadata:

--- a/telco-ran/configuration/source-crs/ptp-operator/PtpOperatorConfigForEvent-SetSelector.yaml
+++ b/telco-ran/configuration/source-crs/ptp-operator/PtpOperatorConfigForEvent-SetSelector.yaml
@@ -1,3 +1,4 @@
+---
 apiVersion: ptp.openshift.io/v1
 kind: PtpOperatorConfig
 metadata:
@@ -7,7 +8,7 @@ metadata:
     ran.openshift.io/ztp-deploy-wave: "10"
 spec:
   daemonNodeSelector:
-#    node-role.kubernetes.io/worker: ""
+  #    node-role.kubernetes.io/worker: ""
   ptpEventConfig:
     enableEventPublisher: true
     transportHost: "http://ptp-event-publisher-service-NODE_NAME.openshift-ptp.svc.cluster.local:9043"

--- a/telco-ran/configuration/source-crs/ptp-operator/PtpOperatorConfigForEvent.yaml
+++ b/telco-ran/configuration/source-crs/ptp-operator/PtpOperatorConfigForEvent.yaml
@@ -1,3 +1,4 @@
+---
 apiVersion: ptp.openshift.io/v1
 kind: PtpOperatorConfig
 metadata:

--- a/telco-ran/configuration/source-crs/ptp-operator/PtpOperatorStatus.yaml
+++ b/telco-ran/configuration/source-crs/ptp-operator/PtpOperatorStatus.yaml
@@ -1,4 +1,5 @@
 # This CR verifies the installation/upgrade of the Ptp Operator
+---
 apiVersion: operators.coreos.com/v1
 kind: Operator
 metadata:

--- a/telco-ran/configuration/source-crs/ptp-operator/PtpSubscription.yaml
+++ b/telco-ran/configuration/source-crs/ptp-operator/PtpSubscription.yaml
@@ -1,3 +1,4 @@
+---
 apiVersion: operators.coreos.com/v1alpha1
 kind: Subscription
 metadata:

--- a/telco-ran/configuration/source-crs/ptp-operator/PtpSubscriptionNS.yaml
+++ b/telco-ran/configuration/source-crs/ptp-operator/PtpSubscriptionNS.yaml
@@ -1,3 +1,4 @@
+---
 apiVersion: v1
 kind: Namespace
 metadata:

--- a/telco-ran/configuration/source-crs/ptp-operator/PtpSubscriptionOperGroup.yaml
+++ b/telco-ran/configuration/source-crs/ptp-operator/PtpSubscriptionOperGroup.yaml
@@ -1,3 +1,4 @@
+---
 apiVersion: operators.coreos.com/v1
 kind: OperatorGroup
 metadata:

--- a/telco-ran/configuration/source-crs/ptp-operator/configuration/PtpConfigBoundary.yaml
+++ b/telco-ran/configuration/source-crs/ptp-operator/configuration/PtpConfigBoundary.yaml
@@ -1,3 +1,4 @@
+---
 apiVersion: ptp.openshift.io/v1
 kind: PtpConfig
 metadata:

--- a/telco-ran/configuration/source-crs/ptp-operator/configuration/PtpConfigBoundaryForEvent.yaml
+++ b/telco-ran/configuration/source-crs/ptp-operator/configuration/PtpConfigBoundaryForEvent.yaml
@@ -1,3 +1,4 @@
+---
 apiVersion: ptp.openshift.io/v1
 kind: PtpConfig
 metadata:

--- a/telco-ran/configuration/source-crs/ptp-operator/configuration/PtpConfigDualCardGmWpc.yaml
+++ b/telco-ran/configuration/source-crs/ptp-operator/configuration/PtpConfigDualCardGmWpc.yaml
@@ -2,6 +2,7 @@
 # It is not installed on production clusters
 # In this example two cards (?<iface_timeTx1>[[:alnum:]]+) and (?<iface_timeTx2>[[:alnum:]]+) are connected via
 # SMA1 ports by a cable and (?<iface_timeTx2>[[:alnum:]]+) receives 1PPS signals from (?<iface_timeTx1>[[:alnum:]]+)
+---
 apiVersion: ptp.openshift.io/v1
 kind: PtpConfig
 metadata:
@@ -43,43 +44,43 @@ spec:
             U.FL1: 0 1
             U.FL2: 0 2
         ublxCmds:
-          - args: #ubxtool -P 29.20 -z CFG-HW-ANT_CFG_VOLTCTRL,1
+          - args:  # ubxtool -P 29.20 -z CFG-HW-ANT_CFG_VOLTCTRL,1
               - "-P"
               - "29.20"
               - "-z"
               - "CFG-HW-ANT_CFG_VOLTCTRL,1"
             reportOutput: false
-          - args: #ubxtool -P 29.20 -e GPS
+          - args:  # ubxtool -P 29.20 -e GPS
               - "-P"
               - "29.20"
               - "-e"
               - "GPS"
             reportOutput: false
-          - args: #ubxtool -P 29.20 -d Galileo
+          - args:  # ubxtool -P 29.20 -d Galileo
               - "-P"
               - "29.20"
               - "-d"
               - "Galileo"
             reportOutput: false
-          - args: #ubxtool -P 29.20 -d GLONASS
+          - args:  # ubxtool -P 29.20 -d GLONASS
               - "-P"
               - "29.20"
               - "-d"
               - "GLONASS"
             reportOutput: false
-          - args: #ubxtool -P 29.20 -d BeiDou
+          - args:  # ubxtool -P 29.20 -d BeiDou
               - "-P"
               - "29.20"
               - "-d"
               - "BeiDou"
             reportOutput: false
-          - args: #ubxtool -P 29.20 -d SBAS
+          - args:  # ubxtool -P 29.20 -d SBAS
               - "-P"
               - "29.20"
               - "-d"
               - "SBAS"
             reportOutput: false
-          - args: #ubxtool -P 29.20 -t -w 5 -v 1 -e SURVEYIN,600,50000
+          - args:  # ubxtool -P 29.20 -t -w 5 -v 1 -e SURVEYIN,600,50000
               - "-P"
               - "29.20"
               - "-t"
@@ -90,13 +91,13 @@ spec:
               - "-e"
               - "SURVEYIN,600,50000"
             reportOutput: true
-          - args: #ubxtool -P 29.20 -p MON-HW
+          - args:  # ubxtool -P 29.20 -p MON-HW
               - "-P"
               - "29.20"
               - "-p"
               - "MON-HW"
             reportOutput: true
-          - args: #ubxtool -P 29.20 -p CFG-MSG,1,38,248
+          - args:  # ubxtool -P 29.20 -p CFG-MSG,1,38,248
               - "-P"
               - "29.20"
               - "-p"

--- a/telco-ran/configuration/source-crs/ptp-operator/configuration/PtpConfigDualCardTBCWpc.yaml
+++ b/telco-ran/configuration/source-crs/ptp-operator/configuration/PtpConfigDualCardTBCWpc.yaml
@@ -6,6 +6,7 @@
 #   - $iface_FirstPort2: First port on the card (used for WPC timing)
 #   - $iface_timeTx1_N: Transmits (Tx) PTP time to downstream devices (N = 0-2)
 #   - $iface_timeTx2_N: Transmits (Tx) PTP time to downstream devices (N = 0-3)
+---
 apiVersion: ptp.openshift.io/v1
 kind: PtpConfig
 metadata:

--- a/telco-ran/configuration/source-crs/ptp-operator/configuration/PtpConfigDualFollower.yaml
+++ b/telco-ran/configuration/source-crs/ptp-operator/configuration/PtpConfigDualFollower.yaml
@@ -1,5 +1,6 @@
 # In this example, 2 ports of a single NIC are used in a active/standby configuration to synchronize to a
 # remote grandmaster via interfaces $iface1 and $iface1
+---
 apiVersion: ptp.openshift.io/v1
 kind: PtpConfig
 metadata:

--- a/telco-ran/configuration/source-crs/ptp-operator/configuration/PtpConfigDualTrTBC.yaml
+++ b/telco-ran/configuration/source-crs/ptp-operator/configuration/PtpConfigDualTrTBC.yaml
@@ -4,6 +4,7 @@
 #   - $iface_timeRx: Receives (Rx) PTP time from upstream source
 #   - $iface_FirstPort: First port on the card (used for WPC timing)
 #   - $iface_timeTx_N: Transmits (Tx) PTP time to downstream devices (N = 0-2)
+---
 apiVersion: ptp.openshift.io/v1
 kind: PtpConfig
 metadata:

--- a/telco-ran/configuration/source-crs/ptp-operator/configuration/PtpConfigForHA.yaml
+++ b/telco-ran/configuration/source-crs/ptp-operator/configuration/PtpConfigForHA.yaml
@@ -1,3 +1,4 @@
+---
 apiVersion: ptp.openshift.io/v1
 kind: PtpConfig
 metadata:

--- a/telco-ran/configuration/source-crs/ptp-operator/configuration/PtpConfigForHAForEvent.yaml
+++ b/telco-ran/configuration/source-crs/ptp-operator/configuration/PtpConfigForHAForEvent.yaml
@@ -1,3 +1,4 @@
+---
 apiVersion: ptp.openshift.io/v1
 kind: PtpConfig
 metadata:

--- a/telco-ran/configuration/source-crs/ptp-operator/configuration/PtpConfigGmWpc.yaml
+++ b/telco-ran/configuration/source-crs/ptp-operator/configuration/PtpConfigGmWpc.yaml
@@ -1,5 +1,6 @@
 # The grandmaster profile is provided for testing only
 # It is not installed on production clusters
+---
 apiVersion: ptp.openshift.io/v1
 kind: PtpConfig
 metadata:
@@ -36,43 +37,43 @@ spec:
             U.FL1: 0 1
             U.FL2: 0 2
         ublxCmds:
-          - args: #ubxtool -P 29.20 -z CFG-HW-ANT_CFG_VOLTCTRL,1
+          - args:  # ubxtool -P 29.20 -z CFG-HW-ANT_CFG_VOLTCTRL,1
               - "-P"
               - "29.20"
               - "-z"
               - "CFG-HW-ANT_CFG_VOLTCTRL,1"
             reportOutput: false
-          - args: #ubxtool -P 29.20 -e GPS
+          - args:  # ubxtool -P 29.20 -e GPS
               - "-P"
               - "29.20"
               - "-e"
               - "GPS"
             reportOutput: false
-          - args: #ubxtool -P 29.20 -d Galileo
+          - args:  # ubxtool -P 29.20 -d Galileo
               - "-P"
               - "29.20"
               - "-d"
               - "Galileo"
             reportOutput: false
-          - args: #ubxtool -P 29.20 -d GLONASS
+          - args:  # ubxtool -P 29.20 -d GLONASS
               - "-P"
               - "29.20"
               - "-d"
               - "GLONASS"
             reportOutput: false
-          - args: #ubxtool -P 29.20 -d BeiDou
+          - args:  # ubxtool -P 29.20 -d BeiDou
               - "-P"
               - "29.20"
               - "-d"
               - "BeiDou"
             reportOutput: false
-          - args: #ubxtool -P 29.20 -d SBAS
+          - args:  # ubxtool -P 29.20 -d SBAS
               - "-P"
               - "29.20"
               - "-d"
               - "SBAS"
             reportOutput: false
-          - args: #ubxtool -P 29.20 -t -w 5 -v 1 -e SURVEYIN,600,50000
+          - args:  # ubxtool -P 29.20 -t -w 5 -v 1 -e SURVEYIN,600,50000
               - "-P"
               - "29.20"
               - "-t"
@@ -83,13 +84,13 @@ spec:
               - "-e"
               - "SURVEYIN,600,50000"
             reportOutput: true
-          - args: #ubxtool -P 29.20 -p MON-HW
+          - args:  # ubxtool -P 29.20 -p MON-HW
               - "-P"
               - "29.20"
               - "-p"
               - "MON-HW"
             reportOutput: true
-          - args: #ubxtool -P 29.20 -p CFG-MSG,1,38,248
+          - args:  # ubxtool -P 29.20 -p CFG-MSG,1,38,248
               - "-P"
               - "29.20"
               - "-p"

--- a/telco-ran/configuration/source-crs/ptp-operator/configuration/PtpConfigGnrdBcNoHoldover.yaml
+++ b/telco-ran/configuration/source-crs/ptp-operator/configuration/PtpConfigGnrdBcNoHoldover.yaml
@@ -2,6 +2,7 @@
 # For this GNR-D boundary clock configuration, we support one Time Reciever port on the NAC,
 # and up to 23 Time Transmitter ports including any other NAC ports and any additional
 # Carter Flats ports.
+---
 apiVersion: ptp.openshift.io/v1
 kind: PtpConfig
 metadata:

--- a/telco-ran/configuration/source-crs/ptp-operator/configuration/PtpConfigGnrdTGM.yaml
+++ b/telco-ran/configuration/source-crs/ptp-operator/configuration/PtpConfigGnrdTGM.yaml
@@ -2,6 +2,7 @@
 # configuration For this GNR-D T-GM configuration, we support GNSS incoming to
 # the onboard connection, and up to 24 Time Transmitter ports including any NAC
 # ports and any additional Carter Flats ports.
+---
 apiVersion: ptp.openshift.io/v1
 kind: PtpConfig
 metadata:
@@ -31,43 +32,43 @@ spec:
             LocalHoldoverTimeout: 14400
             MaxInSpecOffset: 100
           ublxCmds:
-            - args: #ubxtool -P 29.20 -z CFG-HW-ANT_CFG_VOLTCTRL,1
+            - args:  # ubxtool -P 29.20 -z CFG-HW-ANT_CFG_VOLTCTRL,1
                 - "-P"
                 - "29.25"
                 - "-z"
                 - "CFG-HW-ANT_CFG_VOLTCTRL,1"
               reportOutput: false
-            - args: #ubxtool -P 29.20 -e GPS
+            - args:  # ubxtool -P 29.20 -e GPS
                 - "-P"
                 - "29.25"
                 - "-e"
                 - "GPS"
               reportOutput: false
-            - args: #ubxtool -P 29.20 -d Galileo
+            - args:  # ubxtool -P 29.20 -d Galileo
                 - "-P"
                 - "29.25"
                 - "-d"
                 - "Galileo"
               reportOutput: false
-            - args: #ubxtool -P 29.20 -d GLONASS
+            - args:  # ubxtool -P 29.20 -d GLONASS
                 - "-P"
                 - "29.25"
                 - "-d"
                 - "GLONASS"
               reportOutput: false
-            - args: #ubxtool -P 29.20 -d BeiDou
+            - args:  # ubxtool -P 29.20 -d BeiDou
                 - "-P"
                 - "29.25"
                 - "-d"
                 - "BeiDou"
               reportOutput: false
-            - args: #ubxtool -P 29.20 -d SBAS
+            - args:  # ubxtool -P 29.20 -d SBAS
                 - "-P"
                 - "29.25"
                 - "-d"
                 - "SBAS"
               reportOutput: false
-            - args: #ubxtool -P 29.20 -t -w 5 -v 1 -e SURVEYIN,600,50000
+            - args:  # ubxtool -P 29.20 -t -w 5 -v 1 -e SURVEYIN,600,50000
                 - "-P"
                 - "29.25"
                 - "-t"
@@ -78,19 +79,19 @@ spec:
                 - "-e"
                 - "SURVEYIN,600,50000"
               reportOutput: true
-            - args: #ubxtool -P 29.20 -p MON-HW
+            - args:  # ubxtool -P 29.20 -p MON-HW
                 - "-P"
                 - "29.25"
                 - "-p"
                 - "MON-HW"
               reportOutput: true
-            - args: #ubxtool -P 29.20 -p CFG-MSG,1,38,300
+            - args:  # ubxtool -P 29.20 -p CFG-MSG,1,38,300
                 - "-P"
                 - "29.25"
                 - "-p"
                 - "CFG-MSG,1,38,248"
               reportOutput: true
-      #ts2phcOpts: "--ts2phc.holdover 10 --servo_offset_threshold 5 --servo_num_offset_values 10"
+      # ts2phcOpts: "--ts2phc.holdover 10 --servo_offset_threshold 5 --servo_num_offset_values 10"
       ts2phcOpts: "-m"
       ts2phcConf: |
         [nmea]

--- a/telco-ran/configuration/source-crs/ptp-operator/configuration/PtpConfigMaster.yaml
+++ b/telco-ran/configuration/source-crs/ptp-operator/configuration/PtpConfigMaster.yaml
@@ -1,5 +1,6 @@
 # The grandmaster profile is provided for testing only
 # It is not installed on production clusters
+---
 apiVersion: ptp.openshift.io/v1
 kind: PtpConfig
 metadata:

--- a/telco-ran/configuration/source-crs/ptp-operator/configuration/PtpConfigMasterForEvent.yaml
+++ b/telco-ran/configuration/source-crs/ptp-operator/configuration/PtpConfigMasterForEvent.yaml
@@ -1,5 +1,6 @@
 # The grandmaster profile is provided for testing only
 # It is not installed on production clusters
+---
 apiVersion: ptp.openshift.io/v1
 kind: PtpConfig
 metadata:

--- a/telco-ran/configuration/source-crs/ptp-operator/configuration/PtpConfigSlave.yaml
+++ b/telco-ran/configuration/source-crs/ptp-operator/configuration/PtpConfigSlave.yaml
@@ -1,3 +1,4 @@
+---
 apiVersion: ptp.openshift.io/v1
 kind: PtpConfig
 metadata:

--- a/telco-ran/configuration/source-crs/ptp-operator/configuration/PtpConfigSlaveForEvent.yaml
+++ b/telco-ran/configuration/source-crs/ptp-operator/configuration/PtpConfigSlaveForEvent.yaml
@@ -1,3 +1,4 @@
+---
 apiVersion: ptp.openshift.io/v1
 kind: PtpConfig
 metadata:

--- a/telco-ran/configuration/source-crs/ptp-operator/configuration/PtpConfigTBCWpc.yaml
+++ b/telco-ran/configuration/source-crs/ptp-operator/configuration/PtpConfigTBCWpc.yaml
@@ -4,6 +4,7 @@
 #   - $iface_timeRx: Receives (Rx) PTP time from upstream source
 #   - $iface_FirstPort: First port on the card (used for WPC timing)
 #   - $iface_timeTx_N: Transmits (Tx) PTP time to downstream devices (N = 0-2)
+---
 apiVersion: ptp.openshift.io/v1
 kind: PtpConfig
 metadata:

--- a/telco-ran/configuration/source-crs/ptp-operator/configuration/PtpConfigTTSCWpc.yaml
+++ b/telco-ran/configuration/source-crs/ptp-operator/configuration/PtpConfigTTSCWpc.yaml
@@ -3,6 +3,7 @@
 # Interface variables:
 #   - $iface_timeRx: Receives (Rx) PTP time from upstream source
 #   - $iface_FirstPort: First port on the card (used for WPC timing)
+---
 apiVersion: ptp.openshift.io/v1
 kind: PtpConfig
 metadata:

--- a/telco-ran/configuration/source-crs/ptp-operator/configuration/PtpConfigThreeCardGmWpc.yaml
+++ b/telco-ran/configuration/source-crs/ptp-operator/configuration/PtpConfigThreeCardGmWpc.yaml
@@ -2,6 +2,7 @@
 # - $iface_timeTx1 has the GNSS signal input
 # - $iface_timeTx2 SMA1 is connected to $iface_timeTx1 SMA1
 # - $iface_timeTx3 SMA1 is connected to $iface_timeTx1 SMA2
+---
 apiVersion: ptp.openshift.io/v1
 kind: PtpConfig
 metadata:
@@ -48,43 +49,43 @@ spec:
             U.FL1: 0 1
             U.FL2: 0 2
         ublxCmds:
-          - args: #ubxtool -P 29.20 -z CFG-HW-ANT_CFG_VOLTCTRL,1
+          - args:  # ubxtool -P 29.20 -z CFG-HW-ANT_CFG_VOLTCTRL,1
               - "-P"
               - "29.20"
               - "-z"
               - "CFG-HW-ANT_CFG_VOLTCTRL,1"
             reportOutput: false
-          - args: #ubxtool -P 29.20 -e GPS
+          - args:  # ubxtool -P 29.20 -e GPS
               - "-P"
               - "29.20"
               - "-e"
               - "GPS"
             reportOutput: false
-          - args: #ubxtool -P 29.20 -d Galileo
+          - args:  # ubxtool -P 29.20 -d Galileo
               - "-P"
               - "29.20"
               - "-d"
               - "Galileo"
             reportOutput: false
-          - args: #ubxtool -P 29.20 -d GLONASS
+          - args:  # ubxtool -P 29.20 -d GLONASS
               - "-P"
               - "29.20"
               - "-d"
               - "GLONASS"
             reportOutput: false
-          - args: #ubxtool -P 29.20 -d BeiDou
+          - args:  # ubxtool -P 29.20 -d BeiDou
               - "-P"
               - "29.20"
               - "-d"
               - "BeiDou"
             reportOutput: false
-          - args: #ubxtool -P 29.20 -d SBAS
+          - args:  # ubxtool -P 29.20 -d SBAS
               - "-P"
               - "29.20"
               - "-d"
               - "SBAS"
             reportOutput: false
-          - args: #ubxtool -P 29.20 -t -w 5 -v 1 -e SURVEYIN,600,50000
+          - args:  # ubxtool -P 29.20 -t -w 5 -v 1 -e SURVEYIN,600,50000
               - "-P"
               - "29.20"
               - "-t"
@@ -95,13 +96,13 @@ spec:
               - "-e"
               - "SURVEYIN,600,50000"
             reportOutput: true
-          - args: #ubxtool -P 29.20 -p MON-HW
+          - args:  # ubxtool -P 29.20 -p MON-HW
               - "-P"
               - "29.20"
               - "-p"
               - "MON-HW"
             reportOutput: true
-          - args: #ubxtool -P 29.20 -p CFG-MSG,1,38,248
+          - args:  # ubxtool -P 29.20 -p CFG-MSG,1,38,248
               - "-P"
               - "29.20"
               - "-p"

--- a/telco-ran/configuration/source-crs/ptp-operator/configuration/PtpConfigThreeCardTBCWpc.yaml
+++ b/telco-ran/configuration/source-crs/ptp-operator/configuration/PtpConfigThreeCardTBCWpc.yaml
@@ -8,6 +8,7 @@
 #   - $iface_timeTx1_N: Transmits (Tx) PTP time to downstream devices (N = 0-2)
 #   - $iface_timeTx2_N: Transmits (Tx) PTP time to downstream devices (N = 0-3)
 #   - $iface_timeTx3_N: Transmits (Tx) PTP time to downstream devices (N = 0-3)
+---
 apiVersion: ptp.openshift.io/v1
 kind: PtpConfig
 metadata:

--- a/telco-ran/configuration/source-crs/sriov-fec-operator/AcceleratorsNS.yaml
+++ b/telco-ran/configuration/source-crs/sriov-fec-operator/AcceleratorsNS.yaml
@@ -1,3 +1,4 @@
+---
 apiVersion: v1
 kind: Namespace
 metadata:

--- a/telco-ran/configuration/source-crs/sriov-fec-operator/AcceleratorsOperGroup.yaml
+++ b/telco-ran/configuration/source-crs/sriov-fec-operator/AcceleratorsOperGroup.yaml
@@ -1,3 +1,4 @@
+---
 apiVersion: operators.coreos.com/v1
 kind: OperatorGroup
 metadata:

--- a/telco-ran/configuration/source-crs/sriov-fec-operator/AcceleratorsOperatorStatus.yaml
+++ b/telco-ran/configuration/source-crs/sriov-fec-operator/AcceleratorsOperatorStatus.yaml
@@ -1,4 +1,5 @@
 # This CR verifies the installation/upgrade of the Sriov Fec Operator
+---
 apiVersion: operators.coreos.com/v1
 kind: Operator
 metadata:

--- a/telco-ran/configuration/source-crs/sriov-fec-operator/AcceleratorsSubscription.yaml
+++ b/telco-ran/configuration/source-crs/sriov-fec-operator/AcceleratorsSubscription.yaml
@@ -1,3 +1,4 @@
+---
 apiVersion: operators.coreos.com/v1alpha1
 kind: Subscription
 metadata:

--- a/telco-ran/configuration/source-crs/sriov-fec-operator/SriovFecClusterConfig.yaml
+++ b/telco-ran/configuration/source-crs/sriov-fec-operator/SriovFecClusterConfig.yaml
@@ -1,3 +1,4 @@
+---
 apiVersion: sriovfec.intel.com/v2
 kind: SriovFecClusterConfig
 metadata:
@@ -6,10 +7,10 @@ metadata:
   annotations:
     ran.openshift.io/ztp-deploy-wave: "10"
 spec:
-  drainSkip: $drainSkip # true if SNO, false by default
+  drainSkip: $drainSkip  # true if SNO, false by default
   priority: 1
   nodeSelector:
-    node-role.kubernetes.io/$mcp: "" # use master for SNO
+    node-role.kubernetes.io/$mcp: ""  # use master for SNO
   acceleratorSelector:
     pciAddress: $pciAddress
   physicalFunction:
@@ -18,5 +19,5 @@ spec:
     vfAmount: 16
     bbDevConfig:
       $bbDevConfig
-#Recommended configuration for Intel ACC100 eASIC here: https://github.com/intel/sriov-fec-operator/blob/main/spec/sriov-fec-operator.md#sample-cr-for-wireless-fec-acc100
-#Recommended configuration for Intel ACC200 (SPR-EE) here: https://github.com/intel/sriov-fec-operator/blob/main/spec/sriov-fec-operator.md#sample-cr-for-wireless-fec-acc200
+# Recommended configuration for Intel ACC100 eASIC here: https://github.com/intel/sriov-fec-operator/blob/main/spec/sriov-fec-operator.md#sample-cr-for-wireless-fec-acc100
+# Recommended configuration for Intel ACC200 (SPR-EE) here: https://github.com/intel/sriov-fec-operator/blob/main/spec/sriov-fec-operator.md#sample-cr-for-wireless-fec-acc200

--- a/telco-ran/configuration/source-crs/sriov-fec-operator/SriovVrbClusterConfig.yaml
+++ b/telco-ran/configuration/source-crs/sriov-fec-operator/SriovVrbClusterConfig.yaml
@@ -1,3 +1,4 @@
+---
 apiVersion: sriovvrb.intel.com/v1
 kind: SriovVrbClusterConfig
 metadata:
@@ -6,10 +7,10 @@ metadata:
   annotations:
     ran.openshift.io/ztp-deploy-wave: "10"
 spec:
-  drainSkip: $drainSkip # use true for SNO, false by default
+  drainSkip: $drainSkip  # use true for SNO, false by default
   priority: 1
   nodeSelector:
-    node-role.kubernetes.io/$mcp: "" # use master for SNO
+    node-role.kubernetes.io/$mcp: ""  # use master for SNO
   acceleratorSelector:
     pciAddress: $pciAddress
   physicalFunction:

--- a/telco-ran/configuration/source-crs/sriov-operator/SriovNetwork.yaml
+++ b/telco-ran/configuration/source-crs/sriov-operator/SriovNetwork.yaml
@@ -1,3 +1,4 @@
+---
 apiVersion: sriovnetwork.openshift.io/v1
 kind: SriovNetwork
 metadata:

--- a/telco-ran/configuration/source-crs/sriov-operator/SriovNetworkNodePolicy-SetSelector.yaml
+++ b/telco-ran/configuration/source-crs/sriov-operator/SriovNetworkNodePolicy-SetSelector.yaml
@@ -1,3 +1,4 @@
+---
 apiVersion: sriovnetwork.openshift.io/v1
 kind: SriovNetworkNodePolicy
 metadata:
@@ -5,18 +6,18 @@ metadata:
   namespace: openshift-sriov-network-operator
   annotations:
     ran.openshift.io/ztp-deploy-wave: "100"
+# The attributes for Mellanox/Intel based NICs as below.
+#     deviceType: netdevice/vfio-pci
+#     isRdma: true/false
+# deviceType: netdevice
+# isRdma: true
+# nicSelector:
+# The exact physical function name must match the hardware used
+#   pfNames: [eth1]
+# nodeSelector:
+#   node-role.kubernetes.io/worker: ""
+# numVfs: 10
+# priority: 8
+# must match the resourceName at SriovNetwork
+# resourceName: du_mh
 spec:
-  # The attributes for Mellanox/Intel based NICs as below.
-  #     deviceType: netdevice/vfio-pci
-  #     isRdma: true/false
-#  deviceType: netdevice
-#  isRdma: true
-#  nicSelector:
-  # The exact physical function name must match the hardware used
-#    pfNames: [eth1]
-#  nodeSelector:
-#    node-role.kubernetes.io/worker: ""
-#  numVfs: 10
-#  priority: 8
-   # must match the resourceName at SriovNetwork
-#  resourceName: du_mh

--- a/telco-ran/configuration/source-crs/sriov-operator/SriovNetworkNodePolicy.yaml
+++ b/telco-ran/configuration/source-crs/sriov-operator/SriovNetworkNodePolicy.yaml
@@ -1,3 +1,4 @@
+---
 apiVersion: sriovnetwork.openshift.io/v1
 kind: SriovNetworkNodePolicy
 metadata:

--- a/telco-ran/configuration/source-crs/sriov-operator/SriovOperatorConfig-SetSelector.yaml
+++ b/telco-ran/configuration/source-crs/sriov-operator/SriovOperatorConfig-SetSelector.yaml
@@ -1,3 +1,4 @@
+---
 apiVersion: sriovnetwork.openshift.io/v1
 kind: SriovOperatorConfig
 metadata:
@@ -7,7 +8,7 @@ metadata:
     ran.openshift.io/ztp-deploy-wave: "10"
 spec:
   configDaemonNodeSelector:
-#    "node-role.kubernetes.io/master": ""
+  #    "node-role.kubernetes.io/master": ""
   # Injector and OperatorWebhook pods can be disabled (set to "false") below
   # to reduce the number of management pods. It is recommended to start with the
   # webhook and injector pods enabled, and only disable them after verifying the

--- a/telco-ran/configuration/source-crs/sriov-operator/SriovOperatorConfig.yaml
+++ b/telco-ran/configuration/source-crs/sriov-operator/SriovOperatorConfig.yaml
@@ -1,3 +1,4 @@
+---
 apiVersion: sriovnetwork.openshift.io/v1
 kind: SriovOperatorConfig
 metadata:

--- a/telco-ran/configuration/source-crs/sriov-operator/SriovOperatorConfigForSNO.yaml
+++ b/telco-ran/configuration/source-crs/sriov-operator/SriovOperatorConfigForSNO.yaml
@@ -1,3 +1,4 @@
+---
 apiVersion: sriovnetwork.openshift.io/v1
 kind: SriovOperatorConfig
 metadata:

--- a/telco-ran/configuration/source-crs/sriov-operator/SriovOperatorStatus.yaml
+++ b/telco-ran/configuration/source-crs/sriov-operator/SriovOperatorStatus.yaml
@@ -1,4 +1,5 @@
 # This CR verifies the installation/upgrade of the Sriov Network Operator
+---
 apiVersion: operators.coreos.com/v1
 kind: Operator
 metadata:

--- a/telco-ran/configuration/source-crs/sriov-operator/SriovSubscription.yaml
+++ b/telco-ran/configuration/source-crs/sriov-operator/SriovSubscription.yaml
@@ -1,3 +1,4 @@
+---
 apiVersion: operators.coreos.com/v1alpha1
 kind: Subscription
 metadata:

--- a/telco-ran/configuration/source-crs/sriov-operator/SriovSubscriptionNS.yaml
+++ b/telco-ran/configuration/source-crs/sriov-operator/SriovSubscriptionNS.yaml
@@ -1,3 +1,4 @@
+---
 apiVersion: v1
 kind: Namespace
 metadata:

--- a/telco-ran/configuration/source-crs/sriov-operator/SriovSubscriptionOperGroup.yaml
+++ b/telco-ran/configuration/source-crs/sriov-operator/SriovSubscriptionOperGroup.yaml
@@ -1,3 +1,4 @@
+---
 apiVersion: operators.coreos.com/v1
 kind: OperatorGroup
 metadata:

--- a/telco-ran/configuration/source-crs/storage-lso/StorageClass.yaml
+++ b/telco-ran/configuration/source-crs/storage-lso/StorageClass.yaml
@@ -1,3 +1,4 @@
+---
 apiVersion: storage.k8s.io/v1
 kind: StorageClass
 metadata:

--- a/telco-ran/configuration/source-crs/storage-lso/StorageNS.yaml
+++ b/telco-ran/configuration/source-crs/storage-lso/StorageNS.yaml
@@ -1,3 +1,4 @@
+---
 apiVersion: v1
 kind: Namespace
 metadata:

--- a/telco-ran/configuration/source-crs/storage-lso/StorageOperGroup.yaml
+++ b/telco-ran/configuration/source-crs/storage-lso/StorageOperGroup.yaml
@@ -1,3 +1,4 @@
+---
 apiVersion: operators.coreos.com/v1
 kind: OperatorGroup
 metadata:

--- a/telco-ran/configuration/source-crs/storage-lso/StorageOperatorStatus.yaml
+++ b/telco-ran/configuration/source-crs/storage-lso/StorageOperatorStatus.yaml
@@ -1,4 +1,5 @@
 # This CR verifies the installation/upgrade of the Local Storage Operator
+---
 apiVersion: operators.coreos.com/v1
 kind: Operator
 metadata:

--- a/telco-ran/configuration/source-crs/storage-lso/StoragePV.yaml
+++ b/telco-ran/configuration/source-crs/storage-lso/StoragePV.yaml
@@ -1,3 +1,4 @@
+---
 apiVersion: v1
 kind: PersistentVolume
 metadata:
@@ -22,8 +23,8 @@ spec:
           operator: In
           values:
           - ""
-        # Use the hostname if a specific node is used
-        # - key: kubernetes.io/hostname
-        #   operator: In
-        #   values:
-        #   - node1-example.com
+          # Use the hostname if a specific node is used
+          # - key: kubernetes.io/hostname
+          #   operator: In
+          #   values:
+          #   - node1-example.com

--- a/telco-ran/configuration/source-crs/storage-lso/StoragePVC.yaml
+++ b/telco-ran/configuration/source-crs/storage-lso/StoragePVC.yaml
@@ -1,3 +1,4 @@
+---
 kind: PersistentVolumeClaim
 apiVersion: v1
 metadata:
@@ -8,9 +9,9 @@ metadata:
 # User should supply all required content
 spec:
   {}
-  #accessModes:
+  # accessModes:
   #  - ReadWriteOnce
-  #resources:
+  # resources:
   #  requests:
   #    storage: 400Gi
-  #storageClassName: fs-lso
+  # storageClassName: fs-lso

--- a/telco-ran/configuration/source-crs/storage-lso/StorageSubscription.yaml
+++ b/telco-ran/configuration/source-crs/storage-lso/StorageSubscription.yaml
@@ -1,3 +1,4 @@
+---
 apiVersion: operators.coreos.com/v1alpha1
 kind: Subscription
 metadata:

--- a/telco-ran/configuration/source-crs/storage-lvm/LVMOperatorStatus.yaml
+++ b/telco-ran/configuration/source-crs/storage-lvm/LVMOperatorStatus.yaml
@@ -1,4 +1,5 @@
 # This CR verifies the installation/upgrade of the Sriov Network Operator
+---
 apiVersion: operators.coreos.com/v1
 kind: Operator
 metadata:

--- a/telco-ran/configuration/source-crs/storage-lvm/StorageLVMCluster.yaml
+++ b/telco-ran/configuration/source-crs/storage-lvm/StorageLVMCluster.yaml
@@ -1,3 +1,4 @@
+---
 apiVersion: lvm.topolvm.io/v1alpha1
 kind: LVMCluster
 metadata:
@@ -8,7 +9,7 @@ metadata:
 spec:
   {}
 
-#example: creating a vg1 volume group leveraging all available disks on the node
+# example: creating a vg1 volume group leveraging all available disks on the node
 #         except the installation disk.
 #  storage:
 #    deviceClasses:

--- a/telco-ran/configuration/source-crs/storage-lvm/StorageLVMSubscription.yaml
+++ b/telco-ran/configuration/source-crs/storage-lvm/StorageLVMSubscription.yaml
@@ -1,3 +1,4 @@
+---
 apiVersion: operators.coreos.com/v1alpha1
 kind: Subscription
 metadata:

--- a/telco-ran/configuration/source-crs/storage-lvm/StorageLVMSubscriptionNS.yaml
+++ b/telco-ran/configuration/source-crs/storage-lvm/StorageLVMSubscriptionNS.yaml
@@ -1,3 +1,4 @@
+---
 apiVersion: v1
 kind: Namespace
 metadata:

--- a/telco-ran/configuration/source-crs/storage-lvm/StorageLVMSubscriptionOperGroup.yaml
+++ b/telco-ran/configuration/source-crs/storage-lvm/StorageLVMSubscriptionOperGroup.yaml
@@ -1,3 +1,4 @@
+---
 apiVersion: operators.coreos.com/v1
 kind: OperatorGroup
 metadata:

--- a/telco-ran/configuration/source-crs/storage/StorageLV.yaml
+++ b/telco-ran/configuration/source-crs/storage/StorageLV.yaml
@@ -1,3 +1,4 @@
+---
 apiVersion: "local.storage.openshift.io/v1"
 kind: "LocalVolume"
 metadata:
@@ -18,7 +19,7 @@ spec:
       fsType: xfs
       storageClassName: example-storage-class
       volumeMode: Filesystem
-#---
+# ---
 ## How to verify
 ## 1. Create a PVC
 # apiVersion: v1
@@ -33,7 +34,7 @@ spec:
 #     requests:
 #       storage: 100Gi
 #   storageClassName: example-storage-class
-#---
+# ---
 ## 2. Create a pod that mounts it
 # apiVersion: v1
 # kind: Pod

--- a/telco-ran/configuration/source-crs/validatorCRs/informDuValidator.yaml
+++ b/telco-ran/configuration/source-crs/validatorCRs/informDuValidator.yaml
@@ -1,3 +1,4 @@
+---
 apiVersion: machineconfiguration.openshift.io/v1
 kind: MachineConfigPool
 metadata:

--- a/telco-ran/configuration/source-crs/validatorCRs/informDuValidatorMaster.yaml
+++ b/telco-ran/configuration/source-crs/validatorCRs/informDuValidatorMaster.yaml
@@ -1,3 +1,4 @@
+---
 apiVersion: machineconfiguration.openshift.io/v1
 kind: MachineConfigPool
 metadata:

--- a/telco-ran/configuration/source-crs/validatorCRs/informDuValidatorWorker.yaml
+++ b/telco-ran/configuration/source-crs/validatorCRs/informDuValidatorWorker.yaml
@@ -1,3 +1,4 @@
+---
 apiVersion: machineconfiguration.openshift.io/v1
 kind: MachineConfigPool
 metadata:

--- a/telco-ran/configuration/source-crs/validatorCRs/rebootMachineConfigPoolValidator.yaml
+++ b/telco-ran/configuration/source-crs/validatorCRs/rebootMachineConfigPoolValidator.yaml
@@ -1,3 +1,4 @@
+---
 apiVersion: machineconfiguration.openshift.io/v1
 kind: MachineConfigPool
 metadata:

--- a/telco-ran/configuration/template-values/kustomization.yaml
+++ b/telco-ran/configuration/template-values/kustomization.yaml
@@ -1,3 +1,4 @@
+---
 resources:
 - group-hardware-types-configmap.yaml
 - group-zones-configmap.yaml

--- a/telco-ran/install/clusterinstance/kustomization.yaml
+++ b/telco-ran/install/clusterinstance/kustomization.yaml
@@ -1,3 +1,4 @@
+---
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:

--- a/telco-ran/install/kustomization.yaml
+++ b/telco-ran/install/kustomization.yaml
@@ -1,3 +1,4 @@
+---
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:


### PR DESCRIPTION
Add missing document starts and normalize comment formatting so `yamllint` passes cleanly.