### PR TITLE
Update all version references for OpenShift 5.0

### DIFF
--- a/hack/crd-schema-config.json
+++ b/hack/crd-schema-config.json
@@ -20,7 +20,7 @@
         "github": {
           "owner": "openshift",
           "repo": "ptp-operator",
-          "ref": "release-4.22",
+          "ref": "release-5.0",
           "path": "config/crd/bases/ptp.openshift.io_ptpconfigs.yaml"
         }
       },
@@ -38,12 +38,12 @@
         "core",
         "ran"
       ],
-      "subscription_channel": "stable-6.5",
+      "subscription_channel": "stable-6.6",
       "source": {
         "github": {
           "owner": "openshift",
           "repo": "cluster-logging-operator",
-          "ref": "release-6.5",
+          "ref": "release-6.6",
           "path": "config/crd/bases/observability.openshift.io_clusterlogforwarders.yaml"
         }
       },
@@ -66,7 +66,7 @@
         "github": {
           "owner": "openshift",
           "repo": "cluster-node-tuning-operator",
-          "ref": "release-4.22",
+          "ref": "release-5.0",
           "path": "manifests/20-tuned.crd.yaml"
         }
       },
@@ -88,7 +88,7 @@
         "github": {
           "owner": "openshift",
           "repo": "cluster-node-tuning-operator",
-          "ref": "release-4.22",
+          "ref": "release-5.0",
           "path": "manifests/20-performance-profile.crd.yaml"
         }
       },
@@ -101,12 +101,12 @@
       "components": [
         "core"
       ],
-      "subscription_channel": "4.22",
+      "subscription_channel": "5.0",
       "source": {
         "github": {
           "owner": "openshift-kni",
           "repo": "numaresources-operator",
-          "ref": "release-4.22",
+          "ref": "release-5.0",
           "path": "config/crd/bases/nodetopology.openshift.io_numaresourcesoperators.yaml"
         }
       },
@@ -126,7 +126,7 @@
         "github": {
           "owner": "openshift",
           "repo": "api",
-          "ref": "release-4.22",
+          "ref": "release-5.0",
           "path": "config/v1/zz_generated.crd-manifests/0000_10_config-operator_01_imagedigestmirrorsets.crd.yaml"
         }
       },

--- a/telco-core/configuration/core-baseline.yaml
+++ b/telco-core/configuration/core-baseline.yaml
@@ -2,7 +2,7 @@
 apiVersion: policy.open-cluster-management.io/v1
 kind: PolicyGenerator
 metadata:
-  name: core-baseline-22
+  name: core-baseline-5-0
 policyDefaults:
   namespace: ztp-core-policies
   policySets: []
@@ -10,11 +10,11 @@ policyDefaults:
     labelSelector:
       matchLabels:
         common: "core"
-        version: "4.22"
+        version: "5.0"
   remediationAction: "inform"
 policies:
   # Base cluster configuration
-  - name: core-cluster-config-4.22
+  - name: core-cluster-config-5-0
     policyAnnotations:
       ran.openshift.io/ztp-deploy-wave: "1"
     manifests:
@@ -22,11 +22,11 @@ policies:
       - path: reference-crs/required/other/catalog-source.yaml
         patches:
         - spec:
-            image: registry.redhat.io/redhat/redhat-operator-index:v4.22
+            image: registry.redhat.io/redhat/redhat-operator-index:v5.0
       - path: reference-crs/required/scheduling/Scheduler.yaml
 
   # Core cluster OLM operators
-  - name: core-operator-subs-4.22
+  - name: core-operator-subs-5-0
     policyAnnotations:
       ran.openshift.io/ztp-deploy-wave: "5"
     manifests:
@@ -41,7 +41,7 @@ policies:
               - kind: ClusterServiceVersion
                 namespace: openshift-logging
                 # Update with specific target version
-                name: cluster-logging.v6.5.0
+                name: cluster-logging.v6.6.1
                 conditions:
                   - type: Succeeded
                     status: "True"
@@ -64,7 +64,7 @@ policies:
         patches:
         - spec:
             installPlanApproval: Manual
-            channel: stable-4.21
+            channel: stable-5.0
       - path: reference-crs/required/networking/metallb/metallbNS.yaml
       - path: reference-crs/required/networking/metallb/metallbOperGroup.yaml
       - path: reference-crs/required/networking/metallb/metallbSubscription.yaml
@@ -90,7 +90,7 @@ policies:
             installPlanApproval: Manual
 
   # Operator configuration
-  - name: core-operator-config-4.22
+  - name: core-operator-config-5-0
     policyAnnotations:
       ran.openshift.io/ztp-deploy-wave: "6"
     manifests:

--- a/telco-core/configuration/core-finish.yaml
+++ b/telco-core/configuration/core-finish.yaml
@@ -2,7 +2,7 @@
 apiVersion: policy.open-cluster-management.io/v1
 kind: PolicyGenerator
 metadata:
-  name: core-customer-policies-22
+  name: core-customer-policies-5-0
 policyDefaults:
   namespace: ztp-core-policies
   policySets: []
@@ -10,11 +10,11 @@ policyDefaults:
     labelSelector:
       matchLabels:
         common: "core"
-        version: "4.22"
+        version: "5.0"
   remediationAction: "inform"
 policies:
   # unpause baseline configuration
-  - name: custom-mcp-unpause-22
+  - name: custom-mcp-unpause-5-0
     policyAnnotations:
       ran.openshift.io/ztp-deploy-wave: "200"
     placement:
@@ -27,7 +27,7 @@ policies:
           - key: version
             operator: In
             values:
-              - "4.22"
+              - "5.0"
           - key: ztp-done
             operator: DoesNotExist
     # The policy unpauses MCPs that were paused during initial creation
@@ -75,7 +75,7 @@ policies:
             - type: Updating
               status: "False"
 
-  - name: core-custom-mcp-set-maxavailable-22
+  - name: core-custom-mcp-set-maxavailable-5-0
     policyAnnotations:
       ran.openshift.io/ztp-deploy-wave: "201"
     manifests:

--- a/telco-core/configuration/core-overlay.yaml
+++ b/telco-core/configuration/core-overlay.yaml
@@ -2,7 +2,7 @@
 apiVersion: policy.open-cluster-management.io/v1
 kind: PolicyGenerator
 metadata:
-  name: core-overlay-22
+  name: core-overlay-5-0
 policyDefaults:
   namespace: ztp-core-policies
   policySets: []
@@ -10,11 +10,11 @@ policyDefaults:
     labelSelector:
       matchLabels:
         common: "core"
-        version: "4.22"
+        version: "5.0"
   remediationAction: "inform"
 policies:
   # Baseline configuration with custom overlay content
-  - name: core-overlay-base-4.22
+  - name: core-overlay-base-5-0
     policyAnnotations:
       ran.openshift.io/ztp-deploy-wave: "2"
     manifests:
@@ -59,7 +59,7 @@ policies:
       # - path: reference-crs/optional/cert-manager/apiServerConfig.yaml
 
   # Custom networking, operator and cluster configuration
-  - name: core-overlay-config-4.22
+  - name: core-overlay-config-5-0
     policyAnnotations:
       ran.openshift.io/ztp-deploy-wave: "8"
     manifests:
@@ -307,9 +307,9 @@ policies:
 
   # reference-crs/optional/networking/nodeNetworkConfigurationPolicy.yaml
 
-  - name: config-monitoring-4.22
+  - name: config-monitoring-5-0
     # For consistency the name of this policy will be updated in a future release:
-    # - name: core-overlay-monitoring-4.22
+    # - name: core-overlay-monitoring-5-0
     policyAnnotations:
       ran.openshift.io/ztp-deploy-wave: "10"
     manifests:

--- a/telco-core/configuration/core-upgrade-finish.yaml
+++ b/telco-core/configuration/core-upgrade-finish.yaml
@@ -72,7 +72,7 @@ policies:
   # removes the 4 PinnedImageSet CRs created by core-upgrade-precache policies
   # after the upgrade completes. Safe to include even when pre-caching was not
   # used — mustnothave is compliant when the objects do not exist.
