### PR TITLE
Restore maxUnavailable value after MCPs are updated

### DIFF
--- a/telco-core/configuration/core-upgrade-finish.yaml
+++ b/telco-core/configuration/core-upgrade-finish.yaml
@@ -84,3 +84,22 @@ policies:
         complianceType: mustnothave
       - path: reference-crs/optional/other/precache/worker-releases-pinned-images.yaml
         complianceType: mustnothave
+
+  # Restore original value for maxUnavailable
+  - name: core-custom-mcp-restore-maxavailable-22
+    policyAnnotations:
+      ran.openshift.io/ztp-deploy-wave: "31"
+    manifests:
+      # This sets the desired maxUnavailable on the customMCPs
+      - path: reference-crs/custom-manifests/mcp-worker-1.yaml
+        patches:
+        - spec:
+            maxUnavailable: 1
+      - path: reference-crs/custom-manifests/mcp-worker-2.yaml
+        patches:
+        - spec:
+            maxUnavailable: 1
+      - path: reference-crs/custom-manifests/mcp-worker-3.yaml
+        patches:
+        - spec:
+            maxUnavailable: 1


### PR DESCRIPTION
During update MCP's _maxUnavailable_ is set to 100% to speed up the update and when update is finished it must be restored to its original value.