### PR TITLE
OCPBUGS-120708: Set slaveOnly=1 on TR-only ptp4l profiles

### DIFF
--- a/telco-ran/configuration/kube-compare-reference/ptp-operator/configuration/PtpConfigDualCardTBCWpc.yaml
+++ b/telco-ran/configuration/kube-compare-reference/ptp-operator/configuration/PtpConfigDualCardTBCWpc.yaml
@@ -43,7 +43,7 @@ spec:
       # Default Data Set
       #
       twoStepFlag 1
-      slaveOnly 0
+      slaveOnly 1
       priority1 128
       priority2 (?<priority2>[0-9]+)
       domainNumber (?<domainNumber>[0-9]+)

--- a/telco-ran/configuration/kube-compare-reference/ptp-operator/configuration/PtpConfigGnrdBcNoHoldover.yaml
+++ b/telco-ran/configuration/kube-compare-reference/ptp-operator/configuration/PtpConfigGnrdBcNoHoldover.yaml
@@ -147,7 +147,7 @@ spec:
         # Default Data Set
         #
         twoStepFlag 1
-        slaveOnly 0
+        slaveOnly 1
         priority1 128
         priority2 (?<priority2>[0-9]+)
         domainNumber (?<domainNumber>[0-9]+)

--- a/telco-ran/configuration/kube-compare-reference/ptp-operator/configuration/PtpConfigTBCWpc.yaml
+++ b/telco-ran/configuration/kube-compare-reference/ptp-operator/configuration/PtpConfigTBCWpc.yaml
@@ -41,7 +41,7 @@ spec:
       # Default Data Set
       #
       twoStepFlag 1
-      slaveOnly 0
+      slaveOnly 1
       priority1 128
       priority2 (?<priority2>[0-9]+)
       domainNumber (?<domainNumber>[0-9]+)

--- a/telco-ran/configuration/kube-compare-reference/ptp-operator/configuration/PtpConfigTTSCWpc.yaml
+++ b/telco-ran/configuration/kube-compare-reference/ptp-operator/configuration/PtpConfigTTSCWpc.yaml
@@ -39,7 +39,7 @@ spec:
       # Default Data Set
       #
       twoStepFlag 1
-      slaveOnly 0
+      slaveOnly 1
       priority1 128
       priority2 (?<priority2>[0-9]+)
       domainNumber (?<domainNumber>[0-9]+)

--- a/telco-ran/configuration/kube-compare-reference/ptp-operator/configuration/PtpConfigThreeCardTBCWpc.yaml
+++ b/telco-ran/configuration/kube-compare-reference/ptp-operator/configuration/PtpConfigThreeCardTBCWpc.yaml
@@ -45,7 +45,7 @@ spec:
       # Default Data Set
       #
       twoStepFlag 1
-      slaveOnly 0
+      slaveOnly 1
       priority1 128
       priority2 (?<priority2>[0-9]+)
       domainNumber (?<domainNumber>[0-9]+)

--- a/telco-ran/configuration/source-crs/ptp-operator/configuration/PtpConfigDualCardTBCWpc.yaml
+++ b/telco-ran/configuration/source-crs/ptp-operator/configuration/PtpConfigDualCardTBCWpc.yaml
@@ -61,7 +61,7 @@ spec:
       # Default Data Set
       #
       twoStepFlag 1
-      slaveOnly 0
+      slaveOnly 1
       priority1 128
       priority2 128
       domainNumber 24

--- a/telco-ran/configuration/source-crs/ptp-operator/configuration/PtpConfigGnrdBcNoHoldover.yaml
+++ b/telco-ran/configuration/source-crs/ptp-operator/configuration/PtpConfigGnrdBcNoHoldover.yaml
@@ -190,7 +190,7 @@ spec:
         # Default Data Set
         #
         twoStepFlag 1
-        slaveOnly 0
+        slaveOnly 1
         priority1 128
         priority2 128
         domainNumber 24

--- a/telco-ran/configuration/source-crs/ptp-operator/configuration/PtpConfigTBCWpc.yaml
+++ b/telco-ran/configuration/source-crs/ptp-operator/configuration/PtpConfigTBCWpc.yaml
@@ -50,7 +50,7 @@ spec:
       # Default Data Set
       #
       twoStepFlag 1
-      slaveOnly 0
+      slaveOnly 1
       priority1 128
       priority2 128
       domainNumber 24

--- a/telco-ran/configuration/source-crs/ptp-operator/configuration/PtpConfigTTSCWpc.yaml
+++ b/telco-ran/configuration/source-crs/ptp-operator/configuration/PtpConfigTTSCWpc.yaml
@@ -49,7 +49,7 @@ spec:
       # Default Data Set
       #
       twoStepFlag 1
-      slaveOnly 0
+      slaveOnly 1
       priority1 128
       priority2 128
       domainNumber 24

--- a/telco-ran/configuration/source-crs/ptp-operator/configuration/PtpConfigThreeCardTBCWpc.yaml
+++ b/telco-ran/configuration/source-crs/ptp-operator/configuration/PtpConfigThreeCardTBCWpc.yaml
@@ -73,7 +73,7 @@ spec:
       # Default Data Set
       #
       twoStepFlag 1
-      slaveOnly 0
+      slaveOnly 1
       priority1 128
       priority2 128
       domainNumber 24


### PR DESCRIPTION
Set the ptp4l slaveOnly flag to 1 in all TR-only profiles (the TR part of T-BC and T-TSC). This prevents corner cases where a port designated to be a TR at all times becomes a master when no better clock exists.

This will backport to 4.20

/cc @lack 