-  - name: core-upgrade-precache-cleanup-22
+  - name: core-upgrade-precache-cleanup-5-0
     policyAnnotations:
       ran.openshift.io/soak-seconds: "30"
     manifests:

--- a/telco-core/configuration/core-upgrade-precache.yaml
+++ b/telco-core/configuration/core-upgrade-precache.yaml
@@ -2,7 +2,7 @@
 apiVersion: policy.open-cluster-management.io/v1
 kind: PolicyGenerator
 metadata:
-  name: telco-core-upgrade-precache-22
+  name: telco-core-upgrade-precache-5-0
 policyDefaults:
   namespace: ztp-core-policies
   policySets: []
@@ -16,7 +16,7 @@ policyDefaults:
         upgrade-precache: ""
   remediationAction: "inform"
 policies:
-  - name: core-upgrade-precache-controlplane-22
+  - name: core-upgrade-precache-controlplane-5-0
     policyAnnotations:
       ran.openshift.io/soak-seconds: "30"
     manifests:
@@ -36,7 +36,7 @@ policies:
             pinnedImages:
               - name: "quay.io/openshift-release-dev/ocp-release@sha256:<sha>"
               # - name: "<add remaining release images here>"
-  - name: core-upgrade-precache-worker-22
+  - name: core-upgrade-precache-worker-5-0
     policyAnnotations:
       ran.openshift.io/soak-seconds: "30"
     manifests:
@@ -56,7 +56,7 @@ policies:
             pinnedImages:
               - name: "quay.io/openshift-release-dev/ocp-release@sha256:<sha>"
               # - name: "<add remaining release images here>"
-  - name: core-upgrade-precache-validator-22
+  - name: core-upgrade-precache-validator-5-0
     policyAnnotations:
       ran.openshift.io/soak-seconds: "30"
     manifests:

--- a/telco-core/configuration/core-upgrade.yaml
+++ b/telco-core/configuration/core-upgrade.yaml
@@ -2,7 +2,7 @@
 apiVersion: policy.open-cluster-management.io/v1
 kind: PolicyGenerator
 metadata:
-  name: telco-core-upgrade-22
+  name: telco-core-upgrade-5-0
 policyDefaults:
   namespace: ztp-core-policies
   policySets: []
@@ -10,10 +10,10 @@ policyDefaults:
     labelSelector:
       matchLabels:
         common: "core"
-        upgrade-version-4-22: ""
+        upgrade-version-5-0: ""
   remediationAction: "inform"
 policies:
-  - name: core-upgrade-prep-22
+  - name: core-upgrade-prep-5-0
     policyAnnotations:
       # Updates to the catalogsource take a few seconds to propagate
       # to the status. The soak seconds gives time for that
@@ -24,7 +24,7 @@ policies:
       - path: reference-crs/required/other/catalog-source.yaml
         patches:
         - spec:
-            image: registry.redhat.io/redhat/redhat-operator-index:v4.22
+            image: registry.redhat.io/redhat/redhat-operator-index:v5.0
         - status:
             connectionState:
               lastObservedState: READY
@@ -53,22 +53,22 @@ policies:
             # Adjust as needed based on spare capacity, cluster design, and application requirements
             maxUnavailable: 100%
             paused: true
-  - name: core-upgrade-ocp-22
+  - name: core-upgrade-ocp-5-0
     manifests:
       - path: reference-crs/optional/other/ClusterVersion.yaml
         patches:
         - spec:
-            channel: stable-4.22
+            channel: stable-5.0
             desiredUpdate:
               # Replace version, image and status below with desired version
-              version: 4.22.0
+              version: 5.0.0
               image: quay.io/openshift-release-dev/ocp-release@sha256:<TBD>
               force: true
         - status:
             history:
-            - version: 4.22.0
+            - version: 5.0.0
               state: "Completed"
-  - name: core-upgrade-olm-22
+  - name: core-upgrade-olm-5-0
     policyAnnotations:
       # Ensure that status for OLM created operators has time to propagate
       ran.openshift.io/soak-seconds: "60"
@@ -77,7 +77,7 @@ policies:
         patches:
         - metadata:
             annotations:
-              noop-for-triggering-noncompliance: "22"
+              noop-for-triggering-noncompliance: "5-0"
         - status:
             state: AtLatestKnown
       - path: reference-crs/required/networking/sriov/SriovSubscription.yaml
@@ -87,7 +87,7 @@ policies:
       - path: reference-crs/required/storage/odf-external/odfSubscription.yaml
         patches:
         - spec:
-            channel: stable-4.21
+            channel: stable-5.0
         - status:
             state: AtLatestKnown
       - path: reference-crs/required/networking/NMStateSubscription.yaml
@@ -106,7 +106,7 @@ policies:
   # Ensure that all subscriptions are at the latest known, including
   # subscriptions automatically created by OLM on behalf of higher
   # level operators.
-  - name: core-upgrade-validate-22
+  - name: core-upgrade-validate-5-0
     policyAnnotations:
       # Ensure that propagation to OLM created operators has time to propagate
       ran.openshift.io/soak-seconds: "30"

--- a/telco-core/configuration/reference-crs-kube-compare/ReferenceVersionCheck.yaml
+++ b/telco-core/configuration/reference-crs-kube-compare/ReferenceVersionCheck.yaml
@@ -4,4 +4,4 @@ metadata:
   name: version
 status:
   desired:
-    version: {{ template "versionMatch" (list .status.desired.version "4.22") }}
+    version: {{ template "versionMatch" (list .status.desired.version "5.0") }}

--- a/telco-core/configuration/reference-crs-kube-compare/metadata.yaml
+++ b/telco-core/configuration/reference-crs-kube-compare/metadata.yaml
@@ -3,7 +3,7 @@ parts:
   - name: version-check
     description: |-
       A mismatch here means you may be using the wrong reference.
-      This reference was designed for OpenShift 4.22.
+      This reference was designed for OpenShift 5.0.
     components:
       - name: version-check
         allOf:
@@ -26,7 +26,7 @@ parts:
           - path: required/machine-config/container-runtime.yaml
   - name: networking
     description: |-
-      https://docs.redhat.com/en/documentation/openshift_container_platform/4.22/html/scalability_and_performance/telco-core-ref-design-specs#telco-core-networking_telco-core
+      https://docs.redhat.com/en/documentation/openshift_container_platform/5.0/html/scalability_and_performance/telco-core-ref-design-specs#telco-core-networking_telco-core
     components:
       - name: networking-root
         allOf:
@@ -35,7 +35,7 @@ parts:
               ignore-unspecified-fields: true
       - name: networking-nmsate
         description: |-
-          https://docs.redhat.com/en/documentation/openshift_container_platform/4.22/html/scalability_and_performance/telco-core-ref-design-specs#telco-core-nmstate-operator_telco-core
+          https://docs.redhat.com/en/documentation/openshift_container_platform/5.0/html/scalability_and_performance/telco-core-ref-design-specs#telco-core-nmstate-operator_telco-core
         allOrNoneOf:
           - path: required/networking/NMState.yaml
           - path: required/networking/NMStateNS.yaml
@@ -45,7 +45,7 @@ parts:
           - path: required/networking/NMStateSubscription.yaml
       - name: networking-metallb
         description: |-
-          https://docs.redhat.com/en/documentation/openshift_container_platform/4.22/html/scalability_and_performance/telco-core-ref-design-specs#telco-core-load-balancer_telco-core
+          https://docs.redhat.com/en/documentation/openshift_container_platform/5.0/html/scalability_and_performance/telco-core-ref-design-specs#telco-core-load-balancer_telco-core
         allOf:
           - path: required/networking/metallb/addr-pool.yaml
           - path: required/networking/metallb/bfd-profile.yaml
@@ -63,17 +63,17 @@ parts:
           - path: required/networking/metallb/metallbSubscription.yaml
       - name: networking-multinetworkpolicy
         description: |-
