### PR TITLE
CNF-26773: Remove minOffsetThreshold from PTP config source-crs and reference

### DIFF
--- a/telco-ran/configuration/kube-compare-reference/hack/default_value.yaml
+++ b/telco-ran/configuration/kube-compare-reference/hack/default_value.yaml
@@ -231,7 +231,6 @@ ptp_operator_configuration_PtpConfigBoundaryForEvent:
         - ptpClockThreshold:
             holdOverTimeout: 5
             maxOffsetThreshold: 100
-            minOffsetThreshold: -100
           ptpSettings:
             logReduce: "true"
       recommend:
@@ -273,7 +272,6 @@ ptp_operator_configuration_PtpConfigDualCardGmWpc:
           ptpClockThreshold:
             holdOverTimeout: 5
             maxOffsetThreshold: 100
-            minOffsetThreshold: -100
           ptpSettings:
             logReduce: "true"
       recommend:
@@ -299,7 +297,6 @@ ptp_operator_configuration_PtpConfigDualFollower:
         - ptpClockThreshold:
             holdOverTimeout: 5
             maxOffsetThreshold: 100
-            minOffsetThreshold: -100
           ptpSettings:
             logReduce: "true"
       recommend:
@@ -338,7 +335,6 @@ ptp_operator_configuration_PtpConfigThreeCardGmWpc:
           ptpClockThreshold:
             holdOverTimeout: 5
             maxOffsetThreshold: 100
-            minOffsetThreshold: -100
           ptpSettings:
             logReduce: "true"
       recommend:
@@ -394,7 +390,6 @@ ptp_operator_configuration_PtpConfigForHAForEvent:
         - ptpClockThreshold:
             holdOverTimeout: 5
             maxOffsetThreshold: 100
-            minOffsetThreshold: -100
           ptpSettings:
             logReduce: "true"
       recommend:
@@ -421,7 +416,6 @@ ptp_operator_configuration_PtpConfigMasterForEvent:
           ptpClockThreshold:
             holdOverTimeout: 5
             maxOffsetThreshold: 100
-            minOffsetThreshold: -100
           ptpSettings:
             logReduce: "true"
       recommend:
@@ -460,7 +454,6 @@ ptp_operator_configuration_PtpConfigGmWpc:
           ptpClockThreshold:
             holdOverTimeout: 5
             maxOffsetThreshold: 100
-            minOffsetThreshold: -100
           ptpSettings:
             logReduce: "true"
       recommend:
@@ -487,7 +480,6 @@ ptp_operator_configuration_PtpConfigSlaveForEvent:
           ptpClockThreshold:
             holdOverTimeout: 5
             maxOffsetThreshold: 100
-            minOffsetThreshold: -100
           ptpSettings:
             logReduce: "true"
       recommend:

--- a/telco-ran/configuration/source-crs/ptp-operator/configuration/PtpConfigBoundaryForEvent.yaml
+++ b/telco-ran/configuration/source-crs/ptp-operator/configuration/PtpConfigBoundaryForEvent.yaml
@@ -130,7 +130,6 @@ spec:
     ptpClockThreshold:
       holdOverTimeout: 5
       maxOffsetThreshold: 100
-      minOffsetThreshold: -100
   recommend:
   - profile: "boundary"
     priority: 4

--- a/telco-ran/configuration/source-crs/ptp-operator/configuration/PtpConfigDualCardGmWpc.yaml
+++ b/telco-ran/configuration/source-crs/ptp-operator/configuration/PtpConfigDualCardGmWpc.yaml
@@ -238,7 +238,6 @@ spec:
     ptpClockThreshold:
       holdOverTimeout: 5
       maxOffsetThreshold: 100
-      minOffsetThreshold: -100
   recommend:
   - profile: "grandmaster"
     priority: 4

--- a/telco-ran/configuration/source-crs/ptp-operator/configuration/PtpConfigDualFollower.yaml
+++ b/telco-ran/configuration/source-crs/ptp-operator/configuration/PtpConfigDualFollower.yaml
@@ -124,7 +124,6 @@ spec:
     ptpClockThreshold:
       holdOverTimeout: 5
       maxOffsetThreshold: 100
-      minOffsetThreshold: -100
   recommend:
   - profile: "oc1"
     priority: 4

--- a/telco-ran/configuration/source-crs/ptp-operator/configuration/PtpConfigForHAForEvent.yaml
+++ b/telco-ran/configuration/source-crs/ptp-operator/configuration/PtpConfigForHAForEvent.yaml
@@ -18,7 +18,6 @@ spec:
       ptpClockThreshold:
         holdOverTimeout: 5
         maxOffsetThreshold: 100
-        minOffsetThreshold: -100
   recommend:
   - profile: "boundary-ha"
     priority: 4

--- a/telco-ran/configuration/source-crs/ptp-operator/configuration/PtpConfigGmWpc.yaml
+++ b/telco-ran/configuration/source-crs/ptp-operator/configuration/PtpConfigGmWpc.yaml
@@ -225,7 +225,6 @@ spec:
     ptpClockThreshold:
       holdOverTimeout: 5
       maxOffsetThreshold: 100
-      minOffsetThreshold: -100
   recommend:
   - profile: "grandmaster"
     priority: 4

--- a/telco-ran/configuration/source-crs/ptp-operator/configuration/PtpConfigMasterForEvent.yaml
+++ b/telco-ran/configuration/source-crs/ptp-operator/configuration/PtpConfigMasterForEvent.yaml
@@ -123,7 +123,6 @@ spec:
     ptpClockThreshold:
       holdOverTimeout: 5
       maxOffsetThreshold: 100
-      minOffsetThreshold: -100
   recommend:
   - profile: "grandmaster"
     priority: 4

--- a/telco-ran/configuration/source-crs/ptp-operator/configuration/PtpConfigSlaveForEvent.yaml
+++ b/telco-ran/configuration/source-crs/ptp-operator/configuration/PtpConfigSlaveForEvent.yaml
@@ -121,7 +121,6 @@ spec:
     ptpClockThreshold:
       holdOverTimeout: 5
       maxOffsetThreshold: 100
-      minOffsetThreshold: -100
   recommend:
   - profile: "slave"
     priority: 4

--- a/telco-ran/configuration/source-crs/ptp-operator/configuration/PtpConfigThreeCardGmWpc.yaml
+++ b/telco-ran/configuration/source-crs/ptp-operator/configuration/PtpConfigThreeCardGmWpc.yaml
@@ -264,7 +264,6 @@ spec:
     ptpClockThreshold:
       holdOverTimeout: 5
       maxOffsetThreshold: 100
-      minOffsetThreshold: -100
   recommend:
   - profile: grandmaster
     priority: 4


### PR DESCRIPTION
Remove the minOffsetThreshold field from ptpClockThreshold in all PtpConfig source-crs and the corresponding kube-compare-reference default_value.yaml examples.

Assisted by Claude

/cc @lack 