### PR TITLE
Configure CPU requests for ODF for SMT alignment.

### DIFF
--- a/telco-core/configuration/core-overlay.yaml
+++ b/telco-core/configuration/core-overlay.yaml
@@ -304,6 +304,14 @@ policies:
               external_cluster_details: eyJuYW1lIjoicm9vay1jZXBoLW1vbi1lbmRwb2ludHMiLCJraW5kIjoiQ29uZmlnTWFwIiwiZGF0YSI6eyJkYXRhIjoiY2VwaG5vZGUxPTEuMi4zLjQ6Njc4OSIsIm1heE1vbklkIjoiMCIsIm1hcHBpbmciOiJ7fSJ9fSx7Im5hbWUiOiJyb29rLWNlcGgtbW9uIiwia2luZCI6IlNlY3JldCIsImRhdGEiOnsiYWRtaW4tc2VjcmV0IjoiYWRtaW4tc2VjcmV0IiwiZnNpZCI6IjExMTExMTExLTExMTEtMTExMS0xMTExLTExMTExMTExMTExMSIsIm1vbi1zZWNyZXQiOiJtb24tc2VjcmV0In19LHsibmFtZSI6InJvb2stY2VwaC1vcGVyYXRvci1jcmVkcyIsImtpbmQiOiJTZWNyZXQiLCJkYXRhIjp7InVzZXJJRCI6ImNsaWVudC5oZWFsdGhjaGVja2VyIiwidXNlcktleSI6ImMyVmpjbVYwIn19LHsibmFtZSI6Im1vbml0b3JpbmctZW5kcG9pbnQiLCJraW5kIjoiQ2VwaENsdXN0ZXIiLCJkYXRhIjp7Ik1vbml0b3JpbmdFbmRwb2ludCI6IjEuMi4zLjQsMS4yLjMuMywxLjIuMy4yIiwiTW9uaXRvcmluZ1BvcnQiOiI5MjgzIn19LHsibmFtZSI6ImNlcGgtcmJkIiwia2luZCI6IlN0b3JhZ2VDbGFzcyIsImRhdGEiOnsicG9vbCI6Im9kZl9wb29sIn19LHsibmFtZSI6InJvb2stY3NpLXJiZC1ub2RlIiwia2luZCI6IlNlY3JldCIsImRhdGEiOnsidXNlcklEIjoiY3NpLXJiZC1ub2RlIiwidXNlcktleSI6IiJ9fSx7Im5hbWUiOiJyb29rLWNzaS1yYmQtcHJvdmlzaW9uZXIiLCJraW5kIjoiU2VjcmV0IiwiZGF0YSI6eyJ1c2VySUQiOiJjc2ktcmJkLXByb3Zpc2lvbmVyIiwidXNlcktleSI6ImMyVmpjbVYwIn19LHsibmFtZSI6InJvb2stY3NpLWNlcGhmcy1wcm92aXNpb25lciIsImtpbmQiOiJTZWNyZXQiLCJkYXRhIjp7ImFkbWluSUQiOiJjc2ktY2VwaGZzLXByb3Zpc2lvbmVyIiwiYWRtaW5LZXkiOiIifX0seyJuYW1lIjoicm9vay1jc2ktY2VwaGZzLW5vZGUiLCJraW5kIjoiU2VjcmV0IiwiZGF0YSI6eyJhZG1pbklEIjoiY3NpLWNlcGhmcy1ub2RlIiwiYWRtaW5LZXkiOiJjMlZqY21WMCJ9fSx7Im5hbWUiOiJjZXBoZnMiLCJraW5kIjoiU3RvcmFnZUNsYXNzIiwiZGF0YSI6eyJmc05hbWUiOiJjZXBoZnMiLCJwb29sIjoibWFuaWxhX2RhdGEifX0K
 
       - path: reference-crs/required/storage/odf-external/02-ocs-external-storagecluster.yaml
+        patches:
+          - spec:
+              resources:
+                noobaa-db:
+                  limits:
+                    cpu: "2"
+                  requests:
+                    cpu: "2"
 
   # reference-crs/optional/networking/nodeNetworkConfigurationPolicy.yaml
 


### PR DESCRIPTION
When the pod is scheduled to the nodes with hyperthreading (SMT) enabled, pod scheduling fails with error:
```
Pod was rejected: SMT Alignment Error: requested 1 cpus not multiple cpus per core = 2
```