### PR TITLE
CNF-22163: Enable kubelet GracefulNodeShutdown in RAN DU

### DIFF
--- a/telco-ran/configuration/kube-compare-reference/functions/unordered_list.tmpl
+++ b/telco-ran/configuration/kube-compare-reference/functions/unordered_list.tmpl
@@ -63,34 +63,50 @@
 {{- range $value := $expectedArgs }}
   {{- $result = append $result $value }}
 {{- end }}
-{{- $systemReservedMemory := "\"$systemReservedMemory\"" }}
-{{- if hasKey $config "systemReserved" }}
-{{- $inputSystemReserved := $config.systemReserved }}
-{{- if hasKey $inputSystemReserved "memory" }}
-{{- $systemReservedMemory = printf "\"%s\"" $inputSystemReserved.memory }}
+{{- $systemReservedMemory := printf "\"%s\"" (dig "systemReserved" "memory" "$systemReservedMemory" $config) }}
+{{- /* The annotation value is a raw string, so kube-compare diffs it as literal text: the rendered
+       reference's field order must match whatever order the actual CR happens to use, or an
+       order-only diff appears even when every field's value is otherwise correct. Mirror the
+       requiredObjectList pattern: walk the actual field order (Step a/b), and append any required
+       field the actual CR didn't set at all (Step c). */}}
+{{- $textByKey := dict }}
+{{- $_ := set $textByKey "systemReserved" (printf "\"systemReserved\":{\"memory\":%s}" $systemReservedMemory) }}
+{{- $_ = set $textByKey "shutdownGracePeriod" (printf "\"shutdownGracePeriod\":\"%s\"" ($config.shutdownGracePeriod | default "$shutdownGracePeriod")) }}
+{{- $_ = set $textByKey "shutdownGracePeriodCriticalPods" (printf "\"shutdownGracePeriodCriticalPods\":\"%s\"" ($config.shutdownGracePeriodCriticalPods | default "$shutdownGracePeriodCriticalPods")) }}
+{{- $requiredKeys := list "systemReserved" "shutdownGracePeriod" "shutdownGracePeriodCriticalPods" }}
+{{- if $result }}
+{{- $_ = set $textByKey "allowedUnsafeSysctls" (printf "\"allowedUnsafeSysctls\":%s" ($result | toJson)) }}
+{{- $requiredKeys = append $requiredKeys "allowedUnsafeSysctls" }}
+{{- end }}
+{{- /* Step a) track whether each required key was found in the actual field order */}}
+{{- $foundRequired := dict }}
+{{- range $key := $requiredKeys }}
+  {{- $_ = set $foundRequired $key false }}
+{{- end }}
+{{- /* Step b) walk the actual field order (extracted from the raw annotation text, since fromJson
+         does not preserve key order) and render the required text for anything expected */}}
+{{- $actualKeyOrder := list }}
+{{- if ne (index . 0) nil }}
+{{- $keyPattern := `"(allowedUnsafeSysctls|shutdownGracePeriodCriticalPods|shutdownGracePeriod|systemReserved)":` }}
+{{- range $m := regexFindAll $keyPattern (index . 0) -1 }}
+{{- $actualKeyOrder = append $actualKeyOrder (trimSuffix "\":" (trimPrefix "\"" $m)) }}
 {{- end }}
 {{- end }}
-{{- $shutdownGracePeriod := "" }}
-{{- if hasKey $config "shutdownGracePeriod" }}
-{{- $shutdownGracePeriod = $config.shutdownGracePeriod }}
+{{- $fields := list }}
+{{- range $key := $actualKeyOrder }}
+  {{- if hasKey $foundRequired $key }}
+    {{- $_ = set $foundRequired $key true }}
+    {{- $fields = append $fields (get $textByKey $key) }}
+  {{- end }}
 {{- end }}
-{{- $shutdownGracePeriodCriticalPods := "" }}
-{{- if hasKey $config "shutdownGracePeriodCriticalPods" }}
-{{- $shutdownGracePeriodCriticalPods = $config.shutdownGracePeriodCriticalPods }}
+{{- /* Step c) append any required key the actual CR did not set at all */}}
+{{- range $key := $requiredKeys }}
+  {{- if not (index $foundRequired $key) }}
+    {{- $fields = append $fields (get $textByKey $key) }}
+  {{- end }}
 {{- end }}
     kubeletconfig.experimental: |
       {
-       {{- if $result }}
-       "allowedUnsafeSysctls":{{ $result | toJson }},
-       {{- end }}
-       {{- if $systemReservedMemory }}
-       "systemReserved":{"memory":{{ $systemReservedMemory }}},
-       {{- end }}
-       {{- if $shutdownGracePeriod }}
-       "shutdownGracePeriod":"{{ $shutdownGracePeriod }}",
-       {{- end }}
-       {{- if $shutdownGracePeriodCriticalPods }}
-       "shutdownGracePeriodCriticalPods":"{{ $shutdownGracePeriodCriticalPods }}"
-       {{- end }}
+       {{ join ",\n       " $fields }}
       }
 {{- end }}