-          https://docs.redhat.com/en/documentation/openshift_container_platform/4.22/html/scalability_and_performance/telco-core-ref-design-specs#telco-core-sr-iov_telco-core
+          https://docs.redhat.com/en/documentation/openshift_container_platform/5.0/html/scalability_and_performance/telco-core-ref-design-specs#telco-core-sr-iov_telco-core
         allOf:
           - path: required/networking/multinetworkpolicy/multiNetworkPolicyAllowPortProtocol.yaml
       - name: networking-multinetworkpolicy-denyall
         description: |-
-          https://docs.redhat.com/en/documentation/openshift_container_platform/4.22/html/scalability_and_performance/telco-core-ref-design-specs#telco-core-sr-iov_telco-core
+          https://docs.redhat.com/en/documentation/openshift_container_platform/5.0/html/scalability_and_performance/telco-core-ref-design-specs#telco-core-sr-iov_telco-core
         anyOf:
           - path: required/networking/multinetworkpolicy/multiNetworkPolicyDenyAll.yaml
       - name: networking-sriov
         description: |-
-          https://docs.redhat.com/en/documentation/openshift_container_platform/4.22/html/scalability_and_performance/telco-core-ref-design-specs#telco-core-sr-iov_telco-core
+          https://docs.redhat.com/en/documentation/openshift_container_platform/5.0/html/scalability_and_performance/telco-core-ref-design-specs#telco-core-sr-iov_telco-core
         allOf:
           - path: required/networking/sriov/sriovNetwork.yaml
           - path: required/networking/sriov/sriovNetworkNodePolicy.yaml
@@ -103,14 +103,14 @@ parts:
     components:
       - name: disconnected-registry
         description: |-
-          https://docs.redhat.com/en/documentation/openshift_container_platform/4.22/html/scalability_and_performance/telco-core-ref-design-specs#telco-core-disconnected-environment_telco-core
+          https://docs.redhat.com/en/documentation/openshift_container_platform/5.0/html/scalability_and_performance/telco-core-ref-design-specs#telco-core-disconnected-environment_telco-core
         allOf:
           - path: required/other/catalog-source.yaml
           - path: required/other/idms.yaml
           - path: required/other/operator-hub.yaml
   - name: required-performance
     description: |-
-      https://docs.redhat.com/en/documentation/openshift_container_platform/4.22/html/scalability_and_performance/telco-core-ref-design-specs#telco-core-cpu-partitioning-and-performance-tuning_telco-core
+      https://docs.redhat.com/en/documentation/openshift_container_platform/5.0/html/scalability_and_performance/telco-core-ref-design-specs#telco-core-cpu-partitioning-and-performance-tuning_telco-core
     components:
       - name: performance
         allOf:
@@ -131,7 +131,7 @@ parts:
     components:
       - name: scheduling
         description: |-
-          https://docs.redhat.com/en/documentation/openshift_container_platform/4.22/html/scalability_and_performance/telco-core-ref-design-specs#telco-core-scheduling_telco-core
+          https://docs.redhat.com/en/documentation/openshift_container_platform/5.0/html/scalability_and_performance/telco-core-ref-design-specs#telco-core-scheduling_telco-core
         allOf:
           - path: required/scheduling/nrop.yaml
           - path: required/scheduling/NROPSubscription.yaml
@@ -145,7 +145,7 @@ parts:
     components:
       - name: storage-odf
         description: |-
-          https://docs.redhat.com/en/documentation/openshift_container_platform/4.22/html/scalability_and_performance/telco-core-ref-design-specs#telco-core-storage_telco-core
+          https://docs.redhat.com/en/documentation/openshift_container_platform/5.0/html/scalability_and_performance/telco-core-ref-design-specs#telco-core-storage_telco-core
         allOf:
           - path: required/storage/odf-external/01-rook-ceph-external-cluster-details.secret.yaml
           - path: required/storage/odf-external/02-ocs-external-storagecluster.yaml
@@ -158,7 +158,7 @@ parts:
           - path: required/storage/odf-external/odfSubscription.yaml
   - name: other
     description: |-
-      https://docs.redhat.com/en/documentation/openshift_container_platform/4.22/html/scalability_and_performance/telco-core-ref-design-specs#node-configuration-crs
+      https://docs.redhat.com/en/documentation/openshift_container_platform/5.0/html/scalability_and_performance/telco-core-ref-design-specs#node-configuration-crs
     components:
       - name: other
         anyOf:
@@ -178,7 +178,7 @@ parts:
           - path: optional/other/precache/worker-releases-pinned-images.yaml
   - name: logging
     description: |-
-      https://docs.redhat.com/en/documentation/openshift_container_platform/4.22/html/scalability_and_performance/telco-core-ref-design-specs#resource-tuning-crs
+      https://docs.redhat.com/en/documentation/openshift_container_platform/5.0/html/scalability_and_performance/telco-core-ref-design-specs#resource-tuning-crs
     components:
       - name: logging
         allOrNoneOf:
@@ -193,7 +193,7 @@ parts:
           - path: optional/logging/ClusterLogServiceAccountInfrastructureBinding.yaml
   - name: tuning
     description: |-
-      https://docs.redhat.com/en/documentation/openshift_container_platform/4.22/html/scalability_and_performance/telco-core-ref-design-specs#telco-core-cpu-partitioning-and-performance-tuning_telco-core
+      https://docs.redhat.com/en/documentation/openshift_container_platform/5.0/html/scalability_and_performance/telco-core-ref-design-specs#telco-core-cpu-partitioning-and-performance-tuning_telco-core
     components:
       - name: other
         anyOf:

--- a/telco-core/configuration/reference-crs-kube-compare/optional/logging/ClusterLogSubscription.yaml
+++ b/telco-core/configuration/reference-crs-kube-compare/optional/logging/ClusterLogSubscription.yaml
@@ -4,7 +4,7 @@ metadata:
   name: cluster-logging
   namespace: openshift-logging
 spec:
-  channel: "stable-6.5"
+  channel: "stable-6.6"
   name: cluster-logging
   source: {{ .spec.source }}
   sourceNamespace: openshift-marketplace

--- a/telco-core/configuration/reference-crs-kube-compare/required/storage/odf-external/odfSubscription.yaml
+++ b/telco-core/configuration/reference-crs-kube-compare/required/storage/odf-external/odfSubscription.yaml
@@ -7,7 +7,7 @@ metadata:
   name: odf-operator
   namespace: openshift-storage
 spec:
-  channel: "stable-4.21"
+  channel: "stable-5.0"
   name: odf-operator
   source: redhat-operators-disconnected
   sourceNamespace: openshift-marketplace

--- a/telco-core/configuration/reference-crs/custom-manifests/subscription-validator.yaml
+++ b/telco-core/configuration/reference-crs/custom-manifests/subscription-validator.yaml
@@ -12,7 +12,7 @@ object-templates-raw: |
         name: {{ .metadata.name }}
         namespace: {{ .metadata.namespace }}
         annotations:
-          ztp-validated: "4.22"
+          ztp-validated: "5.0"
       status:
         state: AtLatestKnown
   {{- end }}

--- a/telco-core/configuration/reference-crs/optional/logging/ClusterLogSubscription.yaml
+++ b/telco-core/configuration/reference-crs/optional/logging/ClusterLogSubscription.yaml
@@ -5,7 +5,7 @@ metadata:
   name: cluster-logging
   namespace: openshift-logging
 spec:
-  channel: "stable-6.5"
+  channel: "stable-6.6"
   name: cluster-logging
   source: redhat-operators-disconnected
   sourceNamespace: openshift-marketplace

--- a/telco-core/configuration/reference-crs/optional/other/ClusterVersion.yaml
+++ b/telco-core/configuration/reference-crs/optional/other/ClusterVersion.yaml
@@ -5,7 +5,7 @@ kind: ClusterVersion
 metadata:
   name: version
 spec:
-  channel: stable-4.22
+  channel: stable-5.0
   upstream: https://api.openshift.com/api/upgrades_info/v1/graph  # default upstream.
 # add these changes using PG overlay to generate the policy to perform and verify platform upgrade.
 #  desiredUpdate:

