### PR TITLE
Allow hub side templating for image pre-caching.

### DIFF
--- a/telco-core/configuration/reference-crs/optional/other/precache/controlplane-olm-pinned-images.yaml
+++ b/telco-core/configuration/reference-crs/optional/other/precache/controlplane-olm-pinned-images.yaml
@@ -9,7 +9,7 @@ spec:
   # Replace the pinnedImages list below with the actual images required for
   # your target release(s). Use patches in the PolicyGenerator to override
   # this list with environment-specific image digests.
-  pinnedImages: {}
+  pinnedImages: ""
   #  - name: "registry.redhat.io/redhat/redhat-operator-index@sha256:..."
   #  - name: "registry.redhat.io/odf4/odf-rhel9-operator@sha256:..."
   #  - name: "registry.redhat.io/openshift4/ose-sriov-network-rhel9-operator@sha256:..."

--- a/telco-core/configuration/reference-crs/optional/other/precache/controlplane-releases-pinned-images.yaml
+++ b/telco-core/configuration/reference-crs/optional/other/precache/controlplane-releases-pinned-images.yaml
@@ -9,7 +9,7 @@ spec:
   # Replace the pinnedImages list below with the actual release images required
   # for your target release(s). Use patches in the PolicyGenerator to override
   # this list with environment-specific image digests.
-  pinnedImages: {}
+  pinnedImages: ""
   #  - name: "quay.io/openshift-release-dev/ocp-release@sha256:..."
   #  - name: "quay.io/openshift-release-dev/ocp-v4.0-art-dev@sha256:..."
   #  - name: "quay.io/openshift-release-dev/ocp-v4.0-art-dev@sha256:..."

--- a/telco-core/configuration/reference-crs/optional/other/precache/worker-olm-pinned-images.yaml
+++ b/telco-core/configuration/reference-crs/optional/other/precache/worker-olm-pinned-images.yaml
@@ -9,7 +9,7 @@ spec:
   # Replace the pinnedImages list below with the actual images required for
   # your target release(s). Use patches in the PolicyGenerator to override
   # this list with environment-specific image digests.
-  pinnedImages: {}
+  pinnedImages: ""
   #  - name: "registry.redhat.io/redhat/redhat-operator-index@sha256:..."
   #  - name: "registry.redhat.io/odf4/odf-rhel9-operator@sha256:..."
   #  - name: "registry.redhat.io/openshift4/ose-sriov-network-rhel9-operator@sha256:..."

--- a/telco-core/configuration/reference-crs/optional/other/precache/worker-releases-pinned-images.yaml
+++ b/telco-core/configuration/reference-crs/optional/other/precache/worker-releases-pinned-images.yaml
@@ -9,7 +9,7 @@ spec:
   # Replace the pinnedImages list below with the actual release images required
   # for your target release(s). Use patches in the PolicyGenerator to override
   # this list with environment-specific image digests.
-  pinnedImages: {}
+  pinnedImages: ""
   #  - name: "quay.io/openshift-release-dev/ocp-release@sha256:..."
   #  - name: "quay.io/openshift-release-dev/ocp-v4.0-art-dev@sha256:..."
   #  - name: "quay.io/openshift-release-dev/ocp-v4.0-art-dev@sha256:..."


### PR DESCRIPTION
Hub side templating in a form of:
```
  pinnedImages: '{{hub fromConfigMap "" "pinned-imagesets" "controlplane-release-images" | toLiteral hub}}'
```
fails as kustomize fails to apply patches:
```
  wrong node kind: expected MappingNode but got ScalarNode:
```
Root cause: the base CR has pinnedImages: {} (a mapping). The hub template is a string (scalar).
Kustomize strategic-merge patches cannot change node kind (MappingNode → ScalarNode), so the build fails even with the correct template syntax.

ConfigMap looks like:
```yaml
---
apiVersion: v1
kind: ConfigMap
metadata:
  name: pinned-imagesets
  namespace: ztp-core-policies
data:
  controlplane-release-images: '[{"name": "quay.io/openshift-release-dev/ocp-v4.0-art-dev@sha256:abc.."},
    {"name": "quay.io/openshift-release-dev/ocp-v4.0-art-dev@sha256:cde.."},
    {"name": "quay.io/openshift-release-dev/ocp-v4.0-art-dev@sha256:1234..."},
```