--- a/telco-ran/configuration/kube-compare-reference/functions/unordered_list.tmpl
+++ b/telco-ran/configuration/kube-compare-reference/functions/unordered_list.tmpl
@@ -70,13 +70,27 @@
 {{- $systemReservedMemory = printf "\"%s\"" $inputSystemReserved.memory }}
 {{- end }}
 {{- end }}
+{{- $shutdownGracePeriod := "" }}
+{{- if hasKey $config "shutdownGracePeriod" }}
+{{- $shutdownGracePeriod = $config.shutdownGracePeriod }}
+{{- end }}
+{{- $shutdownGracePeriodCriticalPods := "" }}
+{{- if hasKey $config "shutdownGracePeriodCriticalPods" }}
+{{- $shutdownGracePeriodCriticalPods = $config.shutdownGracePeriodCriticalPods }}
+{{- end }}
     kubeletconfig.experimental: |
       {
        {{- if $result }}
        "allowedUnsafeSysctls":{{ $result | toJson }},
        {{- end }}
        {{- if $systemReservedMemory }}
-       "systemReserved":{"memory":{{ $systemReservedMemory }}}
+       "systemReserved":{"memory":{{ $systemReservedMemory }}},
+       {{- end }}
+       {{- if $shutdownGracePeriod }}
+       "shutdownGracePeriod":"{{ $shutdownGracePeriod }}",
+       {{- end }}
+       {{- if $shutdownGracePeriodCriticalPods }}
+       "shutdownGracePeriodCriticalPods":"{{ $shutdownGracePeriodCriticalPods }}"
        {{- end }}
       }
 {{- end }}

--- a/telco-ran/configuration/kube-compare-reference/hack/arch/aarch64.yaml
+++ b/telco-ran/configuration/kube-compare-reference/hack/arch/aarch64.yaml
@@ -3,7 +3,9 @@ node_tuning_operator_PerformanceProfile:
       annotations:
         kubeletconfig.experimental: |
           {
-            "systemReserved":{"memory":"11Gi"}
+            "systemReserved":{"memory":"11Gi"},
+            "shutdownGracePeriod":"30s",
+            "shutdownGracePeriodCriticalPods":"10s"
           }
     spec:
       additionalKernelArgs:

--- a/telco-ran/configuration/kube-compare-reference/hack/arch/x86_64.yaml
+++ b/telco-ran/configuration/kube-compare-reference/hack/arch/x86_64.yaml
@@ -3,7 +3,9 @@ node_tuning_operator_PerformanceProfile:
       annotations:
         kubeletconfig.experimental: |
           {
-            "systemReserved":{"memory":"11Gi"}
+            "systemReserved":{"memory":"11Gi"},
+            "shutdownGracePeriod":"30s",
+            "shutdownGracePeriodCriticalPods":"10s"
           }
     spec:
       additionalKernelArgs:

--- a/telco-ran/configuration/kube-compare-reference/node-tuning-operator/PerformanceProfile.yaml
+++ b/telco-ran/configuration/kube-compare-reference/node-tuning-operator/PerformanceProfile.yaml
@@ -50,6 +50,8 @@ metadata:
     ran.openshift.io/ztp-deploy-wave: "10"
     ran.openshift.io/reference-configuration: "ran-du.redhat.com"
     # systemReserved: when used, it should be tailored for each environment.
