### PR TITLE
CNF-25913 Update CLO to stable-6.6 and ODF to stable-4.22

### DIFF
--- a/telco-core/configuration/core-baseline.yaml
+++ b/telco-core/configuration/core-baseline.yaml
@@ -41,7 +41,7 @@ policies:
               - kind: ClusterServiceVersion
                 namespace: openshift-logging
                 # Update with specific target version
-                name: cluster-logging.v6.5.0
+                name: cluster-logging.v6.6.0
                 conditions:
                   - type: Succeeded
                     status: "True"
@@ -64,7 +64,7 @@ policies:
         patches:
         - spec:
             installPlanApproval: Manual
-            channel: stable-4.21
+            channel: stable-4.22
       - path: reference-crs/required/networking/metallb/metallbNS.yaml
       - path: reference-crs/required/networking/metallb/metallbOperGroup.yaml
       - path: reference-crs/required/networking/metallb/metallbSubscription.yaml

--- a/telco-core/configuration/core-upgrade.yaml
+++ b/telco-core/configuration/core-upgrade.yaml
@@ -87,7 +87,7 @@ policies:
       - path: reference-crs/required/storage/odf-external/odfSubscription.yaml
         patches:
         - spec:
-            channel: stable-4.21
+            channel: stable-4.22
         - status:
             state: AtLatestKnown
       - path: reference-crs/required/networking/NMStateSubscription.yaml

--- a/telco-core/configuration/reference-crs-kube-compare/optional/logging/ClusterLogSubscription.yaml
+++ b/telco-core/configuration/reference-crs-kube-compare/optional/logging/ClusterLogSubscription.yaml
@@ -4,7 +4,7 @@ metadata:
   name: cluster-logging
   namespace: openshift-logging
 spec:
-  channel: "stable-6.5"
+  channel: "stable-6.6"
   name: cluster-logging
   source: {{ .spec.source }}
   sourceNamespace: openshift-marketplace

--- a/telco-core/configuration/reference-crs-kube-compare/required/storage/odf-external/odfSubscription.yaml
+++ b/telco-core/configuration/reference-crs-kube-compare/required/storage/odf-external/odfSubscription.yaml
@@ -7,7 +7,7 @@ metadata:
   name: odf-operator
   namespace: openshift-storage
 spec:
-  channel: "stable-4.21"
+  channel: "stable-4.22"
   name: odf-operator
   source: redhat-operators-disconnected
   sourceNamespace: openshift-marketplace

--- a/telco-core/configuration/reference-crs/optional/logging/ClusterLogSubscription.yaml
+++ b/telco-core/configuration/reference-crs/optional/logging/ClusterLogSubscription.yaml
@@ -5,7 +5,7 @@ metadata:
   name: cluster-logging
   namespace: openshift-logging
 spec:
-  channel: "stable-6.5"
+  channel: "stable-6.6"
   name: cluster-logging
   source: redhat-operators-disconnected
   sourceNamespace: openshift-marketplace

--- a/telco-core/configuration/reference-crs/required/storage/odf-external/odfSubscription.yaml
+++ b/telco-core/configuration/reference-crs/required/storage/odf-external/odfSubscription.yaml
@@ -7,7 +7,7 @@ metadata:
   name: odf-operator
   namespace: openshift-storage
 spec:
-  channel: "stable-4.21"
+  channel: "stable-4.22"
   name: odf-operator
   source: redhat-operators-disconnected
   sourceNamespace: openshift-marketplace

--- a/telco-hub/configuration/reference-crs-kube-compare/optional/logging/clusterLogSubscription.yaml
+++ b/telco-hub/configuration/reference-crs-kube-compare/optional/logging/clusterLogSubscription.yaml
@@ -7,7 +7,7 @@ metadata:
   name: cluster-logging
   namespace: openshift-logging
 spec:
-  channel: "stable-6.5"
+  channel: "stable-6.6"
   name: cluster-logging
   source: {{ .spec.source }}
   sourceNamespace: openshift-marketplace

--- a/telco-hub/configuration/reference-crs-kube-compare/optional/odf-internal/odfSubscription.yaml
+++ b/telco-hub/configuration/reference-crs-kube-compare/optional/odf-internal/odfSubscription.yaml
@@ -7,7 +7,7 @@ metadata:
   name: odf-operator
   namespace: openshift-storage
 spec:
-  channel: "stable-4.21"
+  channel: "stable-4.22"
   name: odf-operator
   source: {{ .spec.source }}
   sourceNamespace: openshift-marketplace

--- a/telco-hub/configuration/reference-crs/optional/logging/clusterLogSubscription.yaml
+++ b/telco-hub/configuration/reference-crs/optional/logging/clusterLogSubscription.yaml
@@ -7,7 +7,7 @@ metadata:
   name: cluster-logging
   namespace: openshift-logging
 spec:
-  channel: "stable-6.5"
+  channel: "stable-6.6"
   name: cluster-logging
   source: redhat-operators-disconnected
   sourceNamespace: openshift-marketplace