--- a/telco-core/configuration/reference-crs/required/scheduling/NROPSubscription.yaml
+++ b/telco-core/configuration/reference-crs/required/scheduling/NROPSubscription.yaml
@@ -7,7 +7,7 @@ metadata:
   name: numaresources-operator
   namespace: openshift-numaresources
 spec:
-  channel: "4.22"
+  channel: "5.0"
   name: numaresources-operator
   source: redhat-operators-disconnected
   sourceNamespace: openshift-marketplace

--- a/telco-core/configuration/reference-crs/required/storage/odf-external/odfSubscription.yaml
+++ b/telco-core/configuration/reference-crs/required/storage/odf-external/odfSubscription.yaml
@@ -7,7 +7,7 @@ metadata:
   name: odf-operator
   namespace: openshift-storage
 spec:
-  channel: "stable-4.21"
+  channel: "stable-5.0"
   name: odf-operator
   source: redhat-operators-disconnected
   sourceNamespace: openshift-marketplace

--- a/telco-core/install/example-standard-clusterinstance.yaml
+++ b/telco-core/install/example-standard-clusterinstance.yaml
@@ -16,7 +16,7 @@ spec:
   baseDomain: example.com
   pullSecretRef:
     name: "assisted-deployment-pull-secret"
-  clusterImageSetNameRef: "openshift-v4.22"
+  clusterImageSetNameRef: "openshift-v5.0"
   sshPublicKey: "ssh-ed25519 AAAA...."
   clusterName: "example-standard"
   networkType: "OVNKubernetes"
@@ -29,7 +29,7 @@ spec:
   extraLabels:
     ManagedCluster:
       common: "core"
-      version: "4.22"
+      version: "5.0"
       region: "zone-1"
   clusterNetwork:
     - cidr: 10.128.0.0/14

--- a/telco-hub/configuration/example-overlays-config/acm/options-agentserviceconfig-patch.yaml
+++ b/telco-hub/configuration/example-overlays-config/acm/options-agentserviceconfig-patch.yaml
@@ -19,11 +19,6 @@
   path: "/spec/osImages"
   value:
     - cpuArchitecture: x86_64
-      openshiftVersion: "4.20"
-      rootFSUrl: https://mirror.example.com/pub/openshift-v4/x86_64/dependencies/rhcos/4.20/latest/rhcos-live-rootfs.x86_64.img
-      url: https://mirror.example.com/pub/openshift-v4/x86_64/dependencies/rhcos/4.20/latest/rhcos-live-iso.x86_64.iso
-      version: 9.6.20250530-0
-    - cpuArchitecture: x86_64
       openshiftVersion: "4.21"
       rootFSUrl: https://mirror.example.com/pub/openshift-v4/x86_64/dependencies/rhcos/4.21/latest/rhcos-live-rootfs.x86_64.img
       url: https://mirror.example.com/pub/openshift-v4/x86_64/dependencies/rhcos/4.21/latest/rhcos-live-iso.x86_64.iso
@@ -33,6 +28,11 @@
       rootFSUrl: https://mirror.example.com/pub/openshift-v4/x86_64/dependencies/rhcos/4.22/latest/rhcos-live-rootfs.x86_64.img
       url: https://mirror.example.com/pub/openshift-v4/x86_64/dependencies/rhcos/4.22/latest/rhcos-live-iso.x86_64.iso
       version: 9.6.20251212-1
+    - cpuArchitecture: x86_64
+      openshiftVersion: "5.0"
+      rootFSUrl: https://mirror.example.com/pub/openshift-v4/x86_64/dependencies/rhcos/5.0/latest/rhcos-live-rootfs.x86_64.img
+      url: https://mirror.example.com/pub/openshift-v4/x86_64/dependencies/rhcos/5.0/latest/rhcos-live-iso.x86_64.iso
+      version: 9.6.YYYYMMDD-0
 
 # when disconnected, the spoke clusters will need to use also a mirrored registry. That could be configured here:
 # https://issues.redhat.com/browse/CNF-17835

--- a/telco-hub/configuration/example-overlays-config/registry/catalog-source-image-patch.yaml
+++ b/telco-hub/configuration/example-overlays-config/registry/catalog-source-image-patch.yaml
@@ -1,4 +1,4 @@
 ---
 - op: replace
   path: /spec/image
-  value: <registry.example.com:8443>/openshift-marketplace/redhat-operators-disconnected:v4.22
+  value: <registry.example.com:8443>/openshift-marketplace/redhat-operators-disconnected:v5.0

--- a/telco-hub/configuration/reference-crs-kube-compare/ReferenceVersionCheck.yaml
+++ b/telco-hub/configuration/reference-crs-kube-compare/ReferenceVersionCheck.yaml
@@ -5,4 +5,4 @@ metadata:
   name: version
 status:
   desired:
-    version: {{ template "versionMatch" (list .status.desired.version "4.22") }}
+    version: {{ template "versionMatch" (list .status.desired.version "5.0") }}

--- a/telco-hub/configuration/reference-crs-kube-compare/default_value.yaml
+++ b/telco-hub/configuration/reference-crs-kube-compare/default_value.yaml
@@ -172,11 +172,6 @@ required_acm_acmAgentServiceConfig:
       name: mirror-registry-config
     osImages:
     - cpuArchitecture: "x86_64"
-      openshiftVersion: "4.20"
-      rootFSUrl: http://<http-server-address:port>/rhcos-4.20.0-x86_64-live-rootfs.x86_64.img
-      url: http://<http-server-address:port>/rhcos-4.20.0-x86_64-live-iso.x86_64.iso
-      version: "9.6.20250530-0"
-    - cpuArchitecture: "x86_64"
       openshiftVersion: "4.21"
       rootFSUrl: https://mirror.example.com/pub/openshift-v4/x86_64/dependencies/rhcos/4.21/latest/rhcos-live-rootfs.x86_64.img
       url: https://mirror.example.com/pub/openshift-v4/x86_64/dependencies/rhcos/4.21/latest/rhcos-live-iso.x86_64.iso
@@ -186,6 +181,11 @@ required_acm_acmAgentServiceConfig:
       rootFSUrl: https://mirror.example.com/pub/openshift-v4/x86_64/dependencies/rhcos/4.22/latest/rhcos-live-rootfs.x86_64.img
       url: https://mirror.example.com/pub/openshift-v4/x86_64/dependencies/rhcos/4.22/latest/rhcos-live-iso.x86_64.iso
       version: "9.6.20251212-1"
+    - cpuArchitecture: "x86_64"
+      openshiftVersion: "5.0"
+      rootFSUrl: https://mirror.example.com/pub/openshift-v4/x86_64/dependencies/rhcos/5.0/latest/rhcos-live-rootfs.x86_64.img
+      url: https://mirror.example.com/pub/openshift-v4/x86_64/dependencies/rhcos/5.0/latest/rhcos-live-iso.x86_64.iso
+      version: "9.6.YYYYMMDD-0"
     osImageVersion: {}
 
 required_acm_acmMirrorRegistryCM:
@@ -352,7 +352,7 @@ required_gitops_argocd_tls_certs_cm:
 # Registry defaults
 required_registry_catalog_source:
 - spec:
-    image: <registry.example.com:8443>/openshift-marketplace/redhat-operators-disconnected:v4.22
+    image: <registry.example.com:8443>/openshift-marketplace/redhat-operators-disconnected:v5.0
 
 required_registry_idms_operator:
 - spec:

--- a/telco-hub/configuration/reference-crs-kube-compare/metadata.yaml
+++ b/telco-hub/configuration/reference-crs-kube-compare/metadata.yaml
@@ -4,7 +4,7 @@ parts:
   - name: version-check
     description: |-
       A mismatch here means you may be using the wrong reference.
-      This reference was designed for OpenShift 4.22.
+      This reference was designed for OpenShift 5.0.
     components:
       - name: version-check
         allOf:
@@ -42,7 +42,7 @@ parts:
     components:
       - name: local-storage-operator
         description: |-