+    # shutdownGracePeriod: enables kubelet GracefulNodeShutdown to reduce
+    # IBU upgrade downtime. Non-critical pods get 20s, critical pods get 10s.
     {{- if .metadata }}
       {{- $allowedSysctls := (list
           "net.ipv6.conf.all.accept_ra"

--- a/telco-ran/configuration/source-crs/node-tuning-operator/aarch64/PerformanceProfile-SetSelector.yaml
+++ b/telco-ran/configuration/source-crs/node-tuning-operator/aarch64/PerformanceProfile-SetSelector.yaml
@@ -10,9 +10,13 @@ metadata:
     ran.openshift.io/ztp-deploy-wave: "10"
     ran.openshift.io/reference-configuration: "ran-du.redhat.com"
     # systemReserved: when used, it should be tailored for each environment.
+    # shutdownGracePeriod: enables kubelet GracefulNodeShutdown to reduce
+    # IBU upgrade downtime. Non-critical pods get 20s, critical pods get 10s.
     kubeletconfig.experimental: |
       {
-       "systemReserved":{"memory":"11Gi"}
+       "systemReserved":{"memory":"11Gi"},
+       "shutdownGracePeriod":"30s",
+       "shutdownGracePeriodCriticalPods":"10s"
       }
 spec:
   # Note: The defaults here are for Grace Hopper systems. Other systems may alternative PCI or iommu settings such as:

--- a/telco-ran/configuration/source-crs/node-tuning-operator/aarch64/PerformanceProfile.yaml
+++ b/telco-ran/configuration/source-crs/node-tuning-operator/aarch64/PerformanceProfile.yaml
@@ -10,9 +10,13 @@ metadata:
     ran.openshift.io/ztp-deploy-wave: "10"
     ran.openshift.io/reference-configuration: "ran-du.redhat.com"
     # systemReserved: when used, it should be tailored for each environment.
+    # shutdownGracePeriod: enables kubelet GracefulNodeShutdown to reduce
+    # IBU upgrade downtime. Non-critical pods get 20s, critical pods get 10s.
     kubeletconfig.experimental: |
       {
-       "systemReserved":{"memory":"11Gi"}
+       "systemReserved":{"memory":"11Gi"},
+       "shutdownGracePeriod":"30s",
+       "shutdownGracePeriodCriticalPods":"10s"
       }
 spec:
   # Note: The defaults here are for Grace Hopper systems. Other systems may alternative PCI or iommu settings such as:

--- a/telco-ran/configuration/source-crs/node-tuning-operator/x86_64/PerformanceProfile-SetSelector.yaml
+++ b/telco-ran/configuration/source-crs/node-tuning-operator/x86_64/PerformanceProfile-SetSelector.yaml
@@ -10,9 +10,13 @@ metadata:
     ran.openshift.io/ztp-deploy-wave: "10"
     ran.openshift.io/reference-configuration: "ran-du.redhat.com"
     # systemReserved: when used, it should be tailored for each environment.
+    # shutdownGracePeriod: enables kubelet GracefulNodeShutdown to reduce
+    # IBU upgrade downtime. Non-critical pods get 20s, critical pods get 10s.
     kubeletconfig.experimental: |
       {
-       "systemReserved":{"memory":"11Gi"}
+       "systemReserved":{"memory":"11Gi"},
+       "shutdownGracePeriod":"30s",
+       "shutdownGracePeriodCriticalPods":"10s"
       }
 spec:
   # Optional kernel arguments:

--- a/telco-ran/configuration/source-crs/node-tuning-operator/x86_64/PerformanceProfile.yaml
+++ b/telco-ran/configuration/source-crs/node-tuning-operator/x86_64/PerformanceProfile.yaml
@@ -10,9 +10,13 @@ metadata:
     ran.openshift.io/ztp-deploy-wave: "10"
     ran.openshift.io/reference-configuration: "ran-du.redhat.com"
     # systemReserved: when used, it should be tailored for each environment.
+    # shutdownGracePeriod: enables kubelet GracefulNodeShutdown to reduce
+    # IBU upgrade downtime. Non-critical pods get 20s, critical pods get 10s.
     kubeletconfig.experimental: |
       {
-       "systemReserved":{"memory":"11Gi"}
+       "systemReserved":{"memory":"11Gi"},
+       "shutdownGracePeriod":"30s",
+       "shutdownGracePeriodCriticalPods":"10s"
       }
 spec:
   # Optional kernel arguments:


### PR DESCRIPTION
Add shutdownGracePeriod and shutdownGracePeriodCriticalPods to the kubeletconfig.experimentalannotation in all PerformanceProfile source CRs (x86_64 and aarch64). This enables the kubelet's native GracefulNodeShutdown feature, which reduces IBU upgrade downtime by allowing pods to terminate gracefully before node shutdown.

The kube-compare template and hack arch values are updated to validate and render the new fields with defaults of 30s total (20s non-critical, 10s critical).

Discussed with Brent and the OCP node team. This is the best solution for SNO despite of some open issues:
https://redhat-internal.slack.com/archives/CK1AE4ZCK/p1786715665943549

This replaces #903