--- a/telco-hub/configuration/reference-crs/optional/odf-internal/odfSubscription.yaml
+++ b/telco-hub/configuration/reference-crs/optional/odf-internal/odfSubscription.yaml
@@ -7,7 +7,7 @@ metadata:
   name: odf-operator
   namespace: openshift-storage
 spec:
-  channel: "stable-4.21"
+  channel: "stable-4.22"
   name: odf-operator
   source: redhat-operators-disconnected
   sourceNamespace: openshift-marketplace

--- a/telco-hub/install/mirror-registry/imageset-config.yaml
+++ b/telco-hub/install/mirror-registry/imageset-config.yaml
@@ -38,65 +38,65 @@ mirror:
       channels:
       - name: stable
     - name: cluster-logging
-      defaultChannel: stable-6.5
+      defaultChannel: stable-6.6
       channels:
-      - name: stable-6.5
+      - name: stable-6.6
     - name: odf-operator
-      defaultChannel: stable-4.21
+      defaultChannel: stable-4.22
       channels:
-      - name: stable-4.21
+      - name: stable-4.22
     - name: odf-external-snapshotter-operator
-      defaultChannel: stable-4.21
+      defaultChannel: stable-4.22
       channels:
-      - name: stable-4.21
+      - name: stable-4.22
     - name: odf-dependencies
-      defaultChannel: stable-4.21
+      defaultChannel: stable-4.22
       channels:
-      - name: stable-4.21
+      - name: stable-4.22
     - name: odf-csi-addons-operator
-      defaultChannel: stable-4.21
+      defaultChannel: stable-4.22
       channels:
-      - name: stable-4.21
+      - name: stable-4.22
     - name: ocs-client-operator
-      defaultChannel: stable-4.21
+      defaultChannel: stable-4.22
       channels:
-      - name: stable-4.21
+      - name: stable-4.22
     - name: cephcsi-operator
-      defaultChannel: stable-4.21
+      defaultChannel: stable-4.22
       channels:
-      - name: stable-4.21
+      - name: stable-4.22
     - name: odf-prometheus-operator
-      defaultChannel: stable-4.21
+      defaultChannel: stable-4.22
       channels:
-      - name: stable-4.21
+      - name: stable-4.22
     - name: odf-multicluster-orchestrator
-      defaultChannel: stable-4.21
+      defaultChannel: stable-4.22
       channels:
-      - name: stable-4.21
+      - name: stable-4.22
     - name: ocs-operator
-      defaultChannel: stable-4.21
+      defaultChannel: stable-4.22
       channels:
-      - name: stable-4.21
+      - name: stable-4.22
     - name: rook-ceph-operator
-      defaultChannel: stable-4.21
+      defaultChannel: stable-4.22
       channels:
-      - name: stable-4.21
+      - name: stable-4.22
     - name: mcg-operator
-      defaultChannel: stable-4.21
+      defaultChannel: stable-4.22
       channels:
-      - name: stable-4.21
+      - name: stable-4.22
     - name: odr-hub-operator
-      defaultChannel: stable-4.21
+      defaultChannel: stable-4.22
       channels:
-      - name: stable-4.21
+      - name: stable-4.22
     - name: odr-cluster-operator
-      defaultChannel: stable-4.21
+      defaultChannel: stable-4.22
       channels:
-      - name: stable-4.21
+      - name: stable-4.22
     - name: recipe
-      defaultChannel: stable-4.21
+      defaultChannel: stable-4.22
       channels:
-      - name: stable-4.21
+      - name: stable-4.22
     - name: openshift-cert-manager-operator
       defaultChannel: stable-v1
       channels:

--- a/telco-ran/configuration/kube-compare-reference/cluster-logging/ClusterLogSubscription.yaml
+++ b/telco-ran/configuration/kube-compare-reference/cluster-logging/ClusterLogSubscription.yaml
@@ -6,7 +6,7 @@ metadata:
   annotations:
     ran.openshift.io/ztp-deploy-wave: "2"
 spec:
-  channel: "stable-6.5"
+  channel: "stable-6.6"
   name: cluster-logging
   source: {{ .spec.source }}
   sourceNamespace: openshift-marketplace

--- a/telco-ran/configuration/source-crs/cluster-logging/ClusterLogSubscription.yaml
+++ b/telco-ran/configuration/source-crs/cluster-logging/ClusterLogSubscription.yaml
@@ -6,7 +6,7 @@ metadata:
   annotations:
     ran.openshift.io/ztp-deploy-wave: "2"
 spec:
-  channel: "stable-6.5"
+  channel: "stable-6.6"
   name: cluster-logging
   source: redhat-operators-disconnected
   sourceNamespace: openshift-marketplace


### PR DESCRIPTION
update CLO subscription channel from stable-6.5 to stable-6.6 and ODF from stable-4.21 to stable-4.22 across RAN, Core, and Hub reference configs and cluster compare files