-          https://docs.redhat.com/en/documentation/openshift_container_platform/4.22/html/scalability_and_performance/telco-hub-ref-design-specs#telco-hub-local-storage-operator_telco-hub
+          https://docs.redhat.com/en/documentation/openshift_container_platform/5.0/html/scalability_and_performance/telco-hub-ref-design-specs#telco-hub-local-storage-operator_telco-hub
         allOrNoneOf:
           - path: optional/lso/lsoNS.yaml
           - path: optional/lso/lsoOperatorGroup.yaml
@@ -50,7 +50,7 @@ parts:
           - path: optional/lso/lsoLocalVolume.yaml
       - name: odf-internal-operator
         description: |-
-          https://docs.redhat.com/en/documentation/openshift_container_platform/4.22/html/scalability_and_performance/telco-hub-ref-design-specs#telco-hub-openshift-data-foundation_telco-hub
+          https://docs.redhat.com/en/documentation/openshift_container_platform/5.0/html/scalability_and_performance/telco-hub-ref-design-specs#telco-hub-openshift-data-foundation_telco-hub
         allOrNoneOf:
           - path: optional/odf-internal/odfNS.yaml
           - path: optional/odf-internal/odfOperatorGroup.yaml
@@ -60,14 +60,14 @@ parts:
               ignore-unspecified-fields: true
   - name: required-talm
     description: |-
-      https://docs.redhat.com/en/documentation/openshift_container_platform/4.22/html/scalability_and_performance/telco-hub-ref-design-specs#telco-hub-topology-aware-lifecycle-manager-talm_telco-hub
+      https://docs.redhat.com/en/documentation/openshift_container_platform/5.0/html/scalability_and_performance/telco-hub-ref-design-specs#telco-hub-topology-aware-lifecycle-manager-talm_telco-hub
     components:
       - name: talm-operator
         allOf:
           - path: required/talm/talmSubscription.yaml
   - name: required-acm
     description: |-
-      https://docs.redhat.com/en/documentation/openshift_container_platform/4.22/html/scalability_and_performance/telco-hub-ref-design-specs#telco-hub-red-hat-advanced-cluster-management-rhacm_telco-hub
+      https://docs.redhat.com/en/documentation/openshift_container_platform/5.0/html/scalability_and_performance/telco-hub-ref-design-specs#telco-hub-red-hat-advanced-cluster-management-rhacm_telco-hub
     components:
       - name: acm-operator
         allOf:
@@ -104,7 +104,7 @@ parts:
           - path: required/acm/thanosSecretPlacementBinding.yaml
   - name: required-gitops
     description: |-
-      https://docs.redhat.com/en/documentation/openshift_container_platform/4.22/html/scalability_and_performance/telco-hub-ref-design-specs#telco-hub-gitops-operator-and-ztp-plugins_telco-hub
+      https://docs.redhat.com/en/documentation/openshift_container_platform/5.0/html/scalability_and_performance/telco-hub-ref-design-specs#telco-hub-gitops-operator-and-ztp-plugins_telco-hub
     components:
       - name: gitops-operator
         allOf:
@@ -131,7 +131,7 @@ parts:
           - path: required/gitops/argocd-ssh-known-hosts-cm.yaml
   - name: required-registry
     description: |-
-      https://docs.redhat.com/en/documentation/openshift_container_platform/4.22/html/disconnected_environments/about-installing-oc-mirror-v2
+      https://docs.redhat.com/en/documentation/openshift_container_platform/5.0/html/disconnected_environments/about-installing-oc-mirror-v2
     components:
       - name: registry-config
         allOf:
@@ -148,7 +148,7 @@ parts:
 
   - name: optional-logging
     description: |-
-      https://docs.redhat.com/en/documentation/openshift_container_platform/4.22/html/scalability_and_performance/telco-hub-ref-design-specs#telco-hub-logging_telco-hub
+      https://docs.redhat.com/en/documentation/openshift_container_platform/5.0/html/scalability_and_performance/telco-hub-ref-design-specs#telco-hub-logging_telco-hub
     components:
       - name: cluster-logging-operator
         allOrNoneOf:

--- a/telco-hub/configuration/reference-crs-kube-compare/optional/logging/clusterLogSubscription.yaml
+++ b/telco-hub/configuration/reference-crs-kube-compare/optional/logging/clusterLogSubscription.yaml
@@ -7,7 +7,7 @@ metadata:
   name: cluster-logging
   namespace: openshift-logging
 spec:
-  channel: "stable-6.5"
+  channel: "stable-6.6"
   name: cluster-logging
   source: {{ .spec.source }}
   sourceNamespace: openshift-marketplace

--- a/telco-hub/configuration/reference-crs-kube-compare/optional/odf-internal/odfSubscription.yaml
+++ b/telco-hub/configuration/reference-crs-kube-compare/optional/odf-internal/odfSubscription.yaml
@@ -7,7 +7,7 @@ metadata:
   name: odf-operator
   namespace: openshift-storage
 spec:
-  channel: "stable-4.21"
+  channel: "stable-5.0"
   name: odf-operator
   source: {{ .spec.source }}
   sourceNamespace: openshift-marketplace

--- a/telco-hub/configuration/reference-crs-kube-compare/required/acm/acmSubscription.yaml
+++ b/telco-hub/configuration/reference-crs-kube-compare/required/acm/acmSubscription.yaml
@@ -7,7 +7,7 @@ metadata:
   name: open-cluster-management-subscription
   namespace: open-cluster-management
 spec:
-  channel: release-2.17
+  channel: release-5.0
   installPlanApproval: Automatic
   name: advanced-cluster-management
   source: {{ .spec.source }}

--- a/telco-hub/configuration/reference-crs-kube-compare/required/gitops/gitopsSubscription.yaml
+++ b/telco-hub/configuration/reference-crs-kube-compare/required/gitops/gitopsSubscription.yaml
@@ -7,7 +7,7 @@ metadata:
   name: openshift-gitops-operator
   namespace: openshift-gitops-operator
 spec:
-  channel: gitops-1.20
+  channel: gitops-1.21
   installPlanApproval: Automatic
   name: openshift-gitops-operator
   source: {{ .spec.source }}

--- a/telco-hub/configuration/reference-crs/optional/logging/clusterLogSubscription.yaml
+++ b/telco-hub/configuration/reference-crs/optional/logging/clusterLogSubscription.yaml
@@ -7,7 +7,7 @@ metadata:
   name: cluster-logging
   namespace: openshift-logging
 spec:
-  channel: "stable-6.5"
+  channel: "stable-6.6"
   name: cluster-logging
   source: redhat-operators-disconnected
   sourceNamespace: openshift-marketplace

--- a/telco-hub/configuration/reference-crs/optional/odf-internal/odfSubscription.yaml
+++ b/telco-hub/configuration/reference-crs/optional/odf-internal/odfSubscription.yaml
@@ -7,7 +7,7 @@ metadata:
   name: odf-operator
   namespace: openshift-storage
 spec:
-  channel: "stable-4.21"
+  channel: "stable-5.0"
   name: odf-operator
   source: redhat-operators-disconnected
   sourceNamespace: openshift-marketplace

--- a/telco-hub/configuration/reference-crs/required/acm/acmAgentServiceConfig.yaml
+++ b/telco-hub/configuration/reference-crs/required/acm/acmAgentServiceConfig.yaml
@@ -34,11 +34,6 @@ spec:
   # Replace <http-server-address:port> with the address of the local web server that stores the RHCOS images.
   # The images can be downloaded from "https://mirror.openshift.com/pub/openshift-v4/x86_64/dependencies/rhcos/".
   - cpuArchitecture: "x86_64"
