### PR TITLE
OCPBUGS-105788: Update Monitoring config for alertmanager fanout in ACM 5.0 

### DIFF
--- a/telco-core/configuration/reference-crs/optional/other/monitoring-config-cm.yaml
+++ b/telco-core/configuration/reference-crs/optional/other/monitoring-config-cm.yaml
@@ -2,7 +2,9 @@
 # count: 1
 ---
 # Core Observability configuration
-# As a prerequisite for merging Core Observability configuration with openshift-monitoring, apply the observabilityRoutePolicy on the HUB from the telco-hub required reference-crs. This is needed to copy the alert-manager URL from the hub side open-cluster-management-observability namespace and make it available in the openshift-monitoring configmap.
+# ACM 5.0+: observatorium-api URL is available from the spoke side; alerts forward via observatorium-api with mTLS.
+# ACM 4.x:  requires the observabilityRoutePolicy from the telco-hub reference to propagate the alertmanager URL
+#            and hub cluster ID as ManagedCluster annotations; alerts forward via the alertmanager route with ingress CA.
 apiVersion: v1
 kind: ConfigMap
 metadata:
@@ -26,14 +28,27 @@ data:
       - apiVersion: v2
         bearerToken:
           key: token
-          name: {{hub $hubID := index (lookup "cluster.open-cluster-management.io/v1" "ManagedCluster" "" .ManagedClusterName).metadata.annotations "acm-hub-cluster-id" hub}}{{hub if $hubID hub}}observability-alertmanager-accessor-{{hub $hubID hub}}{{hub else hub}}observability-alertmanager-accessor{{hub end hub}}
+          name: {{ $hubInfo := fromSecret "open-cluster-management-addon-observability" "hub-info-secret" "hub-info.yaml" | fromYaml }}{{ $hubID := index $hubInfo "hub-cluster-id" }}{{ $fwdRoute := index $hubInfo "hub-alerts-forwarding-route" }}{{ if $hubID }}observability-alertmanager-accessor-{{ $hubID }}{{ else }}observability-alertmanager-accessor{{ end }}
+        {{ if $fwdRoute }}pathPrefix: /api/alertmanager/v2/default
         scheme: https
-        staticConfigs: {{hub $route := index (lookup "cluster.open-cluster-management.io/v1" "ManagedCluster" "" .ManagedClusterName).metadata.annotations "acm-alertmanager-route" hub}}{{hub if $route hub}}[{{hub $route hub}}]{{hub else hub}}[]{{hub end hub}}
+        staticConfigs: [{{ trimPrefix "https://" $fwdRoute | regexFind "^[^/]+" }}]
+        tlsConfig:
+          ca:
+            key: ca.crt
+            name: {{ if $hubID }}obs-alertmanager-mtls-ca-{{ $hubID }}{{ else }}obs-alertmanager-mtls-ca{{ end }}
+          cert:
+            key: tls.crt
+            name: {{ if $hubID }}obs-alertmanager-mtls-cert-{{ $hubID }}{{ else }}obs-alertmanager-mtls-cert{{ end }}
+          key:
+            key: tls.key
+            name: {{ if $hubID }}obs-alertmanager-mtls-cert-{{ $hubID }}{{ else }}obs-alertmanager-mtls-cert{{ end }}
+          insecureSkipVerify: false{{ else }}scheme: https
+        staticConfigs: {{hub $alertmanagerRoute := index (lookup "cluster.open-cluster-management.io/v1" "ManagedCluster" "" .ManagedClusterName).metadata.annotations "acm-alertmanager-route" hub}}{{hub if $alertmanagerRoute hub}}[{{hub $alertmanagerRoute hub}}]{{hub else hub}}[]{{hub end hub}}
         tlsConfig:
           ca:
             key: service-ca.crt
             name: {{hub $hubID2 := index (lookup "cluster.open-cluster-management.io/v1" "ManagedCluster" "" .ManagedClusterName).metadata.annotations "acm-hub-cluster-id" hub}}{{hub if $hubID2 hub}}hub-alertmanager-router-ca-{{hub $hubID2 hub}}{{hub else hub}}hub-alertmanager-router-ca{{hub end hub}}
