### PR TITLE
CNF-26666: Fix wrong compare logic for different configuration files

### DIFF
--- a/telco-core/configuration/reference-crs-kube-compare/required/networking/metallb/addr-pool.yaml
+++ b/telco-core/configuration/reference-crs-kube-compare/required/networking/metallb/addr-pool.yaml
@@ -11,10 +11,10 @@ spec:
 {{ .spec.addresses | toYaml | indent 2}}
 {{ end }}
   #- 3.3.3.0/24
-{{ if .spec.autoAssign }}
+{{ if hasKey .spec "autoAssign" }}
   autoAssign: {{ .spec.autoAssign }}
 {{ end }}
-{{ if .spec.avoidBuggyIPs }}
+{{ if hasKey .spec "avoidBuggyIPs" }}
   avoidBuggyIPs: {{ .spec.avoidBuggyIPs }}
 {{ end }}
   ##############

--- a/telco-core/configuration/reference-crs-kube-compare/required/networking/metallb/bfd-profile.yaml
+++ b/telco-core/configuration/reference-crs-kube-compare/required/networking/metallb/bfd-profile.yaml
@@ -12,7 +12,7 @@ spec:
   echoInterval: {{ if .spec.echoInterval }} {{ .spec.echoInterval }} {{ else }} "50ms" {{ end }} # default 50ms
   {{ end }}
   detectMultiplier: {{ if .spec.detectMultiplier }} {{ .spec.detectMultiplier }} {{ else }} "3" {{ end }} # default 3
-  {{- if .spec.echoMode }}
+  {{- if hasKey .spec "echoMode" }}
   echoMode: {{ .spec.echoMode }}
   {{- end }}
   passiveMode: true

--- a/telco-core/configuration/reference-crs-kube-compare/required/networking/metallb/bgp-peer.yaml
+++ b/telco-core/configuration/reference-crs-kube-compare/required/networking/metallb/bgp-peer.yaml
@@ -10,7 +10,7 @@ spec:
   routerID: {{ .spec.routerID }}
   bfdProfile: {{ .spec.bfdProfile }}
   passwordSecret: {{ .spec.passwordSecret | toJson }}
-  {{- if .spec.disableMP }}
+  {{- if hasKey .spec "disableMP" }}
   disableMP: {{ .spec.disableMP }}
   {{- end }}
   peerPort: {{ .spec.peerPort }}

--- a/telco-hub/configuration/reference-crs-kube-compare/required/acm/acmProvisioning.yaml
+++ b/telco-hub/configuration/reference-crs-kube-compare/required/acm/acmProvisioning.yaml
@@ -11,6 +11,6 @@ spec:
   # some servers do not support virtual media installations
   # when the image is served using the https protocol
   # disableVirtualMediaTLS: true
-  {{- if .spec.disableVirtualMediaTLS }}
-  disableVirtualMediaTLS: true
+  {{- if hasKey .spec "disableVirtualMediaTLS" }}
+  disableVirtualMediaTLS: {{ .spec.disableVirtualMediaTLS }}
   {{- end }}


### PR DESCRIPTION
## Summary
- Backport kube-compare boolean gate fixes to `release-4.20`
- Use `hasKey` for optional boolean fields so explicit `false` values are not treated as unset

## Files
- `telco-core/.../metallb/addr-pool.yaml` (`autoAssign`, `avoidBuggyIPs`)
- `telco-core/.../metallb/bfd-profile.yaml` (`echoMode`)
- `telco-core/.../metallb/bgp-peer.yaml` (`disableMP`)
- `telco-hub/.../acm/acmProvisioning.yaml` (`disableVirtualMediaTLS`)

## Test plan
- [x] `kubectl-cluster_compare` with fixture CRs using `false` for the affected boolean fields reports `CRs with diffs: 0`

Made with [Cursor](https://cursor.com)