-    openshiftVersion: "4.20"
-    rootFSUrl: http://<http-server-address:port>/rhcos-4.20.0-x86_64-live-rootfs.x86_64.img
-    url: http://<http-server-address:port>/rhcos-4.20.0-x86_64-live-iso.x86_64.iso
-    version: "9.6.20250530-0"
-  - cpuArchitecture: "x86_64"
     openshiftVersion: "4.21"
     rootFSUrl: https://mirror.example.com/pub/openshift-v4/x86_64/dependencies/rhcos/4.21/latest/rhcos-live-rootfs.x86_64.img
     url: https://mirror.example.com/pub/openshift-v4/x86_64/dependencies/rhcos/4.21/latest/rhcos-live-iso.x86_64.iso
@@ -48,3 +43,8 @@ spec:
     rootFSUrl: https://mirror.example.com/pub/openshift-v4/x86_64/dependencies/rhcos/4.22/latest/rhcos-live-rootfs.x86_64.img
     url: https://mirror.example.com/pub/openshift-v4/x86_64/dependencies/rhcos/4.22/latest/rhcos-live-iso.x86_64.iso
     version: "9.6.20251212-1"
+  - cpuArchitecture: "x86_64"
+    openshiftVersion: "5.0"
+    rootFSUrl: https://mirror.example.com/pub/openshift-v4/x86_64/dependencies/rhcos/5.0/latest/rhcos-live-rootfs.x86_64.img
+    url: https://mirror.example.com/pub/openshift-v4/x86_64/dependencies/rhcos/5.0/latest/rhcos-live-iso.x86_64.iso
+    version: "9.6.YYYYMMDD-0"

--- a/telco-hub/configuration/reference-crs/required/acm/acmSubscription.yaml
+++ b/telco-hub/configuration/reference-crs/required/acm/acmSubscription.yaml
@@ -7,7 +7,7 @@ metadata:
   name: open-cluster-management-subscription
   namespace: open-cluster-management
 spec:
-  channel: release-2.17
+  channel: release-5.0
   installPlanApproval: Automatic
   name: advanced-cluster-management
   source: redhat-operators-disconnected

--- a/telco-hub/configuration/reference-crs/required/gitops/addPluginsPolicy.yaml
+++ b/telco-hub/configuration/reference-crs/required/gitops/addPluginsPolicy.yaml
@@ -77,7 +77,7 @@ spec:
                         terminationMessagePath: "/dev/termination-log"
                         image: "registry.redhat.io/openshift5/ztp-site-generate-rhel9:v5.0"
                       - name: "policy-generator-install"
-                        image: "registry.redhat.io/rhacm2/multicluster-operators-subscription-rhel9:v2.17"
+                        image: "registry.redhat.io/rhacm2/multicluster-operators-subscription-rhel9:v5.0"
                         imagePullPolicy: "Always"
                         volumeMounts:
                           - name: "kustomize"

--- a/telco-hub/configuration/reference-crs/required/gitops/gitopsSubscription.yaml
+++ b/telco-hub/configuration/reference-crs/required/gitops/gitopsSubscription.yaml
@@ -7,7 +7,7 @@ metadata:
   name: openshift-gitops-operator
   namespace: openshift-gitops-operator
 spec:
-  channel: gitops-1.20
+  channel: gitops-1.21
   installPlanApproval: Automatic
   name: openshift-gitops-operator
   source: redhat-operators-disconnected

--- a/telco-hub/configuration/reference-crs/required/registry/catalog-source.yaml
+++ b/telco-hub/configuration/reference-crs/required/registry/catalog-source.yaml
@@ -8,6 +8,6 @@ metadata:
   namespace: openshift-marketplace
 spec:
   displayName: Disconnected Red Hat Operators
-  image: <registry.example.com:8443>/openshift-marketplace/redhat-operators-disconnected:v4.22
+  image: <registry.example.com:8443>/openshift-marketplace/redhat-operators-disconnected:v5.0
   publisher: Red Hat
   sourceType: grpc

--- a/telco-hub/install/mirror-registry/imageset-config.yaml
+++ b/telco-hub/install/mirror-registry/imageset-config.yaml
@@ -4,30 +4,30 @@ apiVersion: mirror.openshift.io/v2alpha1
 mirror:
   platform:
     channels:
-    - name: stable-4.22
+    - name: stable-5.0
       type: ocp
       # Adjust minVersion and maxVersion according to your required releases. This allows you to
       # minimize the mirrored content to only what is needed for your deployment. Note that only
       # versions which are mirrored to the disconnected registry can be installed, so only versions
       # listed here should be referenced in installation CRs (eg ClusterImageSet / imageSetRef).
-      minVersion: 4.22.0
-      maxVersion: 4.22.2
+      minVersion: 5.0.0
+      maxVersion: 5.0.2
   operators:
-  - catalog: registry.redhat.io/redhat/redhat-operator-index:v4.22
+  - catalog: registry.redhat.io/redhat/redhat-operator-index:v5.0
     targetCatalog: openshift-marketplace/redhat-operators-disconnected
     packages:
     - name: advanced-cluster-management
-      defaultChannel: release-2.17
+      defaultChannel: release-5.0
       channels:
-      - name: release-2.17
+      - name: release-5.0
     - name: multicluster-engine
-      defaultChannel: stable-2.12
+      defaultChannel: stable-5.0
       channels:
-      - name: stable-2.12
+      - name: stable-5.0
     - name: openshift-gitops-operator
-      defaultChannel: gitops-1.20
+      defaultChannel: gitops-1.21
       channels:
-      - name: gitops-1.20
+      - name: gitops-1.21
     - name: redhat-oadp-operator
       channels:
       - name: stable
@@ -38,65 +38,65 @@ mirror:
       channels:
       - name: stable
     - name: cluster-logging
-      defaultChannel: stable-6.5
+      defaultChannel: stable-6.6
       channels:
-      - name: stable-6.5
+      - name: stable-6.6
     - name: odf-operator
-      defaultChannel: stable-4.21
+      defaultChannel: stable-5.0
       channels:
-      - name: stable-4.21
+      - name: stable-5.0
     - name: odf-external-snapshotter-operator
-      defaultChannel: stable-4.21
+      defaultChannel: stable-5.0
       channels:
-      - name: stable-4.21
+      - name: stable-5.0
     - name: odf-dependencies
-      defaultChannel: stable-4.21
+      defaultChannel: stable-5.0
       channels:
-      - name: stable-4.21
+      - name: stable-5.0
     - name: odf-csi-addons-operator
-      defaultChannel: stable-4.21
+      defaultChannel: stable-5.0
       channels:
-      - name: stable-4.21
+      - name: stable-5.0
     - name: ocs-client-operator
-      defaultChannel: stable-4.21
+      defaultChannel: stable-5.0
       channels:
-      - name: stable-4.21
+      - name: stable-5.0
     - name: cephcsi-operator
-      defaultChannel: stable-4.21
+      defaultChannel: stable-5.0
       channels:
-      - name: stable-4.21
+      - name: stable-5.0
     - name: odf-prometheus-operator
-      defaultChannel: stable-4.21
+      defaultChannel: stable-5.0
       channels:
-      - name: stable-4.21
+      - name: stable-5.0
     - name: odf-multicluster-orchestrator
-      defaultChannel: stable-4.21
+      defaultChannel: stable-5.0
       channels:
-      - name: stable-4.21
+      - name: stable-5.0
     - name: ocs-operator
-      defaultChannel: stable-4.21
+      defaultChannel: stable-5.0
       channels:
-      - name: stable-4.21
+      - name: stable-5.0
     - name: rook-ceph-operator
-      defaultChannel: stable-4.21
+      defaultChannel: stable-5.0
       channels:
-      - name: stable-4.21
+      - name: stable-5.0
     - name: mcg-operator
-      defaultChannel: stable-4.21
+      defaultChannel: stable-5.0
       channels:
-      - name: stable-4.21
+      - name: stable-5.0
     - name: odr-hub-operator
-      defaultChannel: stable-4.21
+      defaultChannel: stable-5.0
       channels:
-      - name: stable-4.21
+      - name: stable-5.0
     - name: odr-cluster-operator
-      defaultChannel: stable-4.21
+      defaultChannel: stable-5.0
       channels:
-      - name: stable-4.21
+      - name: stable-5.0
     - name: recipe