-          insecureSkipVerify: false
+          insecureSkipVerify: false{{ end }}
       externalLabels:
         managed_cluster: {{hub index (lookup "cluster.open-cluster-management.io/v1" "ManagedCluster" "" .ManagedClusterName).metadata.labels "clusterID" hub}}
       retention: 15d

--- a/telco-ran/configuration/kube-compare-reference/cluster-tuning/monitoring-configuration/ReduceMonitoringFootprint.yaml
+++ b/telco-ran/configuration/kube-compare-reference/cluster-tuning/monitoring-configuration/ReduceMonitoringFootprint.yaml
@@ -1,6 +1,8 @@
 ---
 # RAN Observability configuration
-# As a prerequisite for merging RAN Observability configuration with openshift-monitoring, apply the observabilityRoutePolicy on the HUB from the telco-hub required reference-crs. This is needed to copy the alert-manager URL from the hub side open-cluster-management-observability namespace and make it available in the openshift-monitoring configmap.
+# ACM 5.0+: observatorium-api URL is available from the spoke side; alerts forward via observatorium-api with mTLS.
+# ACM 4.x:  requires the observabilityRoutePolicy from the telco-hub reference to propagate the alertmanager URL
+#            and hub cluster ID as ManagedCluster annotations; alerts forward via the alertmanager route with ingress CA.
 apiVersion: v1
 kind: ConfigMap
 metadata:

--- a/telco-ran/configuration/source-crs/cluster-tuning/monitoring-configuration/ReduceMonitoringFootprint.yaml
+++ b/telco-ran/configuration/source-crs/cluster-tuning/monitoring-configuration/ReduceMonitoringFootprint.yaml
@@ -1,6 +1,8 @@
 ---
 # RAN Observability configuration
-# As a prerequisite for merging RAN Observability configuration with openshift-monitoring, apply the observabilityRoutePolicy on the HUB from the telco-hub required reference-crs. This is needed to copy the alert-manager URL from the hub side open-cluster-management-observability namespace and make it available in the openshift-monitoring configmap.
+# ACM 5.0+: observatorium-api URL is available from the spoke side; alerts forward via observatorium-api with mTLS.
+# ACM 4.x:  requires the observabilityRoutePolicy from the telco-hub reference to propagate the alertmanager URL
+#            and hub cluster ID as ManagedCluster annotations; alerts forward via the alertmanager route with ingress CA.
 apiVersion: v1
 kind: ConfigMap
 metadata:
@@ -30,14 +32,27 @@ data:
       - apiVersion: v2
         bearerToken:
           key: token
-          name: {{hub $hubID := index (lookup "cluster.open-cluster-management.io/v1" "ManagedCluster" "" .ManagedClusterName).metadata.annotations "acm-hub-cluster-id" hub}}{{hub if $hubID hub}}observability-alertmanager-accessor-{{hub $hubID hub}}{{hub else hub}}observability-alertmanager-accessor{{hub end hub}}
+          name: {{ $hubInfo := fromSecret "open-cluster-management-addon-observability" "hub-info-secret" "hub-info.yaml" | fromYaml }}{{ $hubID := index $hubInfo "hub-cluster-id" }}{{ $fwdRoute := index $hubInfo "hub-alerts-forwarding-route" }}{{ if $hubID }}observability-alertmanager-accessor-{{ $hubID }}{{ else }}observability-alertmanager-accessor{{ end }}
+        {{ if $fwdRoute }}pathPrefix: /api/alertmanager/v2/default
         scheme: https