-      defaultChannel: stable-4.21
+      defaultChannel: stable-5.0
       channels:
-      - name: stable-4.21
+      - name: stable-5.0
     - name: openshift-cert-manager-operator
       defaultChannel: stable-v1
       channels:

--- a/telco-ran/configuration/acmpolicygenerator/ran-common.yaml
+++ b/telco-ran/configuration/acmpolicygenerator/ran-common.yaml
@@ -37,7 +37,7 @@ policies:
           name: redhat-operators-disconnected
         spec:
           displayName: disconnected-redhat-operators
-          image: registry.example.com:5000/disconnected-redhat-operators/disconnected-redhat-operator-index:v4.22
+          image: registry.example.com:5000/disconnected-redhat-operators/disconnected-redhat-operator-index:v5.0
     - path: source-crs/disconnected-registry/DisconnectedIDMS.yaml
       patches:
       - spec:

--- a/telco-ran/configuration/argocd/deployment/openshift-gitops-operator.yaml
+++ b/telco-ran/configuration/argocd/deployment/openshift-gitops-operator.yaml
@@ -9,7 +9,7 @@ metadata:
   name: openshift-gitops-operator
   namespace: openshift-operators
 spec:
-  channel: gitops-1.20
+  channel: gitops-1.21
   name: openshift-gitops-operator
   source: redhat-operators
   sourceNamespace: openshift-marketplace

--- a/telco-ran/configuration/kube-compare-reference/cluster-logging/ClusterLogSubscription.yaml
+++ b/telco-ran/configuration/kube-compare-reference/cluster-logging/ClusterLogSubscription.yaml
@@ -6,7 +6,7 @@ metadata:
   annotations:
     ran.openshift.io/ztp-deploy-wave: "2"
 spec:
-  channel: "stable-6.5"
+  channel: "stable-6.6"
   name: cluster-logging
   source: {{ .spec.source }}
   sourceNamespace: openshift-marketplace

--- a/telco-ran/configuration/kube-compare-reference/metadata.yaml
+++ b/telco-ran/configuration/kube-compare-reference/metadata.yaml
@@ -3,7 +3,7 @@ parts:
   - name: version-check
     description: |-
       A mismatch here means you may be using the wrong reference.
-      This reference was designed for OpenShift 4.22.
+      This reference was designed for OpenShift 5.0.
     components:
       - name: version-check
         allOf:
@@ -35,7 +35,7 @@ parts:
                 - allowStatusCheck
   - name: required-cluster-logging
     description: |-
-      https://docs.redhat.com/en/documentation/openshift_container_platform/4.22/html/scalability_and_performance/telco-ran-du-ref-design-specs#telco-ran-logging_telco-ran-du
+      https://docs.redhat.com/en/documentation/openshift_container_platform/5.0/html/scalability_and_performance/telco-ran-du-ref-design-specs#telco-ran-logging_telco-ran-du
     components:
       - name: cluster-logging
         allOf:
@@ -51,7 +51,7 @@ parts:
           - path: cluster-logging/ClusterLogServiceAccountInfrastructureBinding.yaml
   - name: required-cluster-tuning
     description: |-
-      https://docs.redhat.com/en/documentation/openshift_container_platform/4.22/html/scalability_and_performance/telco-ran-du-ref-design-specs#telco-ran-cluster-tuning_telco-ran-du
+      https://docs.redhat.com/en/documentation/openshift_container_platform/5.0/html/scalability_and_performance/telco-ran-du-ref-design-specs#telco-ran-cluster-tuning_telco-ran-du
     components:
       - name: cluster-tuning
         allOf:
@@ -72,7 +72,7 @@ parts:
           - path: cluster-tuning/DisableOLMPprof.yaml
   - name: optional-lca
     description: |-
-      https://docs.redhat.com/en/documentation/openshift_container_platform/4.22/html/scalability_and_performance/telco-ran-du-ref-design-specs#telco-ran-lca-operator_telco-ran-du
+      https://docs.redhat.com/en/documentation/openshift_container_platform/5.0/html/scalability_and_performance/telco-ran-du-ref-design-specs#telco-ran-lca-operator_telco-ran-du
     components:
       - name: lca
         allOrNoneOf:
@@ -85,7 +85,7 @@ parts:
   - name: optional-nmstate-operator
     description: |-
       The nmstate operator is only used in multinode clusters when required by IPSec:
-        https://docs.openshift.com/container-platform/4.22/edge_computing/ztp-deploying-far-edge-sites.html#ztp-configuring-ipsec-using-ztp-and-siteconfig-for-mno_ztp-deploying-far-edge-sites
+        https://docs.openshift.com/container-platform/5.0/edge_computing/ztp-deploying-far-edge-sites.html#ztp-configuring-ipsec-using-ztp-and-siteconfig-for-mno_ztp-deploying-far-edge-sites
     components:
       - name: nmstate-operator
         allOrNoneOf:
@@ -100,7 +100,7 @@ parts:
           - path: nmstate/NMState.yaml
   - name: required-machine-config
     description: |-
-      https://docs.redhat.com/en/documentation/openshift_container_platform/4.22/html/scalability_and_performance/telco-ran-du-ref-design-specs#telco-ran-machine-configuration_telco-ran-du
+      https://docs.redhat.com/en/documentation/openshift_container_platform/5.0/html/scalability_and_performance/telco-ran-du-ref-design-specs#telco-ran-machine-configuration_telco-ran-du
     components:
       - name: machine-config
         allOf:
@@ -124,7 +124,7 @@ parts:
           - path: machine-config/01-disk-encryption-pcr-rebind-worker.yaml
   - name: required-node-tuning-operator
     description: |-
-      https://docs.redhat.com/en/documentation/openshift_container_platform/4.22/html/scalability_and_performance/telco-ran-du-ref-design-specs#telco-ran-node-tuning-operator_telco-ran-du
+      https://docs.redhat.com/en/documentation/openshift_container_platform/5.0/html/scalability_and_performance/telco-ran-du-ref-design-specs#telco-ran-node-tuning-operator_telco-ran-du
     components:
       - name: node-tuning-operator
         allOf:
@@ -139,7 +139,7 @@ parts:
                   inlineDiffFunc: capturegroups
   - name: required-ptp-operator
     description: |-
-      https://docs.redhat.com/en/documentation/openshift_container_platform/4.22/html/scalability_and_performance/telco-ran-du-ref-design-specs#telco-ran-ptp-operator_telco-ran-du
+      https://docs.redhat.com/en/documentation/openshift_container_platform/5.0/html/scalability_and_performance/telco-ran-du-ref-design-specs#telco-ran-ptp-operator_telco-ran-du
     components:
       - name: ptp-operator
         allOf:
@@ -151,7 +151,7 @@ parts:
           - path: ptp-operator/PtpSubscriptionOperGroup.yaml
   - name: required-sriov-operator
     description: |-
-      https://docs.redhat.com/en/documentation/openshift_container_platform/4.22/html/scalability_and_performance/telco-ran-du-ref-design-specs#telco-ran-sr-iov-operator_telco-ran-du
+      https://docs.redhat.com/en/documentation/openshift_container_platform/5.0/html/scalability_and_performance/telco-ran-du-ref-design-specs#telco-ran-sr-iov-operator_telco-ran-du
     components:
       - name: sriov-operator
         allOf:
@@ -172,7 +172,7 @@ parts:
           - path: sriov-operator/SriovOperatorConfigForSNO.yaml
   - name: optional-storage-lso
     description: |-
-      https://docs.redhat.com/en/documentation/openshift_container_platform/4.22/html/scalability_and_performance/telco-ran-du-ref-design-specs#telco-ran-local-storage-operator_telco-ran-du
+      https://docs.redhat.com/en/documentation/openshift_container_platform/5.0/html/scalability_and_performance/telco-ran-du-ref-design-specs#telco-ran-local-storage-operator_telco-ran-du
     components:
       - name: storage-lso
         allOrNoneOf:
@@ -184,7 +184,7 @@ parts:
                 - subscriptions
   - name: optional-storage-lvm
     description: |-
-      https://docs.redhat.com/en/documentation/openshift_container_platform/4.22/html/scalability_and_performance/telco-ran-du-ref-design-specs#telco-ran-lvms-operator_telco-ran-du
+      https://docs.redhat.com/en/documentation/openshift_container_platform/5.0/html/scalability_and_performance/telco-ran-du-ref-design-specs#telco-ran-lvms-operator_telco-ran-du
     components:
       - name: storage-operator
         allOrNoneOf:
@@ -198,14 +198,14 @@ parts:
           - path: storage-lvm/StoragePV.yaml
   - name: optional-storage-config
     description: |-
-      https://docs.redhat.com/en/documentation/openshift_container_platform/4.22/html/scalability_and_performance/telco-ran-du-ref-design-specs#telco-ran-lvms-operator_telco-ran-du
+      https://docs.redhat.com/en/documentation/openshift_container_platform/5.0/html/scalability_and_performance/telco-ran-du-ref-design-specs#telco-ran-lvms-operator_telco-ran-du
     components:
       - name: local-storage-config
         anyOf:
           - path: storage-lvm/StoragePVC.yaml
   - name: optional-storage
     description: |-
-      https://docs.redhat.com/en/documentation/openshift_container_platform/4.22/html/scalability_and_performance/telco-ran-du-ref-design-specs#telco-ran-local-storage-operator_telco-ran-du
+      https://docs.redhat.com/en/documentation/openshift_container_platform/5.0/html/scalability_and_performance/telco-ran-du-ref-design-specs#telco-ran-local-storage-operator_telco-ran-du
     components:
       - name: storage
         allOrNoneOf:
@@ -217,7 +217,7 @@ parts:
               ignore-unspecified-fields: true
   - name: optional-sriov-fec-operator
     description: |-
-      https://docs.redhat.com/en/documentation/openshift_container_platform/4.22/html/scalability_and_performance/telco-ran-du-ref-design-specs#telco-ran-sriov-fec-operator_telco-ran-du
+      https://docs.redhat.com/en/documentation/openshift_container_platform/5.0/html/scalability_and_performance/telco-ran-du-ref-design-specs#telco-ran-sriov-fec-operator_telco-ran-du
     components:
       - name: sriov-fec-operator
         allOrNoneOf:
@@ -233,7 +233,7 @@ parts:
           - path: sriov-fec-operator/SriovVrbClusterConfig.yaml
   - name: optional-image-registry
     description: |-
-      https://docs.redhat.com/en/documentation/openshift_container_platform/4.22/html/scalability_and_performance/telco-ran-du-ref-design-specs#telco-ran-lca-operator_telco-ran-du
+      https://docs.redhat.com/en/documentation/openshift_container_platform/5.0/html/scalability_and_performance/telco-ran-du-ref-design-specs#telco-ran-lca-operator_telco-ran-du
     components:
       - name: image-registry
         allOrNoneOf:
@@ -241,7 +241,7 @@ parts:
           - path: image-registry/ImageRegistryPV.yaml
   - name: optional-ptp-config
     description: |-
-      https://docs.redhat.com/en/documentation/openshift_container_platform/4.22/html/scalability_and_performance/telco-ran-du-ref-design-specs#telco-ran-ptp-operator_telco-ran-du
+      https://docs.redhat.com/en/documentation/openshift_container_platform/5.0/html/scalability_and_performance/telco-ran-du-ref-design-specs#telco-ran-ptp-operator_telco-ran-du
     components:
       - name: ptp-operator-config
         oneOf:
@@ -418,7 +418,7 @@ parts:
                   inlineDiffFunc: capturegroups
   - name: optional-console-disable
     description: |-
-      https://docs.redhat.com/en/documentation/openshift_container_platform/4.22/html/scalability_and_performance/telco-ran-du-ref-design-specs#telco-ran-cluster-tuning_telco-ran-du
+      https://docs.redhat.com/en/documentation/openshift_container_platform/5.0/html/scalability_and_performance/telco-ran-du-ref-design-specs#telco-ran-cluster-tuning_telco-ran-du
     components:
       - name: console-disable
         allOrNoneOf:

--- a/telco-ran/configuration/kube-compare-reference/version-check/ClusterVersionOperator.yaml
+++ b/telco-ran/configuration/kube-compare-reference/version-check/ClusterVersionOperator.yaml
@@ -4,4 +4,4 @@ metadata:
   name: version
 status:
   desired:
-    version: {{ template "versionMatch" (list .status.desired.version "4.22") }}
+    version: {{ template "versionMatch" (list .status.desired.version "5.0") }}

--- a/telco-ran/configuration/policygentemplates/common-ranGen.yaml
+++ b/telco-ran/configuration/policygentemplates/common-ranGen.yaml
@@ -87,7 +87,7 @@ spec:
         name: redhat-operators-disconnected
       spec:
         displayName: disconnected-redhat-operators
-        image: registry.example.com:5000/disconnected-redhat-operators/disconnected-redhat-operator-index:v4.22
+        image: registry.example.com:5000/disconnected-redhat-operators/disconnected-redhat-operator-index:v5.0
     - fileName: disconnected-registry/DisconnectedIDMS.yaml
       policyName: "config-policy"
       spec:

--- a/telco-ran/configuration/source-crs/cluster-logging/ClusterLogSubscription.yaml
+++ b/telco-ran/configuration/source-crs/cluster-logging/ClusterLogSubscription.yaml
@@ -6,7 +6,7 @@ metadata:
   annotations:
     ran.openshift.io/ztp-deploy-wave: "2"
 spec:
-  channel: "stable-6.5"
+  channel: "stable-6.6"
   name: cluster-logging
   source: redhat-operators-disconnected
   sourceNamespace: openshift-marketplace

--- a/telco-ran/install/clusterinstance/example-3node.yaml
+++ b/telco-ran/install/clusterinstance/example-3node.yaml
@@ -11,7 +11,7 @@ spec:
   baseDomain: "example.com"
   pullSecretRef:
     name: "assisted-deployment-pull-secret"
-  clusterImageSetNameRef: "openshift-4.22"
+  clusterImageSetNameRef: "openshift-5.0"
   sshPublicKey: "ssh-rsa AAAA..."
   clusterName: "example-ai-3node"
   clusterType: HighlyAvailable

--- a/telco-ran/install/clusterinstance/example-sno.yaml
+++ b/telco-ran/install/clusterinstance/example-sno.yaml
@@ -11,7 +11,7 @@ spec:
   baseDomain: "example.com"
   pullSecretRef:
     name: "assisted-deployment-pull-secret"
-  clusterImageSetNameRef: "openshift-4.22"
+  clusterImageSetNameRef: "openshift-5.0"
   sshPublicKey: "ssh-rsa AAAA..."
   clusterName: "example-ai-sno"
   networkType: "OVNKubernetes"

--- a/telco-ran/install/clusterinstance/example-standard.yaml
+++ b/telco-ran/install/clusterinstance/example-standard.yaml
@@ -11,7 +11,7 @@ spec:
   baseDomain: "example.com"
   pullSecretRef:
     name: "assisted-deployment-pull-secret"
-  clusterImageSetNameRef: "openshift-4.22"
+  clusterImageSetNameRef: "openshift-5.0"
   sshPublicKey: "ssh-rsa AAAA..."
   clusterName: "example-ai-standard"
   clusterType: HighlyAvailable


### PR DESCRIPTION
- ACM: 5.0
- MCE: 5.0
- GitOps Operator: 1.21
- Cluster Logging Operator: 6.6.1
- ODF: 5.0
- NROP: 5.0

Update policy generators and configurations, ClusterInstance examples to openshift-5.0, day-2 operator subscriptions and catalog source images, subscription validator annotation, mirror registry, and documentation (metadata.yaml URLs from 4.22 to 5.0) across telco-core, telco-ran, and telco-hub.

The numaresources-operator upstream repo has not yet cut a release-5.0 branch, so hack/crd-schema-config.json points its CRD source ref at main pending that branch's creation.