-        staticConfigs: {{hub $route := index (lookup "cluster.open-cluster-management.io/v1" "ManagedCluster" "" .ManagedClusterName).metadata.annotations "acm-alertmanager-route" hub}}{{hub if $route hub}}[{{hub $route hub}}]{{hub else hub}}[]{{hub end hub}}
+        staticConfigs: [{{ trimPrefix "https://" $fwdRoute | regexFind "^[^/]+" }}]
+        tlsConfig:
+          ca:
+            key: ca.crt
+            name: {{ if $hubID }}obs-alertmanager-mtls-ca-{{ $hubID }}{{ else }}obs-alertmanager-mtls-ca{{ end }}
+          cert:
+            key: tls.crt
+            name: {{ if $hubID }}obs-alertmanager-mtls-cert-{{ $hubID }}{{ else }}obs-alertmanager-mtls-cert{{ end }}
+          key:
+            key: tls.key
+            name: {{ if $hubID }}obs-alertmanager-mtls-cert-{{ $hubID }}{{ else }}obs-alertmanager-mtls-cert{{ end }}
+          insecureSkipVerify: false{{ else }}scheme: https
+        staticConfigs: {{hub $alertmanagerRoute := index (lookup "cluster.open-cluster-management.io/v1" "ManagedCluster" "" .ManagedClusterName).metadata.annotations "acm-alertmanager-route" hub}}{{hub if $alertmanagerRoute hub}}[{{hub $alertmanagerRoute hub}}]{{hub else hub}}[]{{hub end hub}}
         tlsConfig:
           ca:
             key: service-ca.crt
             name: {{hub $hubID2 := index (lookup "cluster.open-cluster-management.io/v1" "ManagedCluster" "" .ManagedClusterName).metadata.annotations "acm-hub-cluster-id" hub}}{{hub if $hubID2 hub}}hub-alertmanager-router-ca-{{hub $hubID2 hub}}{{hub else hub}}hub-alertmanager-router-ca{{hub end hub}}
-          insecureSkipVerify: false
+          insecureSkipVerify: false{{ end }}
       externalLabels:
         managed_cluster: {{hub index (lookup "cluster.open-cluster-management.io/v1" "ManagedCluster" "" .ManagedClusterName).metadata.labels "clusterID" hub}}
       retention: 24h


### PR DESCRIPTION
ACM 5.0 (PR stolostron/multicluster-observability-operator#2485, ACM-33219) removes the hub-alertmanager-router-ca secret from managed clusters. Alert forwarding now fans out through the hub observatorium-api route (path /api/alertmanager/v2/default) using mTLS instead of a dedicated alertmanager route + ingress-router CA.

Changes:
- observabilityRoutePolicy: switch to acm-observatorium-api-route lookup annotation
- ReduceMonitoringFootprint (source-cr + kube-compare twin): point staticConfigs at the observatorium-api route, add pathPrefix, and switch tlsConfig to mTLS (obs-alertmanager-mtls-ca / -cert secrets)
- default_value.yaml: rename/add capture-group defaults to match
- acm readme: document the 5.0 observatorium-api/mTLS fanout

Validation

 Spoke side check - alert firing locally:
```
-> % oc exec -c prometheus -n openshift-monitoring prometheus-k8s-0 -- \                                                                                                       cnfdg38
    curl -s "http://localhost:9090/api/v1/query" \
    --data-urlencode 'query=ALERTS{alertname="ExampleAlert"}' \
    | jq -c '.data.result[] | {state:.metric.alertstate, severity:.metric.severity}'
{"state":"firing","severity":"major"}
```

  Spoke side check - confirm observatorium-api is the active alertmanager target:
  
```
-> % oc exec -c prometheus -n openshift-monitoring prometheus-k8s-0 -- \                                                                                                       cnfdg38
    curl -s "http://localhost:9090/api/v1/alertmanagers" \
    | jq '{active:[.data.activeAlertmanagers[].url], dropped:[.data.droppedAlertmanagers[].url]}'
{
  "active": [
    "https://observatorium-api-open-cluster-management-observability.apps.vcl01.hv4.telco5gran.eng.rdu2.redhat.com/api/alertmanager/v2/default/api/v2/alerts"
  ],
  "dropped": []
}
```

Hub side check — confirm alert arrived tagged with the managed cluster ID:
```
-> % am=$(oc get pods -n open-cluster-management-observability -o name | grep -E 'alertmanager-[0-9]' | head -1)                                                                 vcl01
  oc exec -n open-cluster-management-observability ${am#pod/} -c alertmanager -- \
    curl -s "http://localhost:9093/api/v2/alerts?filter=alertname%3D%22ExampleAlert%22" \
    | jq -c '.[] | {alertname:.labels.alertname, mc:.labels.managed_cluster, severity:.labels.severity, state:.status.state}'
{"alertname":"ExampleAlert","mc":"553521ce-3dbd-48f1-a5ec-9651a35786e2","severity":"major","state":"active"}
```